### PR TITLE
Add nuke command to delete all pads in scope

### DIFF
--- a/cmd/padz/cli/msgs.go
+++ b/cmd/padz/cli/msgs.go
@@ -103,3 +103,25 @@ const (
 	
 	SearchNoMatchesFound = "No matches found."
 )
+
+// Nuke command messages
+const (
+	NukeUse   = "nuke"
+	NukeShort = "Delete all scratches in the current scope"
+	NukeLong  = `Delete all scratches in the current scope (project or global).
+Use --all to delete all scratches across all scopes.`
+	
+	// Confirmation prompts
+	NukeConfirmProject = "This will delete all %d pads in [%s]. Confirm? [y/N] "
+	NukeConfirmGlobal  = "This will delete all %d pads in global storage. Confirm? [y/N] "
+	NukeConfirmAll     = "This will delete all %d pads across all scopes, projects and global. Confirm? [y/N] "
+	
+	// Success messages
+	NukeSuccessProject = "Deleted all %d pads in [%s]."
+	NukeSuccessGlobal  = "Deleted all %d pads in global storage."
+	NukeSuccessAll     = "Deleted all %d pads across all scopes."
+	
+	// Other messages
+	NukeNoPadsFound = "No pads found to delete."
+	NukeCancelled   = "Nuke cancelled."
+)

