### PR TITLE
fix: Add --all flag to single pad commands

### DIFF
--- a/cmd/padz/cli/delete.go
+++ b/cmd/padz/cli/delete.go
@@ -22,6 +22,8 @@ func newDeleteCmd() *cobra.Command {
 	Long:  DeleteLong,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		all, _ := cmd.Flags().GetBool("all")
+
 		s, err := store.NewStore()
 		if err != nil {
 			log.Fatal(err)
@@ -37,7 +39,7 @@ func newDeleteCmd() *cobra.Command {
 			log.Fatal(err)
 		}
 
-		err = commands.Delete(s, proj, args[0])
+		err = commands.Delete(s, all, proj, args[0])
 		
 		// Format output
 		format, formatErr := output.GetFormat(outputFormat)

--- a/cmd/padz/cli/open.go
+++ b/cmd/padz/cli/open.go
@@ -22,6 +22,8 @@ func newOpenCmd() *cobra.Command {
 	Long:  OpenLong,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		all, _ := cmd.Flags().GetBool("all")
+
 		s, err := store.NewStore()
 		if err != nil {
 			log.Fatal(err)
@@ -37,7 +39,7 @@ func newOpenCmd() *cobra.Command {
 			log.Fatal(err)
 		}
 
-		err = commands.Open(s, proj, args[0])
+		err = commands.Open(s, all, proj, args[0])
 		
 		// Format output
 		format, formatErr := output.GetFormat(outputFormat)

--- a/cmd/padz/cli/path.go
+++ b/cmd/padz/cli/path.go
@@ -22,6 +22,8 @@ func newPathCmd() *cobra.Command {
 		Long:  `Get the full path to a scratch file identified by its index.`,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			all, _ := cmd.Flags().GetBool("all")
+
 			s, err := store.NewStore()
 			if err != nil {
 				log.Fatal(err)
@@ -37,7 +39,7 @@ func newPathCmd() *cobra.Command {
 				log.Fatal(err)
 			}
 
-			result, err := commands.Path(s, proj, args[0])
+			result, err := commands.Path(s, all, proj, args[0])
 			
 			// Format output
 			format, formatErr := output.GetFormat(outputFormat)

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -82,10 +82,13 @@ func NewRootCmd() *cobra.Command {
 	// Single scratch commands
 	viewCmd := newViewCmd()
 	viewCmd.GroupID = "single"
+	viewCmd.Flags().Bool("all", false, FlagAllDesc)
+	viewCmd.Flags().Bool("global", false, FlagGlobalDesc)
 	rootCmd.AddCommand(viewCmd)
 	
 	openCmd := newOpenCmd()
 	openCmd.GroupID = "single"
+	openCmd.Flags().Bool("all", false, FlagAllDesc)
 	rootCmd.AddCommand(openCmd)
 	
 	peekCmd := newPeekCmd()
@@ -97,10 +100,12 @@ func NewRootCmd() *cobra.Command {
 	
 	deleteCmd := newDeleteCmd()
 	deleteCmd.GroupID = "single"
+	deleteCmd.Flags().Bool("all", false, FlagAllDesc)
 	rootCmd.AddCommand(deleteCmd)
 	
 	pathCmd := newPathCmd()
 	pathCmd.GroupID = "single"
+	pathCmd.Flags().Bool("all", false, FlagAllDesc)
 	rootCmd.AddCommand(pathCmd)
 	
 	// Multiple scratches commands

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -902,7 +902,7 @@ func TestDelete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			initialCount := len(s.GetScratches())
 
-			err := Delete(s, tt.project, tt.indexStr)
+			err := Delete(s, false, tt.project, tt.indexStr)
 			
 			if tt.expectError {
 				if err == nil {
@@ -1048,7 +1048,7 @@ func TestOpen(t *testing.T) {
 	os.Setenv("EDITOR", wrapperScript)
 
 	// Test opening and editing the scratch
-	err = Open(s, "testproject", "1")
+	err = Open(s, false, "testproject", "1")
 	if err != nil {
 		t.Errorf("unexpected error opening scratch: %v", err)
 	}
@@ -1112,7 +1112,7 @@ func TestOpen_DeletesEmptyScratch(t *testing.T) {
 	os.Setenv("EDITOR", wrapperScript)
 
 	// Open and edit (delete all content)
-	err = Open(s, "testproject", "1")
+	err = Open(s, false, "testproject", "1")
 	if err != nil {
 		t.Errorf("unexpected error opening scratch: %v", err)
 	}

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -5,8 +5,8 @@ import (
 	"github.com/arthur-debert/padz/pkg/store"
 )
 
-func Delete(s *store.Store, project string, indexStr string) error {
-	scratchToDelete, err := GetScratchByIndex(s, false, false, project, indexStr)
+func Delete(s *store.Store, all bool, project string, indexStr string) error {
+	scratchToDelete, err := GetScratchByIndex(s, all, false, project, indexStr)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -5,8 +5,8 @@ import (
 	"github.com/arthur-debert/padz/pkg/store"
 )
 
-func Open(s *store.Store, project string, indexStr string) error {
-	scratchToOpen, err := GetScratchByIndex(s, false, false, project, indexStr)
+func Open(s *store.Store, all bool, project string, indexStr string) error {
+	scratchToOpen, err := GetScratchByIndex(s, all, false, project, indexStr)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/path.go
+++ b/pkg/commands/path.go
@@ -12,8 +12,8 @@ type PathResult struct {
 }
 
 // Path returns the full path to a scratch file
-func Path(s *store.Store, project string, indexStr string) (*PathResult, error) {
-	scratch, err := GetScratchByIndex(s, false, false, project, indexStr)
+func Path(s *store.Store, all bool, project string, indexStr string) (*PathResult, error) {
+	scratch, err := GetScratchByIndex(s, all, false, project, indexStr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/path_test.go
+++ b/pkg/commands/path_test.go
@@ -49,7 +49,7 @@ func TestPath(t *testing.T) {
 	}
 
 	t.Run("ValidIndex", func(t *testing.T) {
-		result, err := Path(s, "test-project", "1")
+		result, err := Path(s, false, "test-project", "1")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -61,7 +61,7 @@ func TestPath(t *testing.T) {
 	})
 
 	t.Run("SecondIndex", func(t *testing.T) {
-		result, err := Path(s, "test-project", "2")
+		result, err := Path(s, false, "test-project", "2")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -73,7 +73,7 @@ func TestPath(t *testing.T) {
 	})
 
 	t.Run("IndexOutOfRange", func(t *testing.T) {
-		_, err := Path(s, "test-project", "3")
+		_, err := Path(s, false, "test-project", "3")
 		if err == nil {
 			t.Error("expected error for out of range index")
 		}
@@ -83,7 +83,7 @@ func TestPath(t *testing.T) {
 	})
 
 	t.Run("InvalidIndex", func(t *testing.T) {
-		_, err := Path(s, "test-project", "invalid")
+		_, err := Path(s, false, "test-project", "invalid")
 		if err == nil {
 			t.Error("expected error for invalid index")
 		}
@@ -93,7 +93,7 @@ func TestPath(t *testing.T) {
 	})
 
 	t.Run("ZeroIndex", func(t *testing.T) {
-		_, err := Path(s, "test-project", "0")
+		_, err := Path(s, false, "test-project", "0")
 		if err == nil {
 			t.Error("expected error for zero index")
 		}
@@ -105,7 +105,7 @@ func TestPath(t *testing.T) {
 			t.Fatalf("failed to clear scratches: %v", err)
 		}
 		
-		_, err := Path(s, "test-project", "1")
+		_, err := Path(s, false, "test-project", "1")
 		if err == nil {
 			t.Error("expected error when no scratches found")
 		}
@@ -121,7 +121,7 @@ func TestPath(t *testing.T) {
 	})
 
 	t.Run("WrongProject", func(t *testing.T) {
-		_, err := Path(s, "nonexistent-project", "1")
+		_, err := Path(s, false, "nonexistent-project", "1")
 		if err == nil {
 			t.Error("expected error for nonexistent project")
 		}


### PR DESCRIPTION
## Problem
Single pad commands (`view`, `delete`, `open`, `path`) could only access pads within the current project scope, making it impossible to manage pads from deleted repositories or different project scopes.

## Solution
Added the `--all` flag to all single pad commands, allowing users to access any pad by its index across all scopes.

## Changes
- ✅ Added `--all` flag definitions to `view`, `delete`, `open`, and `path` commands in CLI
- ✅ Updated CLI handlers to pass the `all` flag to command functions
- ✅ Modified command functions in `pkg/commands` to accept the `all` parameter
- ✅ Updated tests to match new function signatures

## Implementation Details
- The central `GetScratchByIndex` function already supported the `all` parameter
- `peek` and `view` commands already had partial support, now fully integrated
- All commands maintain backward compatibility (default behavior unchanged)

## Testing
```bash
# Without --all (only current project scope)
$ padz view 1
# Error if pad 1 is from different project

# With --all (searches all scopes)
$ padz view --all 1
# Successfully views pad from any project

# Works for all single pad commands
$ padz delete --all 42
$ padz open --all 15
$ padz path --all 7
```

## Examples
```bash
# In project A directory
$ padz ls
1. Project A note
2. Another project A note

# Can now access pads from project B or deleted projects
$ padz view --all 156  # Views pad from project B
$ padz delete --all 200  # Deletes pad from deleted repo
```

Fixes #[issue-number-if-exists]

🤖 Generated with [Claude Code](https://claude.ai/code)