### PR TITLE
Enhance create command with flexible title and content handling

### DIFF
--- a/cmd/padz/cli/create.go
+++ b/cmd/padz/cli/create.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 
 	"github.com/arthur-debert/padz/pkg/commands"
 	"github.com/arthur-debert/padz/pkg/project"
@@ -13,13 +14,18 @@ import (
 // newCreateCmd creates and returns a new create command
 func newCreateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "create",
+		Use:     "create [words...]",
 		Aliases: []string{"new", "n"},
 		Short:   "Create a new scratch",
 		Long: `Create a new scratch in the current project or global scope.
 
 If no content is piped, opens your default editor to write the scratch.
-You can specify a custom title and choose to create in global scope.`,
+You can specify a custom title with --title or use arguments as the title.
+
+Examples:
+  padz create How to forget Greece     # Title: "How to forget Greece"
+  padz create --title "My Title"       # Title: "My Title"
+  padz create --title "My Title" Some content  # Title: "My Title", initial content: "Some content"`,
 		Run: func(cmd *cobra.Command, args []string) {
 			globalFlag, _ := cmd.Flags().GetBool("global")
 			titleFlag, _ := cmd.Flags().GetString("title")
@@ -43,10 +49,34 @@ You can specify a custom title and choose to create in global scope.`,
 				proj = currentProj
 			}
 
-			content := commands.ReadContentFromPipe()
+			pipedContent := commands.ReadContentFromPipe()
 
-			if err := commands.CreateWithTitle(s, proj, content, titleFlag); err != nil {
-				log.Fatal().Err(err).Msg(ErrFailedToCreateNote)
+			// Determine title and content based on flags and args
+			var title string
+			var initialContent []byte
+
+			if titleFlag != "" {
+				// If --title is provided, use it as title
+				title = titleFlag
+				if len(args) > 0 {
+					// Args become initial content
+					initialContent = []byte(strings.Join(args, " "))
+				}
+			} else if len(args) > 0 {
+				// No --title flag, args become the title
+				title = strings.Join(args, " ")
+			}
+
+			// If content was piped, use it
+			if len(pipedContent) > 0 {
+				if err := commands.CreateWithTitle(s, proj, pipedContent, title); err != nil {
+					log.Fatal().Err(err).Msg(ErrFailedToCreateNote)
+				}
+			} else {
+				// No piped content, use initial content if any
+				if err := commands.CreateWithTitleAndContent(s, proj, title, initialContent); err != nil {
+					log.Fatal().Err(err).Msg(ErrFailedToCreateNote)
+				}
 			}
 		},
 	}

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -68,6 +68,64 @@ func CreateWithTitle(s *store.Store, project string, content []byte, providedTit
 	return nil
 }
 
+// CreateWithTitleAndContent creates a scratch with a title and optional initial content
+func CreateWithTitleAndContent(s *store.Store, project string, title string, initialContent []byte) error {
+	var err error
+	var content []byte
+
+	// Prepare initial content for editor
+	var editorContent []byte
+	if title != "" && len(initialContent) > 0 {
+		// Both title and initial content provided
+		editorContent = []byte(title + "\n\n" + string(initialContent))
+	} else if title != "" {
+		// Only title provided
+		editorContent = []byte(title + "\n\n")
+	} else if len(initialContent) > 0 {
+		// Only initial content provided
+		editorContent = initialContent
+	}
+
+	// Open editor with prepared content
+	content, err = editor.OpenInEditor(editorContent)
+	if err != nil {
+		return err
+	}
+
+	trimmedContent := trim(content)
+	if len(trimmedContent) == 0 {
+		return nil // Don't save empty scratches
+	}
+
+	// Use provided title if available, otherwise extract from content
+	finalTitle := title
+	if finalTitle == "" {
+		finalTitle = getTitle(trimmedContent)
+	}
+
+	id := fmt.Sprintf("%x", sha1.Sum(trimmedContent))
+
+	scratch := store.Scratch{
+		ID:        id,
+		Project:   project,
+		Title:     finalTitle,
+		CreatedAt: time.Now(),
+	}
+
+	if err := saveScratchFile(id, trimmedContent); err != nil {
+		return err
+	}
+
+	if err := s.AddScratch(scratch); err != nil {
+		return err
+	}
+
+	// Copy content to clipboard
+	_ = clipboard.Copy(trimmedContent)
+
+	return nil
+}
+
 func getTitle(content []byte) string {
 	reader := bytes.NewReader(content)
 	scanner := bufio.NewScanner(reader)

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -1,0 +1,326 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestCreateWithTitle(t *testing.T) {
+	tests := []struct {
+		name           string
+		project        string
+		content        []byte
+		providedTitle  string
+		expectedTitle  string
+		expectError    bool
+		expectSave     bool
+		expectedEditor bool
+	}{
+		{
+			name:           "create with content and provided title",
+			project:        "testproject",
+			content:        []byte("Hello World\nThis is a test"),
+			providedTitle:  "My Custom Title",
+			expectedTitle:  "My Custom Title",
+			expectError:    false,
+			expectSave:     true,
+			expectedEditor: false,
+		},
+		{
+			name:           "create with content but no provided title",
+			project:        "testproject",
+			content:        []byte("First Line Title\nThis is content"),
+			providedTitle:  "",
+			expectedTitle:  "First Line Title",
+			expectError:    false,
+			expectSave:     true,
+			expectedEditor: false,
+		},
+		{
+			name:           "create with empty content and provided title - opens editor",
+			project:        "testproject",
+			content:        []byte{},
+			providedTitle:  "Editor Title",
+			expectedTitle:  "Editor Title",
+			expectError:    false,
+			expectSave:     true,
+			expectedEditor: true,
+		},
+		{
+			name:           "create with whitespace only content",
+			project:        "testproject",
+			content:        []byte("   \n\t\n   "),
+			providedTitle:  "Whitespace Title",
+			expectedTitle:  "",
+			expectError:    false,
+			expectSave:     false,
+			expectedEditor: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := SetupCommandTest(t)
+			defer setup.Cleanup()
+
+			if tt.expectedEditor {
+				// Set up a mock editor that writes test content
+				oldEditor := os.Getenv("EDITOR")
+				testScript := createMockEditorScript(t, tt.providedTitle+"\n\nContent from editor")
+				defer func() { _ = os.Remove(testScript) }()
+				_ = os.Setenv("EDITOR", testScript)
+				defer func() {
+					if oldEditor == "" {
+						_ = os.Unsetenv("EDITOR")
+					} else {
+						_ = os.Setenv("EDITOR", oldEditor)
+					}
+				}()
+			}
+
+			initialCount := len(setup.Store.GetScratches())
+
+			err := CreateWithTitle(setup.Store, tt.project, tt.content, tt.providedTitle)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			scratches := setup.Store.GetScratches()
+			if tt.expectSave {
+				if len(scratches) != initialCount+1 {
+					t.Errorf("expected scratch to be saved, count: %d -> %d", initialCount, len(scratches))
+				}
+				if len(scratches) > 0 {
+					lastScratch := scratches[len(scratches)-1]
+					if lastScratch.Project != tt.project {
+						t.Errorf("expected project %s, got %s", tt.project, lastScratch.Project)
+					}
+					if lastScratch.Title != tt.expectedTitle {
+						t.Errorf("expected title %q, got %q", tt.expectedTitle, lastScratch.Title)
+					}
+				}
+			} else {
+				if len(scratches) != initialCount {
+					t.Errorf("expected scratch not to be saved, count: %d -> %d", initialCount, len(scratches))
+				}
+			}
+		})
+	}
+}
+
+func TestCreateWithTitleAndContent(t *testing.T) {
+	tests := []struct {
+		name               string
+		project            string
+		title              string
+		initialContent     []byte
+		expectedEditorText string
+		finalEditorContent string
+		expectedTitle      string
+		expectError        bool
+		expectSave         bool
+	}{
+		{
+			name:               "both title and initial content",
+			project:            "testproject",
+			title:              "My Title",
+			initialContent:     []byte("Initial content"),
+			expectedEditorText: "My Title\n\nInitial content",
+			finalEditorContent: "My Title\n\nInitial content\nMore content added",
+			expectedTitle:      "My Title",
+			expectError:        false,
+			expectSave:         true,
+		},
+		{
+			name:               "only title provided",
+			project:            "testproject",
+			title:              "Only Title",
+			initialContent:     []byte{},
+			expectedEditorText: "Only Title\n\n",
+			finalEditorContent: "Only Title\n\nContent added in editor",
+			expectedTitle:      "Only Title",
+			expectError:        false,
+			expectSave:         true,
+		},
+		{
+			name:               "only initial content provided",
+			project:            "testproject",
+			title:              "",
+			initialContent:     []byte("Just content"),
+			expectedEditorText: "Just content",
+			finalEditorContent: "Just content\nMore lines",
+			expectedTitle:      "Just content",
+			expectError:        false,
+			expectSave:         true,
+		},
+		{
+			name:               "neither title nor content",
+			project:            "testproject",
+			title:              "",
+			initialContent:     []byte{},
+			expectedEditorText: "",
+			finalEditorContent: "New content from editor",
+			expectedTitle:      "New content from editor",
+			expectError:        false,
+			expectSave:         true,
+		},
+		{
+			name:               "user clears all content in editor",
+			project:            "testproject",
+			title:              "Title",
+			initialContent:     []byte("Content"),
+			expectedEditorText: "Title\n\nContent",
+			finalEditorContent: "",
+			expectedTitle:      "",
+			expectError:        false,
+			expectSave:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := SetupCommandTest(t)
+			defer setup.Cleanup()
+
+			// Set up a mock editor that verifies initial content and writes final content
+			oldEditor := os.Getenv("EDITOR")
+			testScript := createVerifyingMockEditorScript(t, tt.expectedEditorText, tt.finalEditorContent)
+			defer func() { _ = os.Remove(testScript) }()
+			_ = os.Setenv("EDITOR", testScript)
+			defer func() {
+				if oldEditor == "" {
+					_ = os.Unsetenv("EDITOR")
+				} else {
+					_ = os.Setenv("EDITOR", oldEditor)
+				}
+			}()
+
+			initialCount := len(setup.Store.GetScratches())
+
+			err := CreateWithTitleAndContent(setup.Store, tt.project, tt.title, tt.initialContent)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			scratches := setup.Store.GetScratches()
+			if tt.expectSave {
+				if len(scratches) != initialCount+1 {
+					t.Errorf("expected scratch to be saved, count: %d -> %d", initialCount, len(scratches))
+				}
+				if len(scratches) > 0 {
+					lastScratch := scratches[len(scratches)-1]
+					if lastScratch.Project != tt.project {
+						t.Errorf("expected project %s, got %s", tt.project, lastScratch.Project)
+					}
+					if lastScratch.Title != tt.expectedTitle {
+						t.Errorf("expected title %q, got %q", tt.expectedTitle, lastScratch.Title)
+					}
+
+					// Verify the saved content matches what the editor returned
+					savedContent := setup.ReadScratchFile(t, lastScratch.ID)
+					if string(savedContent) != tt.finalEditorContent {
+						t.Errorf("expected saved content %q, got %q", tt.finalEditorContent, string(savedContent))
+					}
+				}
+			} else {
+				if len(scratches) != initialCount {
+					t.Errorf("expected scratch not to be saved, count: %d -> %d", initialCount, len(scratches))
+				}
+			}
+		})
+	}
+}
+
+func TestCreateWithPipedContentAndTitle(t *testing.T) {
+	setup := SetupCommandTest(t)
+	defer setup.Cleanup()
+
+	pipedContent := "Piped content line 1\nPiped content line 2"
+	providedTitle := "Custom Title for Piped Content"
+
+	// Simulate piped content
+	reader := bytes.NewBufferString(pipedContent)
+	content := ReadContentFromPipeWithReader(reader)
+
+	err := CreateWithTitle(setup.Store, "testproject", content, providedTitle)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	scratches := setup.Store.GetScratches()
+	if len(scratches) != 1 {
+		t.Fatalf("expected 1 scratch, got %d", len(scratches))
+	}
+
+	scratch := scratches[0]
+	if scratch.Title != providedTitle {
+		t.Errorf("expected title %q, got %q", providedTitle, scratch.Title)
+	}
+
+	savedContent := setup.ReadScratchFile(t, scratch.ID)
+	if string(savedContent) != pipedContent {
+		t.Errorf("expected saved content %q, got %q", pipedContent, string(savedContent))
+	}
+}
+
+func createVerifyingMockEditorScript(t *testing.T, expectedContent, outputContent string) string {
+	// Create a script that verifies the initial content and writes the output content
+	scriptContent := `#!/bin/bash
+FILE="$1"
+
+# Read file content preserving trailing newlines
+ACTUAL=$(cat "$FILE"; echo -n x)
+ACTUAL="${ACTUAL%x}"
+
+# Expected content
+EXPECTED="` + expectedContent + `"
+
+# For debugging
+echo "Expected: '$EXPECTED'" >&2
+echo "Actual: '$ACTUAL'" >&2
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "ERROR: Initial content mismatch" >&2
+    echo "Expected: '$EXPECTED'" >&2
+    echo "Actual: '$ACTUAL'" >&2
+    exit 1
+fi
+
+cat > "$FILE" << 'EOF'
+` + outputContent + `
+EOF
+`
+	tmpFile, err := os.CreateTemp("", "verifying-editor-*.sh")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	if _, err := tmpFile.WriteString(scriptContent); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	if err := os.Chmod(tmpFile.Name(), 0755); err != nil {
+		t.Fatalf("failed to make script executable: %v", err)
+	}
+
+	return tmpFile.Name()
+}


### PR DESCRIPTION
## Summary
- Enhanced the `create` command to accept variable arguments as the title
- Added support for using both `--title` flag and arguments together to specify title and initial content
- Improved CLI ergonomics by allowing quick pad creation without the `--title` flag

## Changes
- Modified `cmd/padz/cli/create.go` to parse arguments as title when no `--title` flag is provided
- Added `CreateWithTitleAndContent` function to handle cases where both title and initial content are provided
- Added comprehensive tests for all new functionality

## Usage Examples
```bash
# Create with args as title
padz create How to forget Greece

# Create with --title flag
padz create --title "My Title"  

# Create with title and initial content
padz create --title "How to forget Greece" Greece is unforgettable
```

## Test Plan
- [x] Added unit tests for `CreateWithTitle` function
- [x] Added unit tests for `CreateWithTitleAndContent` function
- [x] Tested various scenarios including empty content, piped content, and editor interactions
- [x] All tests pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)