### PR TITLE
Add path subcommand

### DIFF
--- a/cmd/padz/cli/path.go
+++ b/cmd/padz/cli/path.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2025 YOUR NAME HERE <EMAIL ADDRESS>
+*/
+package cli
+
+import (
+	"log"
+	"os"
+	
+	"github.com/arthur-debert/padz/pkg/commands"
+	"github.com/arthur-debert/padz/pkg/output"
+	"github.com/arthur-debert/padz/pkg/project"
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+// newPathCmd creates and returns a new path command
+func newPathCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "path <index>",
+		Short: "Get the full path to a scratch",
+		Long:  `Get the full path to a scratch file identified by its index.`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			s, err := store.NewStore()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			proj, err := project.GetCurrentProject(dir)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			result, err := commands.Path(s, proj, args[0])
+			
+			// Format output
+			format, formatErr := output.GetFormat(outputFormat)
+			if formatErr != nil {
+				log.Fatal(formatErr)
+			}
+			
+			formatter := output.NewFormatter(format, nil)
+			
+			if err != nil {
+				if err := formatter.FormatError(err); err != nil {
+					log.Fatal(err)
+				}
+				os.Exit(1)
+			}
+			
+			// For path command, output the path directly in plain/term mode
+			if format == output.PlainFormat || format == output.TermFormat {
+				if err := formatter.FormatString(result.Path); err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				// For JSON, output the structured result
+				if err := formatter.FormatPath(result); err != nil {
+					log.Fatal(err)
+				}
+			}
+		},
+	}
+}

--- a/cmd/padz/cli/path_test.go
+++ b/cmd/padz/cli/path_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPathCommand(t *testing.T) {
+	// Test that the path command is available
+	cmd := NewRootCmd()
+	
+	// Look for path command in the command list
+	pathCmd, _, err := cmd.Find([]string{"path"})
+	if err != nil {
+		t.Fatalf("path command not found: %v", err)
+	}
+	
+	if pathCmd.Use != "path <index>" {
+		t.Errorf("expected 'path <index>', got '%s'", pathCmd.Use)
+	}
+	
+	if pathCmd.Short != "Get the full path to a scratch" {
+		t.Errorf("unexpected short description: %s", pathCmd.Short)
+	}
+	
+	// Test that it's in the single scratch group
+	if pathCmd.GroupID != "single" {
+		t.Errorf("expected path command to be in 'single' group, got '%s'", pathCmd.GroupID)
+	}
+}
+
+func TestPathCommandInHelp(t *testing.T) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--help"})
+	
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	
+	output := buf.String()
+	
+	// Check that path command appears in help under SINGLE SCRATCH
+	if !strings.Contains(output, "path") {
+		t.Error("Expected 'path' command in help output")
+	}
+	
+	// Check it's in the right section
+	lines := strings.Split(output, "\n")
+	inSingleSection := false
+	foundPath := false
+	
+	for _, line := range lines {
+		if strings.Contains(line, "SINGLE SCRATCH:") {
+			inSingleSection = true
+		} else if strings.Contains(line, "SCRATCHES:") {
+			inSingleSection = false
+		}
+		
+		if inSingleSection && strings.Contains(line, "path") {
+			foundPath = true
+			break
+		}
+	}
+	
+	if !foundPath {
+		t.Error("Expected 'path' command to be in SINGLE SCRATCH section")
+	}
+}

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -106,6 +106,10 @@ func NewRootCmd() *cobra.Command {
 	deleteCmd.GroupID = "single"
 	rootCmd.AddCommand(deleteCmd)
 	
+	pathCmd := newPathCmd()
+	pathCmd.GroupID = "single"
+	rootCmd.AddCommand(pathCmd)
+	
 	// Multiple scratches commands
 	lsCmd := newLsCmd()
 	lsCmd.GroupID = "multiple"

--- a/pkg/commands/path.go
+++ b/pkg/commands/path.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// PathResult contains the path information for a scratch
+type PathResult struct {
+	Path string `json:"path"`
+}
+
+// Path returns the full path to a scratch file
+func Path(s *store.Store, project string, indexStr string) (*PathResult, error) {
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid index: %s", indexStr)
+	}
+
+	// Get scratches and filter by project
+	allScratches := s.GetScratches()
+	var scratches []store.Scratch
+	
+	for _, scratch := range allScratches {
+		if scratch.Project == project {
+			scratches = append(scratches, scratch)
+		}
+	}
+	
+	if len(scratches) == 0 {
+		return nil, fmt.Errorf("no scratches found in project %s", project)
+	}
+
+	if index < 1 || index > len(scratches) {
+		return nil, fmt.Errorf("index %d out of range (1-%d)", index, len(scratches))
+	}
+
+	scratch := scratches[index-1]
+	path, err := store.GetScratchFilePath(scratch.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scratch file path: %w", err)
+	}
+
+	return &PathResult{Path: path}, nil
+}

