### PR TITLE
Implement individual metadata files with master index (fixes #37)

### DIFF
--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -23,6 +23,8 @@ type FileSystem interface {
 	MkdirAll(path string, perm os.FileMode) error
 	// Join joins path elements
 	Join(elem ...string) string
+	// ReadDir reads the named directory
+	ReadDir(path string) ([]os.DirEntry, error)
 }
 
 // OSFileSystem implements FileSystem using real OS operations
@@ -101,6 +103,20 @@ func (fs *OSFileSystem) MkdirAll(path string, perm os.FileMode) error {
 
 func (fs *OSFileSystem) Join(elem ...string) string {
 	return filepath.Join(elem...)
+}
+
+func (fs *OSFileSystem) ReadDir(path string) ([]os.DirEntry, error) {
+	logger := logging.GetLogger("filesystem.os")
+	logger.Debug().Str("path", path).Msg("Reading directory")
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		logger.Error().Err(err).Str("path", path).Msg("Failed to read directory")
+		return nil, err
+	}
+
+	logger.Debug().Str("path", path).Int("entries", len(entries)).Msg("Directory read successfully")
+	return entries, nil
 }
 
 // MemoryFileSystem implements FileSystem in memory
@@ -228,6 +244,61 @@ func (fs *MemoryFileSystem) Join(elem ...string) string {
 	return filepath.Join(elem...)
 }
 
+func (fs *MemoryFileSystem) ReadDir(path string) ([]os.DirEntry, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if !fs.dirExists(path) {
+		return nil, &os.PathError{Op: "readdir", Path: path, Err: os.ErrNotExist}
+	}
+
+	// Collect all entries in this directory
+	entries := make([]os.DirEntry, 0)
+	seen := make(map[string]bool)
+
+	// Check files
+	for filePath := range fs.files {
+		dir := filepath.Dir(filePath)
+		if dir == path {
+			name := filepath.Base(filePath)
+			if !seen[name] {
+				seen[name] = true
+				entries = append(entries, &memDirEntry{
+					name:  name,
+					isDir: false,
+					info: &memFileInfo{
+						name: name,
+						size: int64(len(fs.files[filePath])),
+						mode: 0644,
+					},
+				})
+			}
+		}
+	}
+
+	// Check subdirectories
+	for dirPath := range fs.dirs {
+		parent := filepath.Dir(dirPath)
+		if parent == path && dirPath != path {
+			name := filepath.Base(dirPath)
+			if !seen[name] {
+				seen[name] = true
+				entries = append(entries, &memDirEntry{
+					name:  name,
+					isDir: true,
+					info: &memFileInfo{
+						name:  name,
+						mode:  os.ModeDir | 0755,
+						isDir: true,
+					},
+				})
+			}
+		}
+	}
+
+	return entries, nil
+}
+
 func (fs *MemoryFileSystem) dirExists(path string) bool {
 	if path == "/" || path == "." {
 		return true
@@ -249,6 +320,18 @@ func (fi *memFileInfo) Mode() os.FileMode  { return fi.mode }
 func (fi *memFileInfo) ModTime() time.Time { return time.Now() }
 func (fi *memFileInfo) IsDir() bool        { return fi.isDir }
 func (fi *memFileInfo) Sys() interface{}   { return nil }
+
+// memDirEntry implements os.DirEntry for in-memory files
+type memDirEntry struct {
+	name  string
+	isDir bool
+	info  os.FileInfo
+}
+
+func (de *memDirEntry) Name() string               { return de.name }
+func (de *memDirEntry) IsDir() bool                { return de.isDir }
+func (de *memDirEntry) Type() os.FileMode          { return de.info.Mode().Type() }
+func (de *memDirEntry) Info() (os.FileInfo, error) { return de.info, nil }
 
 // Reset clears all files and directories in the memory file system
 func (fs *MemoryFileSystem) Reset() {

--- a/pkg/store/metadata.go
+++ b/pkg/store/metadata.go
@@ -1,0 +1,351 @@
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/filesystem"
+	"github.com/arthur-debert/padz/pkg/logging"
+)
+
+const (
+	metadataDirName = "metadata"
+	filesDirName    = "files"
+	indexFileName   = "index.json"
+	indexVersion    = "1.0"
+)
+
+// MetadataManager handles individual metadata files and master index
+type MetadataManager struct {
+	fs       filesystem.FileSystem
+	basePath string
+}
+
+// NewMetadataManager creates a new metadata manager
+func NewMetadataManager(fs filesystem.FileSystem, basePath string) *MetadataManager {
+	return &MetadataManager{
+		fs:       fs,
+		basePath: basePath,
+	}
+}
+
+// GetFilesPath returns the path to the files directory
+func (m *MetadataManager) GetFilesPath() string {
+	return m.fs.Join(m.basePath, filesDirName)
+}
+
+// GetMetadataPath returns the path to the metadata directory
+func (m *MetadataManager) GetMetadataPath() string {
+	return m.fs.Join(m.basePath, metadataDirName)
+}
+
+// GetIndexPath returns the path to the index file
+func (m *MetadataManager) GetIndexPath() string {
+	return m.fs.Join(m.basePath, indexFileName)
+}
+
+// Initialize creates the necessary directory structure
+func (m *MetadataManager) Initialize() error {
+	logger := logging.GetLogger("metadata")
+
+	// Create files directory
+	filesPath := m.GetFilesPath()
+	if err := m.fs.MkdirAll(filesPath, 0755); err != nil {
+		logger.Error().Err(err).Str("path", filesPath).Msg("Failed to create files directory")
+		return err
+	}
+
+	// Create metadata directory
+	metadataPath := m.GetMetadataPath()
+	if err := m.fs.MkdirAll(metadataPath, 0755); err != nil {
+		logger.Error().Err(err).Str("path", metadataPath).Msg("Failed to create metadata directory")
+		return err
+	}
+
+	// Check if index exists, if not create empty one
+	indexPath := m.GetIndexPath()
+	if _, err := m.fs.Stat(indexPath); os.IsNotExist(err) {
+		index := &Index{
+			Version:   indexVersion,
+			UpdatedAt: time.Now(),
+			Scratches: make(map[string]IndexEntry),
+		}
+		if err := m.SaveIndex(index); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LoadIndex reads the master index
+func (m *MetadataManager) LoadIndex() (*Index, error) {
+	indexPath := m.GetIndexPath()
+
+	data, err := m.fs.ReadFile(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Return empty index if file doesn't exist
+			return &Index{
+				Version:   indexVersion,
+				UpdatedAt: time.Now(),
+				Scratches: make(map[string]IndexEntry),
+			}, nil
+		}
+		logger := logging.GetLogger("metadata")
+		logger.Error().Err(err).Str("path", indexPath).Msg("Failed to read index file")
+		return nil, err
+	}
+
+	var index Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		logger := logging.GetLogger("metadata")
+		logger.Error().Err(err).Msg("Failed to unmarshal index")
+		return nil, err
+	}
+
+	return &index, nil
+}
+
+// SaveIndex writes the master index
+func (m *MetadataManager) SaveIndex(index *Index) error {
+	index.UpdatedAt = time.Now()
+
+	logger := logging.GetLogger("metadata")
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to marshal index")
+		return err
+	}
+
+	indexPath := m.GetIndexPath()
+	if err := m.fs.WriteFile(indexPath, data, 0644); err != nil {
+		logger.Error().Err(err).Str("path", indexPath).Msg("Failed to write index file")
+		return err
+	}
+
+	logger.Debug().Str("path", indexPath).Int("scratch_count", len(index.Scratches)).Msg("Index saved successfully")
+	return nil
+}
+
+// LoadScratchMetadata loads individual scratch metadata
+func (m *MetadataManager) LoadScratchMetadata(id string) (*Scratch, error) {
+	metadataPath := m.fs.Join(m.GetMetadataPath(), id+".json")
+
+	logger := logging.GetLogger("metadata")
+
+	data, err := m.fs.ReadFile(metadataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debug().Str("id", id).Msg("Metadata file not found")
+			return nil, nil
+		}
+		logger.Error().Err(err).Str("path", metadataPath).Msg("Failed to read metadata file")
+		return nil, err
+	}
+
+	var scratch Scratch
+	if err := json.Unmarshal(data, &scratch); err != nil {
+		logger.Error().Err(err).Str("id", id).Msg("Failed to unmarshal scratch metadata")
+		return nil, err
+	}
+
+	return &scratch, nil
+}
+
+// SaveScratchMetadata saves individual scratch metadata
+func (m *MetadataManager) SaveScratchMetadata(scratch *Scratch) error {
+	// Update timestamps
+	if scratch.UpdatedAt.IsZero() {
+		scratch.UpdatedAt = time.Now()
+	}
+
+	// Calculate checksum if not set
+	if scratch.Checksum == "" {
+		contentPath := m.fs.Join(m.GetFilesPath(), scratch.ID)
+		if data, err := m.fs.ReadFile(contentPath); err == nil {
+			scratch.Checksum = fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+			scratch.Size = int64(len(data))
+		}
+	}
+
+	logger := logging.GetLogger("metadata")
+
+	data, err := json.MarshalIndent(scratch, "", "  ")
+	if err != nil {
+		logger.Error().Err(err).Str("id", scratch.ID).Msg("Failed to marshal scratch metadata")
+		return err
+	}
+
+	metadataPath := m.fs.Join(m.GetMetadataPath(), scratch.ID+".json")
+	if err := m.fs.WriteFile(metadataPath, data, 0644); err != nil {
+		logger.Error().Err(err).Str("path", metadataPath).Msg("Failed to write metadata file")
+		return err
+	}
+
+	logger.Debug().Str("id", scratch.ID).Str("path", metadataPath).Msg("Scratch metadata saved")
+	return nil
+}
+
+// DeleteScratchMetadata removes individual scratch metadata
+func (m *MetadataManager) DeleteScratchMetadata(id string) error {
+	metadataPath := m.fs.Join(m.GetMetadataPath(), id+".json")
+
+	logger := logging.GetLogger("metadata")
+
+	if err := m.fs.Remove(metadataPath); err != nil && !os.IsNotExist(err) {
+		logger.Error().Err(err).Str("path", metadataPath).Msg("Failed to delete metadata file")
+		return err
+	}
+
+	logger.Debug().Str("id", id).Msg("Scratch metadata deleted")
+	return nil
+}
+
+// UpdateIndexEntry updates or adds an entry in the index
+func (m *MetadataManager) UpdateIndexEntry(scratch *Scratch) error {
+	index, err := m.LoadIndex()
+	if err != nil {
+		return err
+	}
+
+	index.Scratches[scratch.ID] = IndexEntry{
+		Project:   scratch.Project,
+		Title:     scratch.Title,
+		CreatedAt: scratch.CreatedAt,
+	}
+
+	return m.SaveIndex(index)
+}
+
+// RemoveIndexEntry removes an entry from the index
+func (m *MetadataManager) RemoveIndexEntry(id string) error {
+	index, err := m.LoadIndex()
+	if err != nil {
+		return err
+	}
+
+	delete(index.Scratches, id)
+
+	return m.SaveIndex(index)
+}
+
+// RebuildIndex reconstructs the index from individual metadata files
+func (m *MetadataManager) RebuildIndex() error {
+	logger := logging.GetLogger("metadata")
+	logger.Info().Msg("Rebuilding index from individual metadata files")
+
+	metadataPath := m.GetMetadataPath()
+	entries, err := m.fs.ReadDir(metadataPath)
+	if err != nil {
+		logger.Error().Err(err).Str("path", metadataPath).Msg("Failed to read metadata directory")
+		return err
+	}
+
+	index := &Index{
+		Version:   indexVersion,
+		UpdatedAt: time.Now(),
+		Scratches: make(map[string]IndexEntry),
+	}
+
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		id := entry.Name()[:len(entry.Name())-5] // Remove .json extension
+		scratch, err := m.LoadScratchMetadata(id)
+		if err != nil {
+			logger.Warn().Err(err).Str("id", id).Msg("Failed to load scratch metadata during rebuild")
+			continue
+		}
+
+		if scratch != nil {
+			index.Scratches[id] = IndexEntry{
+				Project:   scratch.Project,
+				Title:     scratch.Title,
+				CreatedAt: scratch.CreatedAt,
+			}
+		}
+	}
+
+	if err := m.SaveIndex(index); err != nil {
+		return err
+	}
+
+	logger.Info().Int("scratch_count", len(index.Scratches)).Msg("Index rebuilt successfully")
+	return nil
+}
+
+// MigrateFromLegacyMetadata migrates from old metadata.json to new structure
+func (m *MetadataManager) MigrateFromLegacyMetadata(scratches []Scratch) error {
+	logger := logging.GetLogger("metadata")
+	logger.Info().Int("scratch_count", len(scratches)).Msg("Starting migration from legacy metadata")
+
+	// Initialize directory structure
+	if err := m.Initialize(); err != nil {
+		return err
+	}
+
+	// Create individual metadata files and build index
+	index := &Index{
+		Version:   indexVersion,
+		UpdatedAt: time.Now(),
+		Scratches: make(map[string]IndexEntry),
+	}
+
+	for _, scratch := range scratches {
+		// Move content file if it's in the wrong place
+		oldPath := m.fs.Join(m.basePath, scratch.ID)
+		newPath := m.fs.Join(m.GetFilesPath(), scratch.ID)
+
+		if _, err := m.fs.Stat(oldPath); err == nil {
+			// File exists in old location, move it
+			if content, err := m.fs.ReadFile(oldPath); err == nil {
+				if err := m.fs.WriteFile(newPath, content, 0644); err != nil {
+					logger.Error().Err(err).Str("id", scratch.ID).Msg("Failed to move content file")
+					continue
+				}
+				// Remove old file
+				_ = m.fs.Remove(oldPath)
+				logger.Debug().Str("id", scratch.ID).Msg("Moved content file to new location")
+			}
+		}
+
+		// Save individual metadata
+		if err := m.SaveScratchMetadata(&scratch); err != nil {
+			logger.Error().Err(err).Str("id", scratch.ID).Msg("Failed to save scratch metadata during migration")
+			continue
+		}
+
+		// Add to index
+		index.Scratches[scratch.ID] = IndexEntry{
+			Project:   scratch.Project,
+			Title:     scratch.Title,
+			CreatedAt: scratch.CreatedAt,
+		}
+	}
+
+	// Save index
+	if err := m.SaveIndex(index); err != nil {
+		return err
+	}
+
+	// Backup old metadata.json
+	oldMetadataPath := m.fs.Join(m.basePath, metadataFileName)
+	backupPath := m.fs.Join(m.basePath, metadataFileName+".backup")
+	if _, err := m.fs.Stat(oldMetadataPath); err == nil {
+		if data, err := m.fs.ReadFile(oldMetadataPath); err == nil {
+			_ = m.fs.WriteFile(backupPath, data, 0644)
+			logger.Info().Str("backup_path", backupPath).Msg("Created backup of old metadata.json")
+		}
+	}
+
+	logger.Info().Int("migrated_count", len(index.Scratches)).Msg("Migration completed successfully")
+	return nil
+}

