### PR TITLE
Improve default UX: run ls command when no arguments provided

### DIFF
--- a/cmd/padz/cli/ls.go
+++ b/cmd/padz/cli/ls.go
@@ -52,7 +52,7 @@ The output includes the index, the relative time of creation, and the title of t
 
 			if len(scratches) == 0 {
 				if format == output.PlainFormat || format == output.TermFormat {
-					fmt.Println("No scratches found.")
+					fmt.Println("Nothing here, create your first scratch with `padz create` or `padz help` for assistance.")
 				}
 				return
 			}

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/arthur-debert/padz/internal/version"
 	"github.com/arthur-debert/padz/pkg/logging"
 	"github.com/rs/zerolog/log"
@@ -45,9 +43,9 @@ func NewRootCmd() *cobra.Command {
 			cmd.Printf(VersionFormat, version.Version, version.Commit, version.Date)
 			return
 		}
-		// Show help when no command is provided
-		_ = cmd.Help()
-		os.Exit(1)
+		// Run ls command when no command is provided
+		lsCmd := newLsCmd()
+		lsCmd.Run(lsCmd, args)
 	}
 
 	// Set up command groups


### PR DESCRIPTION
## Summary
- Changes default behavior from showing help + exit(1) to running `ls` command when no arguments are provided
- Updates empty state message to be more helpful and actionable: "Nothing here, create your first scratch with `padz create` or `padz help` for assistance."
- Removes unused `os` import from root.go

## Test plan
- [x] Verify `padz` (no args) now runs ls command instead of showing help
- [x] Test empty state shows new helpful message
- [x] Run build script and verify all tests pass
- [x] Verify binary works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)