--- a/pkg/commands/path_test.go
+++ b/pkg/commands/path_test.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+func TestPath(t *testing.T) {
+	// Setup test environment
+	tmpDir := setupCommandsTestDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a real store
+	s, err := store.NewStore()
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	// Add test scratches to the store
+	testScratches := []store.Scratch{
+		{
+			ID:        "test-scratch-1",
+			Title:     "Test Scratch 1",
+			Project:   "test-project",
+			CreatedAt: time.Now(),
+		},
+		{
+			ID:        "test-scratch-2",
+			Title:     "Test Scratch 2",
+			Project:   "test-project",
+			CreatedAt: time.Now(),
+		},
+		{
+			ID:        "other-project-scratch",
+			Title:     "Other Project Scratch",
+			Project:   "other-project",
+			CreatedAt: time.Now(),
+		},
+	}
+
+	// Save the test scratches
+	if err := s.SaveScratches(testScratches); err != nil {
+		t.Fatalf("failed to save scratches: %v", err)
+	}
+
+	t.Run("ValidIndex", func(t *testing.T) {
+		result, err := Path(s, "test-project", "1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// The path should contain the scratch ID
+		if !strings.Contains(result.Path, "test-scratch-1") {
+			t.Errorf("expected path to contain scratch ID 'test-scratch-1', got %s", result.Path)
+		}
+	})
+
+	t.Run("SecondIndex", func(t *testing.T) {
+		result, err := Path(s, "test-project", "2")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !strings.Contains(result.Path, "test-scratch-2") {
+			t.Errorf("expected path to contain scratch ID 'test-scratch-2', got %s", result.Path)
+		}
+	})
+
+	t.Run("IndexOutOfRange", func(t *testing.T) {
+		_, err := Path(s, "test-project", "3")
+		if err == nil {
+			t.Error("expected error for out of range index")
+		}
+		if !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("expected 'out of range' error, got: %v", err)
+		}
+	})
+
+	t.Run("InvalidIndex", func(t *testing.T) {
+		_, err := Path(s, "test-project", "invalid")
+		if err == nil {
+			t.Error("expected error for invalid index")
+		}
+		if !strings.Contains(err.Error(), "invalid index") {
+			t.Errorf("expected 'invalid index' error, got: %v", err)
+		}
+	})
+
+	t.Run("ZeroIndex", func(t *testing.T) {
+		_, err := Path(s, "test-project", "0")
+		if err == nil {
+			t.Error("expected error for zero index")
+		}
+	})
+
+	t.Run("NoScratches", func(t *testing.T) {
+		// Clear all scratches
+		if err := s.SaveScratches([]store.Scratch{}); err != nil {
+			t.Fatalf("failed to clear scratches: %v", err)
+		}
+		
+		_, err := Path(s, "test-project", "1")
+		if err == nil {
+			t.Error("expected error when no scratches found")
+		}
+		if !strings.Contains(err.Error(), "no scratches found") {
+			t.Errorf("expected 'no scratches found' error, got: %v", err)
+		}
+		
+		// Restore scratches for other tests
+		if err := s.SaveScratches(testScratches); err != nil {
+			t.Fatalf("failed to restore scratches: %v", err)
+		}
+	})
+
+	t.Run("WrongProject", func(t *testing.T) {
+		_, err := Path(s, "nonexistent-project", "1")
+		if err == nil {
+			t.Error("expected error for nonexistent project")
+		}
+		if !strings.Contains(err.Error(), "no scratches found") {
+			t.Errorf("expected 'no scratches found' error, got: %v", err)
+		}
+	})
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/arthur-debert/padz/pkg/commands"
 	"github.com/arthur-debert/padz/pkg/store"
 	"github.com/dustin/go-humanize"
 )