--- a/cmd/padz/cli/nuke.go
+++ b/cmd/padz/cli/nuke.go
@@ -1,0 +1,152 @@
+/*
+Copyright © 2025 YOUR NAME HERE <EMAIL ADDRESS>
+*/
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arthur-debert/padz/cmd/padz/formatter"
+	"github.com/arthur-debert/padz/pkg/commands"
+	"github.com/arthur-debert/padz/pkg/output"
+	"github.com/arthur-debert/padz/pkg/project"
+	"github.com/arthur-debert/padz/pkg/store"
+
+	"github.com/spf13/cobra"
+)
+
+// newNukeCmd creates and returns a new nuke command
+func newNukeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   NukeUse,
+		Short: NukeShort,
+		Long:  NukeLong,
+		Run: func(cmd *cobra.Command, args []string) {
+			all, _ := cmd.Flags().GetBool("all")
+
+			s, err := store.NewStore()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			proj, err := project.GetCurrentProject(dir)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// Format output
+			format, err := output.GetFormat(outputFormat)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// For JSON format, we need to handle confirmation differently
+			if format == output.JSONFormat {
+				// For JSON, we would need a --yes flag to proceed without confirmation
+				// For now, we'll just fail with an error
+				outputFormatter := output.NewFormatter(format, nil)
+				if err := outputFormatter.FormatError(fmt.Errorf("interactive confirmation not supported in JSON format")); err != nil {
+					log.Fatal(err)
+				}
+				return
+			}
+
+			// First, get the count of pads to delete
+			var count int
+			var confirmMsg string
+			var successMsg string
+			
+			// Count the pads that would be deleted
+			if all {
+				count = len(s.GetScratches())
+			} else if proj == "" {
+				// Count global pads
+				for _, scratch := range s.GetScratches() {
+					if scratch.Project == "global" {
+						count++
+					}
+				}
+			} else {
+				// Count project pads
+				for _, scratch := range s.GetScratches() {
+					if scratch.Project == proj {
+						count++
+					}
+				}
+			}
+
+			// Check if there are any pads to delete
+			if count == 0 {
+				handleTerminalSuccess(NukeNoPadsFound, format)
+				return
+			}
+
+			// Prepare messages based on scope
+			if all {
+				confirmMsg = fmt.Sprintf(NukeConfirmAll, count)
+				successMsg = fmt.Sprintf(NukeSuccessAll, count)
+			} else if proj == "" {
+				confirmMsg = fmt.Sprintf(NukeConfirmGlobal, count)
+				successMsg = fmt.Sprintf(NukeSuccessGlobal, count)
+			} else {
+				// For project scope, extract just the project name from the path
+				projectName := filepath.Base(proj)
+				confirmMsg = fmt.Sprintf(NukeConfirmProject, count, projectName)
+				successMsg = fmt.Sprintf(NukeSuccessProject, count, projectName)
+			}
+
+			// Show confirmation prompt
+			if format == output.PlainFormat || format == output.TermFormat {
+				// For warnings, we should use the warning style
+				warningStyle, err := formatter.NewTerminalFormatter(os.Stderr)
+				if err != nil {
+					fmt.Fprint(os.Stderr, confirmMsg)
+				} else {
+					warningStyle.FormatWarning(strings.TrimSpace(confirmMsg))
+					fmt.Fprint(os.Stderr, " ")
+				}
+
+				// Read user confirmation
+				reader := bufio.NewReader(os.Stdin)
+				response, err := reader.ReadString('\n')
+				if err != nil {
+					handleTerminalError(err, format)
+				}
+
+				response = strings.TrimSpace(strings.ToLower(response))
+				if response != "y" && response != "yes" {
+					handleTerminalSuccess(NukeCancelled, format)
+					return
+				}
+
+				// Actually perform the nuke operation
+				result, err := commands.Nuke(s, all, proj)
+				if err != nil {
+					handleTerminalError(err, format)
+				}
+
+				// Use the actual deleted count from the result
+				if all {
+					successMsg = fmt.Sprintf(NukeSuccessAll, result.DeletedCount)
+				} else if result.Scope == "global" {
+					successMsg = fmt.Sprintf(NukeSuccessGlobal, result.DeletedCount)
+				} else {
+					projectName := filepath.Base(result.ProjectName)
+					successMsg = fmt.Sprintf(NukeSuccessProject, result.DeletedCount, projectName)
+				}
+
+				handleTerminalSuccess(successMsg, format)
+			}
+		},
+	}
+}

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -120,6 +120,11 @@ func NewRootCmd() *cobra.Command {
 	searchCmd.Flags().BoolP("all", "a", false, FlagAllDescSearch)
 	searchCmd.Flags().BoolP("global", "g", false, FlagGlobalDescSearch)
 	rootCmd.AddCommand(searchCmd)
+	
+	nukeCmd := newNukeCmd()
+	nukeCmd.GroupID = "multiple"
+	nukeCmd.Flags().Bool("all", false, FlagAllDesc)
+	rootCmd.AddCommand(nukeCmd)
 
 
 	return rootCmd

--- a/pkg/commands/nuke.go
+++ b/pkg/commands/nuke.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// NukeResult contains the result of a nuke operation
+type NukeResult struct {
+	DeletedCount int
+	Scope        string
+	ProjectName  string
+}
+
+// Nuke deletes all scratches in the specified scope
+func Nuke(s *store.Store, all bool, project string) (*NukeResult, error) {
+	var scratchesToDelete []store.Scratch
+	result := &NukeResult{}
+
+	if all {
+		// Delete all scratches across all scopes
+		scratchesToDelete = s.GetScratches()
+		result.Scope = "all"
+		result.DeletedCount = len(scratchesToDelete)
+	} else if project == "" {
+		// Delete only global scratches
+		for _, scratch := range s.GetScratches() {
+			if scratch.Project == "global" {
+				scratchesToDelete = append(scratchesToDelete, scratch)
+			}
+		}
+		result.Scope = "global"
+		result.DeletedCount = len(scratchesToDelete)
+	} else {
+		// Delete only project-specific scratches
+		for _, scratch := range s.GetScratches() {
+			if scratch.Project == project {
+				scratchesToDelete = append(scratchesToDelete, scratch)
+			}
+		}
+		result.Scope = "project"
+		result.ProjectName = project
+		result.DeletedCount = len(scratchesToDelete)
+	}
+
+	// Delete the scratch files
+	for _, scratch := range scratchesToDelete {
+		if err := deleteScratchFile(scratch.ID); err != nil {
+			// Continue deleting even if one fails
+			fmt.Fprintf(os.Stderr, "Warning: failed to delete file for scratch %s: %v\n", scratch.ID, err)
+		}
+	}
+
+	// Remove all scratches from the store
+	if all {
+		// Clear all scratches
+		if err := s.SaveScratches([]store.Scratch{}); err != nil {
+			return nil, err
+		}
+	} else {
+		// Keep only scratches not in the delete list
+		var remainingScratches []store.Scratch
+		for _, scratch := range s.GetScratches() {
+			shouldDelete := false
+			for _, toDelete := range scratchesToDelete {
+				if scratch.ID == toDelete.ID {
+					shouldDelete = true
+					break
+				}
+			}
+			if !shouldDelete {
+				remainingScratches = append(remainingScratches, scratch)
+			}
+		}
+		if err := s.SaveScratches(remainingScratches); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/commands/nuke_test.go
+++ b/pkg/commands/nuke_test.go
@@ -1,0 +1,163 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+func TestNuke(t *testing.T) {
+	// Create temporary store
+	tempDir := t.TempDir()
+	os.Setenv("XDG_DATA_HOME", tempDir)
+	defer os.Unsetenv("XDG_DATA_HOME")
+
+	s, err := store.NewStore()
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	// Create test scratches in different projects
+	project1 := "test-project-1"
+	project2 := "test-project-2"
+	globalProject := "global"
+
+	// Add scratches to project1
+	for i := 0; i < 3; i++ {
+		scratch := store.Scratch{
+			ID:      generateTestID("proj1", i),
+			Project: project1,
+			Title:   "Project 1 scratch",
+		}
+		if err := s.AddScratch(scratch); err != nil {
+			t.Fatalf("Failed to add scratch: %v", err)
+		}
+		// Create the file
+		createTestScratchFile(t, scratch.ID, "content")
+	}
+
+	// Add scratches to project2
+	for i := 0; i < 2; i++ {
+		scratch := store.Scratch{
+			ID:      generateTestID("proj2", i),
+			Project: project2,
+			Title:   "Project 2 scratch",
+		}
+		if err := s.AddScratch(scratch); err != nil {
+			t.Fatalf("Failed to add scratch: %v", err)
+		}
+		createTestScratchFile(t, scratch.ID, "content")
+	}
+
+	// Add global scratches
+	for i := 0; i < 4; i++ {
+		scratch := store.Scratch{
+			ID:      generateTestID("global", i),
+			Project: globalProject,
+			Title:   "Global scratch",
+		}
+		if err := s.AddScratch(scratch); err != nil {
+			t.Fatalf("Failed to add scratch: %v", err)
+		}
+		createTestScratchFile(t, scratch.ID, "content")
+	}
+
+	// Test 1: Nuke specific project
+	t.Run("NukeProject", func(t *testing.T) {
+		result, err := Nuke(s, false, project1)
+		if err != nil {
+			t.Fatalf("Failed to nuke project: %v", err)
+		}
+		if result.DeletedCount != 3 {
+			t.Errorf("Expected 3 deleted, got %d", result.DeletedCount)
+		}
+		if result.Scope != "project" {
+			t.Errorf("Expected scope 'project', got %s", result.Scope)
+		}
+		if result.ProjectName != project1 {
+			t.Errorf("Expected project name %s, got %s", project1, result.ProjectName)
+		}
+
+		// Verify only project1 scratches were deleted
+		remaining := s.GetScratches()
+		if len(remaining) != 6 { // 2 from project2 + 4 global
+			t.Errorf("Expected 6 remaining scratches, got %d", len(remaining))
+		}
+	})
+
+	// Test 2: Nuke global
+	t.Run("NukeGlobal", func(t *testing.T) {
+		result, err := Nuke(s, false, "")
+		if err != nil {
+			t.Fatalf("Failed to nuke global: %v", err)
+		}
+		if result.DeletedCount != 4 {
+			t.Errorf("Expected 4 deleted, got %d", result.DeletedCount)
+		}
+		if result.Scope != "global" {
+			t.Errorf("Expected scope 'global', got %s", result.Scope)
+		}
+
+		// Verify only global scratches were deleted
+		remaining := s.GetScratches()
+		if len(remaining) != 2 { // 2 from project2
+			t.Errorf("Expected 2 remaining scratches, got %d", len(remaining))
+		}
+	})
+
+	// Test 3: Nuke all
+	t.Run("NukeAll", func(t *testing.T) {
+		// Re-add some scratches
+		s.AddScratch(store.Scratch{ID: generateTestID("new", 0), Project: "new-project", Title: "New"})
+		s.AddScratch(store.Scratch{ID: generateTestID("new", 1), Project: globalProject, Title: "New global"})
+
+		result, err := Nuke(s, true, "")
+		if err != nil {
+			t.Fatalf("Failed to nuke all: %v", err)
+		}
+		if result.DeletedCount != 4 { // 2 from project2 + 2 new
+			t.Errorf("Expected 4 deleted, got %d", result.DeletedCount)
+		}
+		if result.Scope != "all" {
+			t.Errorf("Expected scope 'all', got %s", result.Scope)
+		}
+
+		// Verify all scratches were deleted
+		remaining := s.GetScratches()
+		if len(remaining) != 0 {
+			t.Errorf("Expected 0 remaining scratches, got %d", len(remaining))
+		}
+	})
+
+	// Test 4: Nuke empty project
+	t.Run("NukeEmptyProject", func(t *testing.T) {
+		result, err := Nuke(s, false, "non-existent-project")
+		if err != nil {
+			t.Fatalf("Failed to nuke empty project: %v", err)
+		}
+		if result.DeletedCount != 0 {
+			t.Errorf("Expected 0 deleted, got %d", result.DeletedCount)
+		}
+	})
+}
+
+func generateTestID(prefix string, index int) string {
+	return fmt.Sprintf("%s_test_%d", prefix, index)
+}
+
+func createTestScratchFile(t *testing.T, id, content string) {
+	path, err := store.GetScratchFilePath(id)
+	if err != nil {
+		t.Fatalf("Failed to get scratch file path: %v", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write scratch file: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Added new `nuke` command that deletes all pads within a specific scope
- Supports deleting pads in current project, global scope, or all scopes with --all flag
- Includes interactive confirmation prompts with pad counts

## Implementation Details

This PR implements the `nuke` command as specified in #17. The command provides a quick way to clear all pads when starting fresh or cleaning up after a project.

### Features:
- **Current scope deletion**: `padz nuke` deletes all pads in the current project (or global if not in a project)
- **All scopes deletion**: `padz nuke --all` deletes all pads across all projects and global
- **Interactive confirmation**: Shows pad count and scope before deletion, requires explicit "y" confirmation
- **Proper error handling**: Continues deletion even if some files are missing, shows warnings
- **Comprehensive tests**: Added unit tests covering all scenarios

### Confirmation prompts:
- Project scope: `This will delete all 13 pads in [iphone-app]. Confirm? [y/N]`
- Global scope: `This will delete all 8 pads in global storage. Confirm? [y/N]`
- All scopes: `This will delete all 24 pads across all scopes, projects and global. Confirm? [y/N]`

## Test plan
- [x] Build the project successfully
- [x] Test `padz nuke` in a project directory
- [x] Test `padz nuke` outside a project (global scope)
- [x] Test `padz nuke --all` to delete all pads
- [x] Test confirmation prompt with "n" response (cancels)
- [x] Test confirmation prompt with "y" response (proceeds)
- [x] Verify proper pad counts in confirmation messages
- [x] Verify project names are displayed correctly
- [x] Unit tests pass for all scenarios
- [x] Help text shows correct usage

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)