### PR TITLE
feat: Auto-copy pad content to clipboard on creation

### DIFF
--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -1,0 +1,44 @@
+package clipboard
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Copy copies the given content to the system clipboard
+func Copy(content []byte) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return copyDarwin(content)
+	case "linux":
+		return copyLinux(content)
+	default:
+		return fmt.Errorf("clipboard not supported on %s", runtime.GOOS)
+	}
+}
+
+func copyDarwin(content []byte) error {
+	cmd := exec.Command("pbcopy")
+	cmd.Stdin = bytes.NewReader(content)
+	return cmd.Run()
+}
+
+func copyLinux(content []byte) error {
+	// Try xclip first, then xsel
+	cmds := [][]string{
+		{"xclip", "-selection", "clipboard"},
+		{"xsel", "--clipboard", "--input"},
+	}
+
+	for _, cmdArgs := range cmds {
+		cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+		cmd.Stdin = bytes.NewReader(content)
+		if err := cmd.Run(); err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no clipboard utility found (tried xclip and xsel)")
+}

--- a/pkg/clipboard/clipboard_test.go
+++ b/pkg/clipboard/clipboard_test.go
@@ -1,0 +1,24 @@
+package clipboard
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestCopy(t *testing.T) {
+	// Skip test if not on supported platform
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("Clipboard not supported on this platform")
+	}
+
+	content := []byte("test clipboard content")
+
+	err := Copy(content)
+
+	// On CI or systems without clipboard utilities, this might fail
+	// We just check that the function doesn't panic
+	if err != nil && runtime.GOOS == "linux" {
+		// Expected on Linux systems without xclip/xsel
+		t.Logf("Clipboard copy failed (expected on systems without clipboard utilities): %v", err)
+	}
+}

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
+	"github.com/arthur-debert/padz/pkg/clipboard"
 	"github.com/arthur-debert/padz/pkg/config"
 	"github.com/arthur-debert/padz/pkg/editor"
 	"github.com/arthur-debert/padz/pkg/store"
@@ -57,7 +58,14 @@ func CreateWithTitle(s *store.Store, project string, content []byte, providedTit
 		return err
 	}
 
-	return s.AddScratch(scratch)
+	if err := s.AddScratch(scratch); err != nil {
+		return err
+	}
+
+	// Copy content to clipboard
+	_ = clipboard.Copy(trimmedContent)
+
+	return nil
 }
 
 func getTitle(content []byte) string {


### PR DESCRIPTION
## Summary
- Automatically copy pad content to system clipboard when creating a new pad
- Cross-platform support for macOS (pbcopy) and Linux (xclip/xsel)
- Gracefully handle systems without clipboard utilities

## Test plan
- [x] Test on macOS with pbcopy
- [ ] Test on Linux with xclip
- [ ] Test on Linux with xsel
- [ ] Verify tests pass on systems without clipboard utilities

🤖 Generated with [Claude Code](https://claude.ai/code)