### PR TITLE
feat: Implement reverse chronological ordering and centralize index-to-pad logic

### DIFF
--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -1199,6 +1199,141 @@ func TestSortByCreatedAtDesc(t *testing.T) {
 	}
 }
 
+func TestGetScratchByIndex(t *testing.T) {
+	tmpDir := setupCommandsTestDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	s, err := store.NewStore()
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	now := time.Now()
+	testScratches := []store.Scratch{
+		{ID: "1", Project: "project1", Title: "Title 1", CreatedAt: now.Add(-3 * time.Hour)}, // oldest, will be index 3
+		{ID: "2", Project: "project2", Title: "Title 2", CreatedAt: now.Add(-2 * time.Hour)}, // index 3 in all
+		{ID: "3", Project: "global", Title: "Global Title", CreatedAt: now.Add(-1 * time.Hour)}, // index 2 in all
+		{ID: "4", Project: "project1", Title: "Another P1", CreatedAt: now}, // newest, will be index 1
+	}
+
+	for _, scratch := range testScratches {
+		s.AddScratch(scratch)
+	}
+
+	tests := []struct {
+		name        string
+		all         bool
+		global      bool
+		project     string
+		indexStr    string
+		expectedID  string
+		expectError bool
+	}{
+		{
+			name:        "get first scratch in project1 (newest)",
+			all:         false,
+			global:      false,
+			project:     "project1",
+			indexStr:    "1",
+			expectedID:  "4", // newest project1 scratch
+			expectError: false,
+		},
+		{
+			name:        "get second scratch in project1 (oldest)",
+			all:         false,
+			global:      false,
+			project:     "project1",
+			indexStr:    "2",
+			expectedID:  "1", // oldest project1 scratch
+			expectError: false,
+		},
+		{
+			name:        "get first scratch globally (newest overall)",
+			all:         true,
+			global:      false,
+			project:     "",
+			indexStr:    "1",
+			expectedID:  "4", // newest overall
+			expectError: false,
+		},
+		{
+			name:        "get global scratch",
+			all:         false,
+			global:      true,
+			project:     "",
+			indexStr:    "1",
+			expectedID:  "3", // only global scratch
+			expectError: false,
+		},
+		{
+			name:        "invalid index string",
+			all:         false,
+			global:      false,
+			project:     "project1",
+			indexStr:    "invalid",
+			expectedID:  "",
+			expectError: true,
+		},
+		{
+			name:        "index out of range - too high",
+			all:         false,
+			global:      false,
+			project:     "project1",
+			indexStr:    "99",
+			expectedID:  "",
+			expectError: true,
+		},
+		{
+			name:        "index out of range - zero",
+			all:         false,
+			global:      false,
+			project:     "project1",
+			indexStr:    "0",
+			expectedID:  "",
+			expectError: true,
+		},
+		{
+			name:        "index out of range - negative",
+			all:         false,
+			global:      false,
+			project:     "project1",
+			indexStr:    "-1",
+			expectedID:  "",
+			expectError: true,
+		},
+		{
+			name:        "no scratches in non-existent project",
+			all:         false,
+			global:      false,
+			project:     "nonexistent",
+			indexStr:    "1",
+			expectedID:  "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetScratchByIndex(s, tt.all, tt.global, tt.project, tt.indexStr)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result.ID != tt.expectedID {
+				t.Errorf("expected ID %s, got %s", tt.expectedID, result.ID)
+			}
+		})
+	}
+}
+
 func setupCommandsTestDir(t *testing.T) string {
 	tmpDir := t.TempDir()
 	oldXDGDataHome := os.Getenv("XDG_DATA_HOME")

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -431,11 +431,12 @@ func TestLs(t *testing.T) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
+	now := time.Now()
 	testScratches := []store.Scratch{
-		{ID: "1", Project: "project1", Title: "Title 1", CreatedAt: time.Now()},
-		{ID: "2", Project: "project2", Title: "Title 2", CreatedAt: time.Now()},
-		{ID: "3", Project: "global", Title: "Global Title", CreatedAt: time.Now()},
-		{ID: "4", Project: "project1", Title: "Another P1", CreatedAt: time.Now()},
+		{ID: "1", Project: "project1", Title: "Title 1", CreatedAt: now.Add(-3 * time.Hour)}, // oldest
+		{ID: "2", Project: "project2", Title: "Title 2", CreatedAt: now.Add(-2 * time.Hour)},
+		{ID: "3", Project: "global", Title: "Global Title", CreatedAt: now.Add(-1 * time.Hour)},
+		{ID: "4", Project: "project1", Title: "Another P1", CreatedAt: now}, // newest
 	}
 
 	for _, scratch := range testScratches {
@@ -451,20 +452,20 @@ func TestLs(t *testing.T) {
 		expectedIDs   []string
 	}{
 		{
-			name:          "list all scratches",
+			name:          "list all scratches - reverse chronological order",
 			all:           true,
 			global:        false,
 			project:       "",
 			expectedCount: 4,
-			expectedIDs:   []string{"1", "2", "3", "4"},
+			expectedIDs:   []string{"4", "3", "2", "1"}, // newest first
 		},
 		{
-			name:          "list project1 scratches",
+			name:          "list project1 scratches - reverse chronological order",
 			all:           false,
 			global:        false,
 			project:       "project1",
 			expectedCount: 2,
-			expectedIDs:   []string{"1", "4"},
+			expectedIDs:   []string{"4", "1"}, // newest first
 		},
 		{
 			name:          "list project2 scratches",
@@ -520,10 +521,11 @@ func TestSearch(t *testing.T) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
+	now := time.Now()
 	testScratches := []store.Scratch{
-		{ID: "1", Project: "project1", Title: "Title 1", CreatedAt: time.Now()},
-		{ID: "2", Project: "project2", Title: "Title 2", CreatedAt: time.Now()},
-		{ID: "3", Project: "global", Title: "Global Title", CreatedAt: time.Now()},
+		{ID: "1", Project: "project1", Title: "Title 1", CreatedAt: now.Add(-2 * time.Hour)}, // older
+		{ID: "2", Project: "project2", Title: "Title 2", CreatedAt: now.Add(-1 * time.Hour)}, // newer
+		{ID: "3", Project: "global", Title: "Global Title", CreatedAt: now}, // newest
 	}
 
 	testContents := map[string]string{
@@ -598,13 +600,13 @@ func TestSearch(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name:          "regex pattern search",
+			name:          "regex pattern search - reverse chronological order",
 			all:           true,
 			global:        false,
 			project:       "",
 			term:          "scratch [0-9]",
 			expectedCount: 2,
-			expectedIDs:   []string{"1", "2"},
+			expectedIDs:   []string{"2", "1"}, // newest first (2 is newer than 1)
 			expectError:   false,
 		},
 	}
@@ -744,21 +746,22 @@ func TestPeek(t *testing.T) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
-	// Create test scratches in different projects
+	// Create test scratches in different projects with distinct timestamps
+	now := time.Now()
 	testScratches := []struct {
 		scratch store.Scratch
 		content string
 	}{
 		{
-			scratch: store.Scratch{ID: "test1", Project: "testproject", Title: "Test Title", CreatedAt: time.Now()},
+			scratch: store.Scratch{ID: "test1", Project: "testproject", Title: "Test Title", CreatedAt: now.Add(-2 * time.Hour)}, // older
 			content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8",
 		},
 		{
-			scratch: store.Scratch{ID: "test2", Project: "otherproject", Title: "Other Title", CreatedAt: time.Now()},
+			scratch: store.Scratch{ID: "test2", Project: "otherproject", Title: "Other Title", CreatedAt: now.Add(-1 * time.Hour)}, // middle
 			content: "Other Line 1\nOther Line 2\nOther Line 3\nOther Line 4\nOther Line 5",
 		},
 		{
-			scratch: store.Scratch{ID: "test3", Project: "global", Title: "Global Title", CreatedAt: time.Now()},
+			scratch: store.Scratch{ID: "test3", Project: "global", Title: "Global Title", CreatedAt: now}, // newest
 			content: "Global Line 1\nGlobal Line 2\nGlobal Line 3",
 		},
 	}
@@ -1167,6 +1170,33 @@ FILE="$1"
 	}
 
 	return tmpFile.Name()
+}
+
+func TestSortByCreatedAtDesc(t *testing.T) {
+	now := time.Now()
+	testScratches := []store.Scratch{
+		{ID: "oldest", Project: "test", Title: "Oldest", CreatedAt: now.Add(-3 * time.Hour)},
+		{ID: "newest", Project: "test", Title: "Newest", CreatedAt: now},
+		{ID: "middle", Project: "test", Title: "Middle", CreatedAt: now.Add(-1 * time.Hour)},
+		{ID: "old", Project: "test", Title: "Old", CreatedAt: now.Add(-2 * time.Hour)},
+	}
+
+	sorted := sortByCreatedAtDesc(testScratches)
+
+	expected := []string{"newest", "middle", "old", "oldest"}
+	actual := make([]string, len(sorted))
+	for i, scratch := range sorted {
+		actual[i] = scratch.ID
+	}
+
+	if !equalStringSlices(actual, expected) {
+		t.Errorf("expected order %v, got %v", expected, actual)
+	}
+
+	// Test that original slice is not modified
+	if testScratches[0].ID != "oldest" {
+		t.Errorf("original slice was modified")
+	}
 }
 
 func setupCommandsTestDir(t *testing.T) string {

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -1,25 +1,15 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 	"github.com/arthur-debert/padz/pkg/store"
-	"strconv"
 )
 
 func Delete(s *store.Store, project string, indexStr string) error {
-	scratches := Ls(s, false, false, project)
-
-	index, err := strconv.Atoi(indexStr)
+	scratchToDelete, err := GetScratchByIndex(s, false, false, project, indexStr)
 	if err != nil {
-		return fmt.Errorf("invalid index: %s", indexStr)
+		return err
 	}
-
-	if index < 1 || index > len(scratches) {
-		return fmt.Errorf("index out of range: %d", index)
-	}
-
-	scratchToDelete := scratches[index-1]
 
 	if err := deleteScratchFile(scratchToDelete.ID); err != nil {
 		return err

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -1,13 +1,14 @@
 package commands
 
 import (
+	"sort"
 	"github.com/arthur-debert/padz/pkg/store"
 )
 
 func Ls(s *store.Store, all, global bool, project string) []store.Scratch {
 	scratches := s.GetScratches()
 	if all {
-		return scratches
+		return sortByCreatedAtDesc(scratches)
 	}
 
 	var filtered []store.Scratch
@@ -18,5 +19,14 @@ func Ls(s *store.Store, all, global bool, project string) []store.Scratch {
 			filtered = append(filtered, scratch)
 		}
 	}
-	return filtered
+	return sortByCreatedAtDesc(filtered)
+}
+
+func sortByCreatedAtDesc(scratches []store.Scratch) []store.Scratch {
+	sorted := make([]store.Scratch, len(scratches))
+	copy(sorted, scratches)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].CreatedAt.After(sorted[j].CreatedAt)
+	})
+	return sorted
 }

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
 	"github.com/arthur-debert/padz/pkg/store"
 )
 