--- a/pkg/store/metadata_test.go
+++ b/pkg/store/metadata_test.go
@@ -1,0 +1,309 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/config"
+	"github.com/arthur-debert/padz/pkg/filesystem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataManager(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "metadata_test")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	fs := filesystem.NewOSFileSystem()
+	mm := NewMetadataManager(fs, tmpDir)
+
+	t.Run("Initialize", func(t *testing.T) {
+		err := mm.Initialize()
+		assert.NoError(t, err)
+
+		// Check directories exist
+		assert.DirExists(t, mm.GetFilesPath())
+		assert.DirExists(t, mm.GetMetadataPath())
+
+		// Check empty index exists
+		assert.FileExists(t, mm.GetIndexPath())
+
+		index, err := mm.LoadIndex()
+		assert.NoError(t, err)
+		assert.Equal(t, indexVersion, index.Version)
+		assert.Empty(t, index.Scratches)
+	})
+
+	t.Run("SaveAndLoadScratchMetadata", func(t *testing.T) {
+		scratch := &Scratch{
+			ID:        "test123",
+			Project:   "test-project",
+			Title:     "Test Scratch",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Size:      100,
+			Checksum:  "sha256:abc123",
+		}
+
+		// Save metadata
+		err := mm.SaveScratchMetadata(scratch)
+		assert.NoError(t, err)
+
+		// Load metadata
+		loaded, err := mm.LoadScratchMetadata(scratch.ID)
+		assert.NoError(t, err)
+		assert.NotNil(t, loaded)
+		assert.Equal(t, scratch.ID, loaded.ID)
+		assert.Equal(t, scratch.Title, loaded.Title)
+		assert.Equal(t, scratch.Project, loaded.Project)
+	})
+
+	t.Run("UpdateIndex", func(t *testing.T) {
+		scratch := &Scratch{
+			ID:        "index123",
+			Project:   "index-project",
+			Title:     "Index Test",
+			CreatedAt: time.Now(),
+		}
+
+		// Update index
+		err := mm.UpdateIndexEntry(scratch)
+		assert.NoError(t, err)
+
+		// Load index
+		index, err := mm.LoadIndex()
+		assert.NoError(t, err)
+		assert.Len(t, index.Scratches, 1)
+
+		entry, exists := index.Scratches[scratch.ID]
+		assert.True(t, exists)
+		assert.Equal(t, scratch.Project, entry.Project)
+		assert.Equal(t, scratch.Title, entry.Title)
+	})
+
+	t.Run("RemoveFromIndex", func(t *testing.T) {
+		// First add
+		scratch := &Scratch{
+			ID:        "remove123",
+			Project:   "remove-project",
+			Title:     "Remove Test",
+			CreatedAt: time.Now(),
+		}
+		err := mm.UpdateIndexEntry(scratch)
+		assert.NoError(t, err)
+
+		// Then remove
+		err = mm.RemoveIndexEntry(scratch.ID)
+		assert.NoError(t, err)
+
+		// Verify removed
+		index, err := mm.LoadIndex()
+		assert.NoError(t, err)
+		_, exists := index.Scratches[scratch.ID]
+		assert.False(t, exists)
+	})
+
+	t.Run("RebuildIndex", func(t *testing.T) {
+		// Create new temp dir for rebuild test
+		rebuildTmpDir, err := os.MkdirTemp("", "rebuild_test")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(rebuildTmpDir) }()
+
+		rebuildMM := NewMetadataManager(fs, rebuildTmpDir)
+
+		// Initialize first to create directories
+		err = rebuildMM.Initialize()
+		assert.NoError(t, err)
+
+		// Create some metadata files
+		scratches := []Scratch{
+			{ID: "rebuild1", Project: "proj1", Title: "Title 1", CreatedAt: time.Now()},
+			{ID: "rebuild2", Project: "proj2", Title: "Title 2", CreatedAt: time.Now()},
+			{ID: "rebuild3", Project: "proj3", Title: "Title 3", CreatedAt: time.Now()},
+		}
+
+		for _, s := range scratches {
+			s := s // capture range variable
+			err := rebuildMM.SaveScratchMetadata(&s)
+			assert.NoError(t, err)
+		}
+
+		// Corrupt the index by clearing it
+		err = rebuildMM.SaveIndex(&Index{
+			Version:   indexVersion,
+			UpdatedAt: time.Now(),
+			Scratches: make(map[string]IndexEntry),
+		})
+		assert.NoError(t, err)
+
+		// Rebuild
+		err = rebuildMM.RebuildIndex()
+		assert.NoError(t, err)
+
+		// Verify all entries are back
+		index, err := rebuildMM.LoadIndex()
+		assert.NoError(t, err)
+		assert.Len(t, index.Scratches, 3)
+		for _, s := range scratches {
+			entry, exists := index.Scratches[s.ID]
+			assert.True(t, exists)
+			assert.Equal(t, s.Project, entry.Project)
+			assert.Equal(t, s.Title, entry.Title)
+		}
+	})
+
+	t.Run("MigrateFromLegacy", func(t *testing.T) {
+		// Create new temp dir for migration test
+		migrateTmpDir, err := os.MkdirTemp("", "migrate_test")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(migrateTmpDir) }()
+
+		migrateMM := NewMetadataManager(fs, migrateTmpDir)
+
+		// Create legacy scratches
+		legacyScratches := []Scratch{
+			{ID: "legacy1", Project: "proj1", Title: "Legacy 1", CreatedAt: time.Now()},
+			{ID: "legacy2", Project: "proj2", Title: "Legacy 2", CreatedAt: time.Now()},
+		}
+
+		// Create legacy content files in root
+		for _, s := range legacyScratches {
+			content := []byte("content for " + s.ID)
+			err := fs.WriteFile(filepath.Join(migrateTmpDir, s.ID), content, 0644)
+			assert.NoError(t, err)
+		}
+
+		// Migrate
+		err = migrateMM.MigrateFromLegacyMetadata(legacyScratches)
+		assert.NoError(t, err)
+
+		// Verify migration
+		// 1. Check index
+		index, err := migrateMM.LoadIndex()
+		assert.NoError(t, err)
+		assert.Len(t, index.Scratches, 2)
+
+		// 2. Check individual metadata files
+		for _, s := range legacyScratches {
+			loaded, err := migrateMM.LoadScratchMetadata(s.ID)
+			assert.NoError(t, err)
+			assert.NotNil(t, loaded)
+			assert.Equal(t, s.ID, loaded.ID)
+			assert.Equal(t, s.Title, loaded.Title)
+		}
+
+		// 3. Check content files moved to files/
+		for _, s := range legacyScratches {
+			newPath := filepath.Join(migrateMM.GetFilesPath(), s.ID)
+			assert.FileExists(t, newPath)
+
+			oldPath := filepath.Join(migrateTmpDir, s.ID)
+			_, err := os.Stat(oldPath)
+			assert.True(t, os.IsNotExist(err), "Old file should be removed")
+		}
+
+		// 4. Check backup created
+		backupPath := filepath.Join(migrateTmpDir, metadataFileName+".backup")
+		if _, err := os.Stat(filepath.Join(migrateTmpDir, metadataFileName)); err == nil {
+			assert.FileExists(t, backupPath)
+		}
+	})
+}
+
+func TestStoreWithNewMetadata(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "store_metadata_test")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	cfg := &config.Config{
+		FileSystem: filesystem.NewOSFileSystem(),
+		DataPath:   tmpDir,
+	}
+
+	t.Run("NewStoreTriggersAutomaticMigration", func(t *testing.T) {
+		// Create legacy metadata.json
+		legacyScratches := []Scratch{
+			{ID: "auto1", Project: "proj1", Title: "Auto 1", CreatedAt: time.Now()},
+			{ID: "auto2", Project: "proj2", Title: "Auto 2", CreatedAt: time.Now()},
+		}
+
+		// Write legacy metadata
+		metadataPath := filepath.Join(tmpDir, dataDirName, metadataFileName)
+		err = cfg.FileSystem.MkdirAll(filepath.Join(tmpDir, dataDirName), 0755)
+		require.NoError(t, err)
+
+		data, err := json.Marshal(legacyScratches)
+		require.NoError(t, err)
+		err = cfg.FileSystem.WriteFile(metadataPath, data, 0644)
+		require.NoError(t, err)
+
+		// Create store - should trigger migration
+		store, err := NewStoreWithConfig(cfg)
+		assert.NoError(t, err)
+		assert.NotNil(t, store)
+		assert.True(t, store.useNewMetadata)
+
+		// Verify migration happened
+		scratches := store.GetScratches()
+		assert.Len(t, scratches, 2)
+
+		// Check new structure exists
+		indexPath := store.metadataManager.GetIndexPath()
+		assert.FileExists(t, indexPath)
+	})
+
+	t.Run("ConcurrentOperations", func(t *testing.T) {
+		// Create new temp dir for concurrent test
+		concurrentTmpDir, err := os.MkdirTemp("", "concurrent_test")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(concurrentTmpDir) }()
+
+		concurrentCfg := &config.Config{
+			FileSystem: filesystem.NewOSFileSystem(),
+			DataPath:   concurrentTmpDir,
+		}
+
+		store, err := NewStoreWithConfig(concurrentCfg)
+		require.NoError(t, err)
+
+		// Force new metadata system
+		err = store.metadataManager.Initialize()
+		require.NoError(t, err)
+		store.useNewMetadata = true
+
+		// Run concurrent adds
+		done := make(chan bool, 10)
+		for i := 0; i < 10; i++ {
+			go func(n int) {
+				scratch := Scratch{
+					ID:        fmt.Sprintf("concurrent%d", n),
+					Project:   "test",
+					Title:     fmt.Sprintf("Concurrent %d", n),
+					CreatedAt: time.Now(),
+				}
+				err := store.AddScratchAtomic(scratch)
+				assert.NoError(t, err)
+				done <- true
+			}(i)
+		}
+
+		// Wait for all to complete
+		for i := 0; i < 10; i++ {
+			<-done
+		}
+
+		// Verify all added
+		scratches := store.GetScratches()
+		assert.Len(t, scratches, 10)
+
+		// Verify index consistency
+		index, err := store.metadataManager.LoadIndex()
+		assert.NoError(t, err)
+		assert.Len(t, index.Scratches, 10)
+	})
+}

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -7,4 +7,21 @@ type Scratch struct {
 	Project   string    `json:"project"`
 	Title     string    `json:"title"`
 	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Size      int64     `json:"size,omitempty"`
+	Checksum  string    `json:"checksum,omitempty"`
+}
+
+// IndexEntry represents minimal scratch info for the master index
+type IndexEntry struct {
+	Project   string    `json:"project"`
+	Title     string    `json:"title"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Index represents the master index structure
+type Index struct {
+	Version   string                `json:"version"`
+	UpdatedAt time.Time             `json:"updated_at"`
+	Scratches map[string]IndexEntry `json:"scratches"`
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,10 +21,12 @@ const (
 )
 
 type Store struct {
-	mu        sync.Mutex
-	scratches []Scratch
-	fs        filesystem.FileSystem
-	cfg       *config.Config
+	mu              sync.Mutex
+	scratches       []Scratch
+	fs              filesystem.FileSystem
+	cfg             *config.Config
+	metadataManager *MetadataManager
+	useNewMetadata  bool // Flag to enable new metadata system
 }
 
 func NewStore() (*Store, error) {
@@ -39,6 +43,17 @@ func NewStoreWithConfig(cfg *config.Config) (*Store, error) {
 		fs:  cfg.FileSystem,
 		cfg: cfg,
 	}
+
+	// Initialize metadata manager
+	basePath, err := GetScratchPathWithConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	store.metadataManager = NewMetadataManager(cfg.FileSystem, basePath)
+
+	// Check if we should use new metadata system
+	store.useNewMetadata = store.shouldUseNewMetadata()
+
 	if err := store.load(); err != nil {
 		logger.Error().Err(err).Msg("Failed to load store data")
 		return nil, err
@@ -66,15 +81,84 @@ func (s *Store) SaveScratches(scratches []Scratch) error {
 	newCount := len(scratches)
 
 	logger.Info().Int("old_count", oldCount).Int("new_count", newCount).Msg("Bulk replacing scratches")
+
+	if s.useNewMetadata {
+		// Rebuild entire metadata system with new scratches
+		// This is expensive but ensures consistency
+		logger.Info().Msg("Rebuilding metadata for bulk save")
+
+		// Create new index
+		index := &Index{
+			Version:   indexVersion,
+			UpdatedAt: time.Now(),
+			Scratches: make(map[string]IndexEntry),
+		}
+
+		// Save all individual metadata files
+		for _, scratch := range scratches {
+			if err := s.metadataManager.SaveScratchMetadata(&scratch); err != nil {
+				logger.Error().Err(err).Str("scratch_id", scratch.ID).Msg("Failed to save scratch metadata during bulk save")
+				continue
+			}
+
+			// Add to index
+			index.Scratches[scratch.ID] = IndexEntry{
+				Project:   scratch.Project,
+				Title:     scratch.Title,
+				CreatedAt: scratch.CreatedAt,
+			}
+		}
+
+		// Save index
+		if err := s.metadataManager.SaveIndex(index); err != nil {
+			logger.Error().Err(err).Msg("Failed to save index during bulk save")
+			return err
+		}
+
+		// Clean up orphaned metadata files
+		metadataPath := s.metadataManager.GetMetadataPath()
+		if entries, err := s.fs.ReadDir(metadataPath); err == nil {
+			for _, entry := range entries {
+				if strings.HasSuffix(entry.Name(), ".json") {
+					id := strings.TrimSuffix(entry.Name(), ".json")
+					if _, exists := index.Scratches[id]; !exists {
+						// Remove orphaned metadata file
+						_ = s.metadataManager.DeleteScratchMetadata(id)
+					}
+				}
+			}
+		}
+	}
+
 	s.scratches = scratches
 
-	if err := s.save(); err != nil {
-		logger.Error().Err(err).Int("scratch_count", newCount).Msg("Failed to save scratches after bulk replace")
-		return err
+	if !s.useNewMetadata {
+		if err := s.save(); err != nil {
+			logger.Error().Err(err).Int("scratch_count", newCount).Msg("Failed to save scratches after bulk replace")
+			return err
+		}
 	}
 
 	logger.Info().Int("scratch_count", newCount).Msg("Bulk scratches saved successfully")
 	return nil
+}
+
+// shouldUseNewMetadata checks if we should use the new metadata system
+func (s *Store) shouldUseNewMetadata() bool {
+	indexPath := s.metadataManager.GetIndexPath()
+	if _, err := s.fs.Stat(indexPath); err == nil {
+		// Index exists, use new system
+		return true
+	}
+
+	// Check if metadata directory exists with files
+	metadataPath := s.metadataManager.GetMetadataPath()
+	if entries, err := s.fs.ReadDir(metadataPath); err == nil && len(entries) > 0 {
+		// Metadata directory has files, use new system
+		return true
+	}
+
+	return false
 }
 
 func (s *Store) load() error {
@@ -82,6 +166,10 @@ func (s *Store) load() error {
 	defer s.mu.Unlock()
 
 	logger := logging.GetLogger("store")
+
+	if s.useNewMetadata {
+		return s.loadWithNewMetadata()
+	}
 
 	path, err := s.getMetadataPathWithStore()
 	if err != nil {
@@ -111,11 +199,68 @@ func (s *Store) load() error {
 	}
 
 	logger.Info().Int("scratch_count", len(s.scratches)).Str("path", path).Msg("Store data loaded successfully")
+
+	// Check if we should migrate to new system
+	if !s.useNewMetadata && len(s.scratches) > 0 {
+		logger.Info().Msg("Legacy metadata detected, migrating to new system")
+		if err := s.metadataManager.MigrateFromLegacyMetadata(s.scratches); err != nil {
+			logger.Error().Err(err).Msg("Failed to migrate to new metadata system")
+			// Continue with old system if migration fails
+		} else {
+			s.useNewMetadata = true
+			logger.Info().Msg("Migration to new metadata system completed")
+		}
+	}
+
+	return nil
+}
+
+// loadWithNewMetadata loads scratches using the new metadata system
+func (s *Store) loadWithNewMetadata() error {
+	logger := logging.GetLogger("store")
+	logger.Debug().Msg("Loading store data using new metadata system")
+
+	// Initialize metadata system if needed
+	if err := s.metadataManager.Initialize(); err != nil {
+		return err
+	}
+
+	// Load index
+	index, err := s.metadataManager.LoadIndex()
+	if err != nil {
+		return err
+	}
+
+	// Load individual metadata for each scratch in index
+	s.scratches = make([]Scratch, 0, len(index.Scratches))
+	for id, entry := range index.Scratches {
+		scratch, err := s.metadataManager.LoadScratchMetadata(id)
+		if err != nil {
+			logger.Warn().Err(err).Str("id", id).Msg("Failed to load scratch metadata")
+			continue
+		}
+		if scratch == nil {
+			// Metadata file missing, reconstruct from index
+			scratch = &Scratch{
+				ID:        id,
+				Project:   entry.Project,
+				Title:     entry.Title,
+				CreatedAt: entry.CreatedAt,
+			}
+		}
+		s.scratches = append(s.scratches, *scratch)
+	}
+
+	logger.Info().Int("scratch_count", len(s.scratches)).Msg("Store data loaded successfully with new metadata system")
 	return nil
 }
 
 func (s *Store) save() error {
 	logger := logging.GetLogger("store")
+
+	if s.useNewMetadata {
+		return s.saveWithNewMetadata()
+	}
 
 	path, err := s.getMetadataPathWithStore()
 	if err != nil {
@@ -142,6 +287,17 @@ func (s *Store) save() error {
 	return nil
 }
 
+// saveWithNewMetadata saves using the new metadata system
+func (s *Store) saveWithNewMetadata() error {
+	logger := logging.GetLogger("store")
+	logger.Debug().Msg("Saving store data using new metadata system")
+
+	// This is now a no-op as individual operations update metadata
+	// The index is updated with each operation
+	logger.Debug().Msg("Save called but using new metadata system (no-op)")
+	return nil
+}
+
 func (s *Store) AddScratch(scratch Scratch) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -149,11 +305,27 @@ func (s *Store) AddScratch(scratch Scratch) error {
 	logger := logging.GetLogger("store")
 	logger.Info().Str("scratch_id", scratch.ID).Str("title", scratch.Title).Msg("Adding new scratch")
 
+	if s.useNewMetadata {
+		// Save individual metadata file
+		if err := s.metadataManager.SaveScratchMetadata(&scratch); err != nil {
+			logger.Error().Err(err).Str("scratch_id", scratch.ID).Msg("Failed to save scratch metadata")
+			return err
+		}
+
+		// Update index
+		if err := s.metadataManager.UpdateIndexEntry(&scratch); err != nil {
+			logger.Error().Err(err).Str("scratch_id", scratch.ID).Msg("Failed to update index")
+			return err
+		}
+	}
+
 	s.scratches = append(s.scratches, scratch)
 
-	if err := s.save(); err != nil {
-		logger.Error().Err(err).Str("scratch_id", scratch.ID).Msg("Failed to save after adding scratch")
-		return err
+	if !s.useNewMetadata {
+		if err := s.save(); err != nil {
+			logger.Error().Err(err).Str("scratch_id", scratch.ID).Msg("Failed to save after adding scratch")
+			return err
+		}
 	}
 
 	logger.Info().Str("scratch_id", scratch.ID).Int("total_count", len(s.scratches)).Msg("Scratch added successfully")
@@ -167,6 +339,20 @@ func (s *Store) RemoveScratch(id string) error {
 	logger := logging.GetLogger("store")
 	oldCount := len(s.scratches)
 	logger.Info().Str("scratch_id", id).Int("current_count", oldCount).Msg("Removing scratch")
+
+	if s.useNewMetadata {
+		// Delete individual metadata file
+		if err := s.metadataManager.DeleteScratchMetadata(id); err != nil {
+			logger.Error().Err(err).Str("scratch_id", id).Msg("Failed to delete scratch metadata")
+			return err
+		}
+
+		// Remove from index
+		if err := s.metadataManager.RemoveIndexEntry(id); err != nil {
+			logger.Error().Err(err).Str("scratch_id", id).Msg("Failed to update index")
+			return err
+		}
+	}
 
 	var newScratches []Scratch
 	found := false
@@ -186,9 +372,11 @@ func (s *Store) RemoveScratch(id string) error {
 	s.scratches = newScratches
 	newCount := len(s.scratches)
 
-	if err := s.save(); err != nil {
-		logger.Error().Err(err).Str("scratch_id", id).Msg("Failed to save after removing scratch")
-		return err
+	if !s.useNewMetadata {
+		if err := s.save(); err != nil {
+			logger.Error().Err(err).Str("scratch_id", id).Msg("Failed to save after removing scratch")
+			return err
+		}
 	}
 
 	logger.Info().Str("scratch_id", id).Int("old_count", oldCount).Int("new_count", newCount).Bool("found", found).Msg("Scratch removal completed")
@@ -201,6 +389,23 @@ func (s *Store) UpdateScratch(scratchToUpdate Scratch) error {
 
 	logger := logging.GetLogger("store")
 	logger.Info().Str("scratch_id", scratchToUpdate.ID).Str("title", scratchToUpdate.Title).Msg("Updating scratch")
+
+	if s.useNewMetadata {
+		// Update timestamp
+		scratchToUpdate.UpdatedAt = time.Now()
+
+		// Save individual metadata file
+		if err := s.metadataManager.SaveScratchMetadata(&scratchToUpdate); err != nil {
+			logger.Error().Err(err).Str("scratch_id", scratchToUpdate.ID).Msg("Failed to save scratch metadata")
+			return err
+		}
+
+		// Update index
+		if err := s.metadataManager.UpdateIndexEntry(&scratchToUpdate); err != nil {
+			logger.Error().Err(err).Str("scratch_id", scratchToUpdate.ID).Msg("Failed to update index")
+			return err
+		}
+	}
 
 	found := false
 	for i, scratch := range s.scratches {
@@ -216,9 +421,11 @@ func (s *Store) UpdateScratch(scratchToUpdate Scratch) error {
 		logger.Warn().Str("scratch_id", scratchToUpdate.ID).Msg("Scratch not found for update")
 	}
 
-	if err := s.save(); err != nil {
-		logger.Error().Err(err).Str("scratch_id", scratchToUpdate.ID).Msg("Failed to save after updating scratch")
-		return err
+	if !s.useNewMetadata {
+		if err := s.save(); err != nil {
+			logger.Error().Err(err).Str("scratch_id", scratchToUpdate.ID).Msg("Failed to save after updating scratch")
+			return err
+		}
 	}
 
 	logger.Info().Str("scratch_id", scratchToUpdate.ID).Bool("found", found).Msg("Scratch update completed")
@@ -273,8 +480,19 @@ func GetScratchFilePathWithConfig(id string, cfg *config.Config) (string, error)
 		return "", err
 	}
 
+	// Check if new metadata system is in use
+	metadataManager := NewMetadataManager(cfg.FileSystem, path)
+	filesPath := metadataManager.GetFilesPath()
+	if _, err := cfg.FileSystem.Stat(filesPath); err == nil {
+		// New structure exists, use it
+		filePath := cfg.FileSystem.Join(filesPath, id)
+		logger.Debug().Str("scratch_id", id).Str("file_path", filePath).Msg("Resolved scratch file path (new structure)")
+		return filePath, nil
+	}
+
+	// Fall back to old structure
 	filePath := cfg.FileSystem.Join(path, id)
-	logger.Debug().Str("scratch_id", id).Str("file_path", filePath).Msg("Resolved scratch file path")
+	logger.Debug().Str("scratch_id", id).Str("file_path", filePath).Msg("Resolved scratch file path (legacy structure)")
 	return filePath, nil
 }
 
@@ -296,16 +514,34 @@ func (s *Store) getMetadataPathWithStore() (string, error) {
 	return getMetadataPathWithConfig(s.cfg)
 }
 
+// RebuildIndex rebuilds the master index from individual metadata files
+func (s *Store) RebuildIndex() error {
+	if !s.useNewMetadata {
+		return fmt.Errorf("new metadata system not in use")
+	}
+
+	return s.metadataManager.RebuildIndex()
+}
+
 // withFileLock performs an operation with file-based locking to prevent concurrent metadata corruption
 func (s *Store) withFileLock(operation func() error) error {
 	logger := logging.GetLogger("store")
 
-	metadataPath, err := s.getMetadataPathWithStore()
-	if err != nil {
-		return err
+	var lockPath string
+	var err error
+
+	if s.useNewMetadata {
+		// Lock on index file for new system
+		lockPath = s.metadataManager.GetIndexPath()
+	} else {
+		// Lock on metadata.json for old system
+		lockPath, err = s.getMetadataPathWithStore()
+		if err != nil {
+			return err
+		}
 	}
 
-	lock := filelock.New(metadataPath)
+	lock := filelock.New(lockPath)
 
 	// Try to acquire lock with 5 second timeout
 	if err := lock.Lock(5 * time.Second); err != nil {
@@ -351,6 +587,19 @@ func (s *Store) AddScratchAtomic(scratch Scratch) error {
 		}
 
 		logger.Info().Str("scratch_id", scratch.ID).Str("title", scratch.Title).Msg("Adding new scratch atomically")
+
+		if s.useNewMetadata {
+			// Save individual metadata file (no lock needed for individual file)
+			if err := s.metadataManager.SaveScratchMetadata(&scratch); err != nil {
+				return err
+			}
+
+			// Update index (already within lock)
+			if err := s.metadataManager.UpdateIndexEntry(&scratch); err != nil {
+				return err
+			}
+		}
+
 		s.scratches = append(s.scratches, scratch)
 		return nil
 	})
@@ -382,6 +631,18 @@ func (s *Store) RemoveScratchAtomic(id string) error {
 			logger.Warn().Str("scratch_id", id).Msg("Scratch not found for removal")
 		}
 
+		if s.useNewMetadata && found {
+			// Delete individual metadata file
+			if err := s.metadataManager.DeleteScratchMetadata(id); err != nil {
+				return err
+			}
+
+			// Remove from index
+			if err := s.metadataManager.RemoveIndexEntry(id); err != nil {
+				return err
+			}
+		}
+
 		s.scratches = newScratches
 		return nil
 	})
@@ -411,6 +672,21 @@ func (s *Store) UpdateScratchAtomic(scratchToUpdate Scratch) error {
 			logger.Warn().Str("scratch_id", scratchToUpdate.ID).Msg("Scratch not found for update")
 		}
 
+		if s.useNewMetadata && found {
+			// Update timestamp
+			scratchToUpdate.UpdatedAt = time.Now()
+
+			// Save individual metadata file
+			if err := s.metadataManager.SaveScratchMetadata(&scratchToUpdate); err != nil {
+				return err
+			}
+
+			// Update index
+			if err := s.metadataManager.UpdateIndexEntry(&scratchToUpdate); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }
@@ -425,6 +701,37 @@ func (s *Store) SaveScratchesAtomic(scratches []Scratch) error {
 	return s.withFileLock(func() error {
 		logger := logging.GetLogger("store")
 		logger.Info().Int("old_count", len(s.scratches)).Int("new_count", len(scratches)).Msg("Bulk replacing scratches atomically")
+
+		if s.useNewMetadata {
+			// Rebuild metadata within lock
+			// Create new index
+			index := &Index{
+				Version:   indexVersion,
+				UpdatedAt: time.Now(),
+				Scratches: make(map[string]IndexEntry),
+			}
+
+			// Save all individual metadata files
+			for _, scratch := range scratches {
+				if err := s.metadataManager.SaveScratchMetadata(&scratch); err != nil {
+					logger.Error().Err(err).Str("scratch_id", scratch.ID).Msg("Failed to save scratch metadata during bulk save")
+					continue
+				}
+
+				// Add to index
+				index.Scratches[scratch.ID] = IndexEntry{
+					Project:   scratch.Project,
+					Title:     scratch.Title,
+					CreatedAt: scratch.CreatedAt,
+				}
+			}
+
+			// Save index
+			if err := s.metadataManager.SaveIndex(index); err != nil {
+				return err
+			}
+		}
+
 		s.scratches = scratches
 		return nil
 	})


### PR DESCRIPTION
## Summary
- Implements individual metadata files for each scratch with a master index
- Reduces lock contention and improves resilience to corruption
- Automatic migration from legacy metadata.json format

## Changes
- Added `MetadataManager` to handle individual metadata files and master index
- Updated `Store` to use new metadata system when available
- Added automatic migration from legacy metadata.json to new structure
- Updated filesystem interface to support `ReadDir` operation
- Added comprehensive tests for all metadata operations
- Maintains full backward compatibility with existing installations

## New Directory Structure
```
scratch/
├── files/                  # Actual scratch content
│   └── <hash>
├── metadata/              # Individual metadata files
│   └── <hash>.json
└── index.json             # Master index for fast lookups
```

## Benefits
- **Reduced Lock Contention**: Only lock when updating index
- **Parallel Writes**: Multiple scratches can be saved simultaneously  
- **Partial Recovery**: Can rebuild index from individual files
- **Atomic Operations**: Each scratch update is atomic

## Testing
- Added comprehensive unit tests for metadata operations
- Tested migration from legacy format
- Tested concurrent operations
- All existing tests continue to pass

## Part of #39
This is Step 1 of the metadata system improvements outlined in #39.

🤖 Generated with [Claude Code](https://claude.ai/code)