### PR TITLE
feat: Add filesystem symlinks for pad access

### DIFF
--- a/cmd/padz/cli/links.go
+++ b/cmd/padz/cli/links.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/arthur-debert/padz/pkg/symlinks"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// newLinksCmd creates and returns a new links command
+func newLinksCmd() *cobra.Command {
+	var linkDir string
+
+	cmd := &cobra.Command{
+		Use:   "links",
+		Short: "Manage filesystem links to pads",
+		Long: `Create and manage symlinks to pad files, allowing you to access them as regular files.
+
+By default, creates links in ~/.padz-links/. You can then:
+  cat ~/.padz-links/1           # Read pad by index
+  cat ~/.padz-links/<id>        # Read pad by ID
+  cat ~/.padz-links/<title>     # Read pad by title
+
+Example:
+  padz links                    # Update links in default location
+  padz links -d /tmp/padz       # Update links in custom location`,
+		Run: func(cmd *cobra.Command, args []string) {
+			s, err := store.NewStore()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to initialize store")
+			}
+
+			manager, err := symlinks.NewManager(s, linkDir)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create symlink manager")
+			}
+
+			if err := manager.Update(); err != nil {
+				log.Fatal().Err(err).Msg("Failed to update symlinks")
+			}
+
+			dir := manager.GetLinkDir()
+			fmt.Printf("✓ Symlinks updated in %s\n", dir)
+
+			// Show example usage
+			scratches := s.GetScratches()
+			if len(scratches) > 0 {
+				fmt.Println("\nExample usage:")
+				fmt.Printf("  cat %s\n", filepath.Join(dir, "1"))
+				if scratches[0].Title != "" && scratches[0].Title != "Untitled" {
+					fmt.Printf("  cat %s\n", filepath.Join(dir, symlinks.SanitizeFilename(scratches[0].Title)))
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&linkDir, "directory", "d", "", "Directory to create symlinks in (default: ~/.padz-links)")
+
+	return cmd
+}

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -120,6 +120,10 @@ func NewRootCmd() *cobra.Command {
 	recoverCmd.GroupID = "multiple"
 	rootCmd.AddCommand(recoverCmd)
 
+	linksCmd := newLinksCmd()
+	linksCmd.GroupID = "multiple"
+	rootCmd.AddCommand(linksCmd)
+
 	return rootCmd
 }
 

--- a/pkg/symlinks/symlinks.go
+++ b/pkg/symlinks/symlinks.go
@@ -1,0 +1,148 @@
+package symlinks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// Manager handles creating and maintaining symlinks to pad files
+type Manager struct {
+	store   *store.Store
+	linkDir string
+}
+
+// NewManager creates a new symlink manager
+func NewManager(s *store.Store, linkDir string) (*Manager, error) {
+	// Default to ~/.padz-links if not specified
+	if linkDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		linkDir = filepath.Join(home, ".padz-links")
+	}
+
+	if err := os.MkdirAll(linkDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create link directory: %w", err)
+	}
+
+	return &Manager{
+		store:   s,
+		linkDir: linkDir,
+	}, nil
+}
+
+// Update refreshes all symlinks based on current pads
+func (m *Manager) Update() error {
+	// Clean existing links
+	if err := m.clean(); err != nil {
+		return err
+	}
+
+	// Create new links
+	scratches := m.store.GetScratches()
+	for i, scratch := range scratches {
+		// Create numeric link (1-based index)
+		numLink := filepath.Join(m.linkDir, fmt.Sprintf("%d", i+1))
+		target, err := store.GetScratchFilePath(scratch.ID)
+		if err != nil {
+			continue
+		}
+
+		// Remove existing link if it exists
+		_ = os.Remove(numLink)
+		if err := os.Symlink(target, numLink); err != nil {
+			return fmt.Errorf("failed to create numeric link: %w", err)
+		}
+
+		// Create ID link
+		idLink := filepath.Join(m.linkDir, scratch.ID)
+		_ = os.Remove(idLink) // Remove existing link if it exists
+		if err := os.Symlink(target, idLink); err != nil {
+			return fmt.Errorf("failed to create ID link: %w", err)
+		}
+
+		// Create title link if title exists
+		if scratch.Title != "" && scratch.Title != "Untitled" {
+			titleLink := filepath.Join(m.linkDir, SanitizeFilename(scratch.Title))
+			// Handle collisions by appending part of ID
+			if _, err := os.Stat(titleLink); err == nil {
+				titleLink = filepath.Join(m.linkDir, fmt.Sprintf("%s-%s", SanitizeFilename(scratch.Title), scratch.ID[:8]))
+			}
+			if err := os.Symlink(target, titleLink); err != nil {
+				// Non-fatal - title links are optional
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetLinkDir returns the directory containing symlinks
+func (m *Manager) GetLinkDir() string {
+	return m.linkDir
+}
+
+// clean removes all existing files in the link directory
+func (m *Manager) clean() error {
+	entries, err := os.ReadDir(m.linkDir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(m.linkDir, entry.Name())
+		// Remove all files (symlinks, regular files, etc)
+		// This ensures we start fresh
+		_ = os.Remove(path)
+	}
+
+	return nil
+}
+
+// SanitizeFilename makes a title safe for use as a filename
+func SanitizeFilename(name string) string {
+	// Replace problematic characters
+	replacements := []struct {
+		old, new string
+	}{
+		{"/", "-"},
+		{"\\", "-"},
+		{":", "-"},
+		{"*", ""},
+		{"?", ""},
+		{"\"", ""},
+		{"<", ""},
+		{">", ""},
+		{"|", "-"},
+		{"\n", " "},
+		{"\r", " "},
+		{"\t", " "},
+	}
+
+	result := name
+	for _, r := range replacements {
+		result = strings.ReplaceAll(result, r.old, r.new)
+	}
+
+	// Collapse multiple spaces/dashes
+	result = strings.TrimSpace(result)
+	for strings.Contains(result, "  ") {
+		result = strings.ReplaceAll(result, "  ", " ")
+	}
+	for strings.Contains(result, "--") {
+		result = strings.ReplaceAll(result, "--", "-")
+	}
+
+	// Limit length
+	if len(result) > 50 {
+		result = result[:50]
+	}
+
+	return result
+}


### PR DESCRIPTION
## Summary
- Add `padz links` command to create filesystem symlinks to pad files
- Allows accessing pads as regular files with standard Unix tools
- Creates symlinks by index, ID, and title

## Features
- Symlinks by index: `~/.padz-links/1`, `~/.padz-links/2`, etc.
- Symlinks by ID: `~/.padz-links/<pad-id>`
- Symlinks by title: `~/.padz-links/<sanitized-title>`
- Custom link directory support with `-d` flag
- Automatic cleanup of old symlinks on update

## Test plan
- [x] Test creating symlinks in default location
- [x] Test accessing pads via `cat`, `grep`, etc.
- [x] Test custom directory with `-d` flag
- [x] Test title sanitization for filesystem safety
- [x] Test collision handling for duplicate titles

🤖 Generated with [Claude Code](https://claude.ai/code)