@@ -29,4 +31,19 @@ func sortByCreatedAtDesc(scratches []store.Scratch) []store.Scratch {
 		return sorted[i].CreatedAt.After(sorted[j].CreatedAt)
 	})
 	return sorted
+}
+
+func GetScratchByIndex(s *store.Store, all, global bool, project string, indexStr string) (*store.Scratch, error) {
+	scratches := Ls(s, all, global, project)
+
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid index: %s", indexStr)
+	}
+
+	if index < 1 || index > len(scratches) {
+		return nil, fmt.Errorf("index out of range: %d", index)
+	}
+
+	return &scratches[index-1], nil
 }

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -1,25 +1,15 @@
 package commands
 
 import (
-	"fmt"
 	"github.com/arthur-debert/padz/pkg/editor"
 	"github.com/arthur-debert/padz/pkg/store"
-	"strconv"
 )
 
 func Open(s *store.Store, project string, indexStr string) error {
-	scratches := Ls(s, false, false, project)
-
-	index, err := strconv.Atoi(indexStr)
+	scratchToOpen, err := GetScratchByIndex(s, false, false, project, indexStr)
 	if err != nil {
-		return fmt.Errorf("invalid index: %s", indexStr)
+		return err
 	}
-
-	if index < 1 || index > len(scratches) {
-		return fmt.Errorf("index out of range: %d", index)
-	}
-
-	scratchToOpen := scratches[index-1]
 
 	content, err := readScratchFile(scratchToOpen.ID)
 	if err != nil {
@@ -45,5 +35,5 @@ func Open(s *store.Store, project string, indexStr string) error {
 	}
 
 	scratchToOpen.Title = getTitle(trimmedContent)
-	return s.UpdateScratch(scratchToOpen)
+	return s.UpdateScratch(*scratchToOpen)
 }

--- a/pkg/commands/path.go
+++ b/pkg/commands/path.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/arthur-debert/padz/pkg/store"
 )