@@ -110,6 +111,19 @@ func (f *Formatter) FormatSuccess(message string) error {
 		if message != "" {
 			fmt.Fprintln(f.writer, message)
 		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported format: %s", f.format)
+	}
+}
+
+// FormatPath formats a path result
+func (f *Formatter) FormatPath(result *commands.PathResult) error {
+	switch f.format {
+	case JSONFormat:
+		return json.NewEncoder(f.writer).Encode(result)
+	case PlainFormat, TermFormat:
+		fmt.Fprintln(f.writer, result.Path)
 		return nil
 	default:
 		return fmt.Errorf("unsupported format: %s", f.format)

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arthur-debert/padz/pkg/commands"
 	"github.com/arthur-debert/padz/pkg/store"
 )
 
@@ -171,6 +172,46 @@ func TestFormatSuccess(t *testing.T) {
 
 		if !strings.Contains(buf.String(), message) {
 			t.Errorf("expected message in output")
+		}
+	})
+}
+
+func TestFormatPath(t *testing.T) {
+	pathResult := &commands.PathResult{
+		Path: "/tmp/padz/test-scratch-123",
+	}
+
+	t.Run("JSON", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		formatter := NewFormatter(JSONFormat, buf)
+		
+		err := formatter.FormatPath(pathResult)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var result commands.PathResult
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+
+		if result.Path != pathResult.Path {
+			t.Errorf("expected path %s, got %s", pathResult.Path, result.Path)
+		}
+	})
+
+	t.Run("Plain", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		formatter := NewFormatter(PlainFormat, buf)
+		
+		err := formatter.FormatPath(pathResult)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		output := strings.TrimSpace(buf.String())
+		if output != pathResult.Path {
+			t.Errorf("expected %s, got %s", pathResult.Path, output)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

This PR implements the `path` subcommand that returns the full filesystem path to a scratch file.

## Changes

- Added `Path` function in `pkg/commands` that:
  - Accepts a store, project, and index string
  - Returns a `PathResult` struct containing the file path
  - Validates the index and handles errors appropriately
  
- Created `path` CLI command that:
  - Accepts an index parameter (like all single scratch commands)
  - Supports all output formats (plain, json, term)
  - Is grouped under "SINGLE SCRATCH" commands in help
  
- Added `FormatPath` method to the output formatter for consistent formatting
  
- Added comprehensive tests for both the Path function and CLI integration

## Usage

```bash
# Get the path to the first scratch
$ padz path 1
/Users/username/Library/Application Support/scratch/56712c4f956d8e6c009e9da49c030073915aec42

# Get path in JSON format for scripting
$ padz path 1 --format=json
{"path":"/Users/username/Library/Application Support/scratch/56712c4f956d8e6c009e9da49c030073915aec42"}

# Use in scripts
$ cat "$(padz path 1)"
```

## Testing

- Unit tests for the Path function cover all edge cases
- CLI tests verify command registration and help output
- Output formatter tests ensure proper JSON/plain formatting

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)