@@ -14,30 +13,11 @@ type PathResult struct {
 
 // Path returns the full path to a scratch file
 func Path(s *store.Store, project string, indexStr string) (*PathResult, error) {
-	index, err := strconv.Atoi(indexStr)
+	scratch, err := GetScratchByIndex(s, false, false, project, indexStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid index: %s", indexStr)
+		return nil, err
 	}
 
-	// Get scratches and filter by project
-	allScratches := s.GetScratches()
-	var scratches []store.Scratch
-	
-	for _, scratch := range allScratches {
-		if scratch.Project == project {
-			scratches = append(scratches, scratch)
-		}
-	}
-	
-	if len(scratches) == 0 {
-		return nil, fmt.Errorf("no scratches found in project %s", project)
-	}
-
-	if index < 1 || index > len(scratches) {
-		return nil, fmt.Errorf("index %d out of range (1-%d)", index, len(scratches))
-	}
-
-	scratch := scratches[index-1]
 	path, err := store.GetScratchFilePath(scratch.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scratch file path: %w", err)

--- a/pkg/commands/path_test.go
+++ b/pkg/commands/path_test.go
@@ -20,25 +20,26 @@ func TestPath(t *testing.T) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
-	// Add test scratches to the store
+	// Add test scratches to the store with distinct timestamps
+	now := time.Now()
 	testScratches := []store.Scratch{
 		{
 			ID:        "test-scratch-1",
 			Title:     "Test Scratch 1",
 			Project:   "test-project",
-			CreatedAt: time.Now(),
+			CreatedAt: now.Add(-2 * time.Hour), // older scratch
 		},
 		{
 			ID:        "test-scratch-2",
 			Title:     "Test Scratch 2",
 			Project:   "test-project",
-			CreatedAt: time.Now(),
+			CreatedAt: now, // newer scratch, will be index 1
 		},
 		{
 			ID:        "other-project-scratch",
 			Title:     "Other Project Scratch",
 			Project:   "other-project",
-			CreatedAt: time.Now(),
+			CreatedAt: now.Add(-1 * time.Hour),
 		},
 	}
 
@@ -53,9 +54,9 @@ func TestPath(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// The path should contain the scratch ID
-		if !strings.Contains(result.Path, "test-scratch-1") {
-			t.Errorf("expected path to contain scratch ID 'test-scratch-1', got %s", result.Path)
+		// With reverse chronological order, index 1 should be test-scratch-2 (newest)
+		if !strings.Contains(result.Path, "test-scratch-2") {
+			t.Errorf("expected path to contain scratch ID 'test-scratch-2', got %s", result.Path)
 		}
 	})
 
@@ -65,8 +66,9 @@ func TestPath(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if !strings.Contains(result.Path, "test-scratch-2") {
-			t.Errorf("expected path to contain scratch ID 'test-scratch-2', got %s", result.Path)
+		// With reverse chronological order, index 2 should be test-scratch-1 (older)
+		if !strings.Contains(result.Path, "test-scratch-1") {
+			t.Errorf("expected path to contain scratch ID 'test-scratch-1', got %s", result.Path)
 		}
 	})
 
@@ -107,8 +109,9 @@ func TestPath(t *testing.T) {
 		if err == nil {
 			t.Error("expected error when no scratches found")
 		}
-		if !strings.Contains(err.Error(), "no scratches found") {
-			t.Errorf("expected 'no scratches found' error, got: %v", err)
+		// The centralized function returns "index out of range" when there are no scratches
+		if !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("expected 'out of range' error, got: %v", err)
 		}
 		
 		// Restore scratches for other tests
@@ -122,8 +125,9 @@ func TestPath(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for nonexistent project")
 		}
-		if !strings.Contains(err.Error(), "no scratches found") {
-			t.Errorf("expected 'no scratches found' error, got: %v", err)
+		// The centralized function returns "index out of range" when no scratches match the filter
+		if !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("expected 'out of range' error, got: %v", err)
 		}
 	})
 }

--- a/pkg/commands/view.go
+++ b/pkg/commands/view.go
@@ -1,25 +1,15 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 	"github.com/arthur-debert/padz/pkg/store"
-	"strconv"
 )
 
 func View(s *store.Store, all, global bool, project string, indexStr string) (string, error) {
-	scratches := Ls(s, all, global, project)
-
-	index, err := strconv.Atoi(indexStr)
+	scratch, err := GetScratchByIndex(s, all, global, project, indexStr)
 	if err != nil {
-		return "", fmt.Errorf("invalid index: %s", indexStr)
+		return "", err
 	}
-
-	if index < 1 || index > len(scratches) {
-		return "", fmt.Errorf("index out of range: %d", index)
-	}
-
-	scratch := scratches[index-1]
 
 	content, err := readScratchFile(scratch.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR implements two major improvements to enhance user experience with pad listings:

• **Reverse chronological ordering**: All pad listings now show most recent items first
• **Centralized index-to-pad conversion**: Eliminates code duplication across commands

## Changes Made

### Reverse Chronological Ordering
- Modified `Ls()` function to sort all results by `CreatedAt` in descending order (most recent first)
- Added `sortByCreatedAtDesc()` helper function to centralize sorting logic
- Updated all tests to reflect new ordering behavior
- Both `ls` and `search` commands now consistently show newest pads first

### Centralized Index-to-Pad Logic
- Created `GetScratchByIndex()` function to eliminate duplicate code across commands
- Refactored `view`, `delete`, `open`, and `path` commands to use centralized function
- Fixed `path` command to use consistent ordering with other commands
- Removed ~32 lines of duplicate index validation code
- Added comprehensive tests for the new centralized function

## Benefits

### For Users
- **Better UX**: Most recent pads appear first, making it easier to find recent work
- **Consistent behavior**: All commands (`ls`, `search`, `view`, `peek`, `delete`, `open`, `path`) use the same ordering
- **Reliable indexing**: Index numbers consistently refer to the same pads across all commands

### For Maintainers
- **DRY principle**: Eliminated code duplication across 5 commands
- **Centralized logic**: Index validation and error handling in one well-tested function
- **Easier maintenance**: Future changes to ordering or validation logic only need updates in one place
- **Better test coverage**: Comprehensive tests for edge cases and error conditions

## Test Plan

- [x] All existing tests pass without modification to core functionality
- [x] Added tests for reverse chronological ordering in `ls` and `search`
- [x] Added comprehensive tests for `GetScratchByIndex()` function (9 test cases)
- [x] Updated `path` command tests to reflect new ordering and error messages
- [x] Verified consistent behavior across all index-based commands
- [x] Tested edge cases: invalid indices, empty projects, out-of-range values

🤖 Generated with [Claude Code](https://claude.ai/code)