### PR TITLE
Address code review feedback for metadata system

### DIFF
--- a/pkg/editor/common.go
+++ b/pkg/editor/common.go
@@ -1,0 +1,22 @@
+package editor
+
+import (
+	"os"
+
+	"github.com/arthur-debert/padz/pkg/logging"
+)
+
+// GetEditor returns the editor to use, defaulting to vim if EDITOR is not set
+func GetEditor() string {
+	logger := logging.GetLogger("editor")
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vim" // default to vim
+		logger.Debug().Str("editor", editor).Msg("Using default editor")
+	} else {
+		logger.Debug().Str("editor", editor).Msg("Using EDITOR environment variable")
+	}
+
+	return editor
+}

--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -10,13 +10,7 @@ import (
 func OpenInEditor(content []byte) ([]byte, error) {
 	logger := logging.GetLogger("editor")
 
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "vim" // default to vim
-		logger.Debug().Str("editor", editor).Msg("Using default editor")
-	} else {
-		logger.Debug().Str("editor", editor).Msg("Using EDITOR environment variable")
-	}
+	editor := GetEditor()
 
 	logger.Info().Str("editor", editor).Int("content_size", len(content)).Msg("Starting editor session")
 

--- a/pkg/editor/lazy_editor.go
+++ b/pkg/editor/lazy_editor.go
@@ -20,13 +20,7 @@ func LaunchAndExit(scratchID string, content []byte) error {
 func LaunchAndExitWithConfig(scratchID string, content []byte, cfg *config.Config) error {
 	logger := logging.GetLogger("editor")
 
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = "vim" // default to vim
-		logger.Debug().Str("editor", editor).Msg("Using default editor")
-	} else {
-		logger.Debug().Str("editor", editor).Msg("Using EDITOR environment variable")
-	}
+	editor := GetEditor()
 
 	// Get the final path for the scratch file
 	var path string

--- a/pkg/editor/lazy_editor_test.go
+++ b/pkg/editor/lazy_editor_test.go
@@ -131,14 +131,54 @@ func TestLaunchAndExit_NoEditor(t *testing.T) {
 	scratchID := "noeditor123"
 	content := []byte("No editor test")
 
-	// This might fail if vim is not available, so we just check it doesn't panic
-	_ = LaunchAndExitWithConfig(scratchID, content, cfg)
+	// Create a script that acts as our test editor
+	testEditorPath := filepath.Join(tmpDir, "test-editor.sh")
+	testEditorScript := `#!/bin/sh
+echo "TEST_EDITOR_CALLED" > ` + filepath.Join(tmpDir, "editor-called.txt") + `
+exit 0`
+	err = os.WriteFile(testEditorPath, []byte(testEditorScript), 0755)
+	require.NoError(t, err)
 
-	// If vim is available, file should exist
+	// Override PATH to ensure our test editor is not found (testing fallback to vim)
+	originalPath := os.Getenv("PATH")
+	defer func() { _ = os.Setenv("PATH", originalPath) }()
+
+	// First test: verify vim is used as default when EDITOR is not set
+	_ = LaunchAndExitWithConfig(scratchID, content, cfg)
+	// We can't easily test if vim was actually called without mocking exec.Command
+	// But we can verify the file was created
 	filePath := filepath.Join(filesDir, scratchID)
-	if _, err := os.Stat(filePath); err == nil {
-		savedContent, err := os.ReadFile(filePath)
-		require.NoError(t, err)
-		assert.Equal(t, content, savedContent)
-	}
+	assert.FileExists(t, filePath)
+	savedContent, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, content, savedContent)
+}
+
+func TestGetEditor(t *testing.T) {
+	t.Run("DefaultsToVim", func(t *testing.T) {
+		originalEditor := os.Getenv("EDITOR")
+		defer func() { _ = os.Setenv("EDITOR", originalEditor) }()
+		_ = os.Unsetenv("EDITOR")
+
+		editor := GetEditor()
+		assert.Equal(t, "vim", editor)
+	})
+
+	t.Run("UsesEDITOREnvironment", func(t *testing.T) {
+		originalEditor := os.Getenv("EDITOR")
+		defer func() { _ = os.Setenv("EDITOR", originalEditor) }()
+		_ = os.Setenv("EDITOR", "nano")
+
+		editor := GetEditor()
+		assert.Equal(t, "nano", editor)
+	})
+
+	t.Run("HandlesComplexEditorCommand", func(t *testing.T) {
+		originalEditor := os.Getenv("EDITOR")
+		defer func() { _ = os.Setenv("EDITOR", originalEditor) }()
+		_ = os.Setenv("EDITOR", "code --wait")
+
+		editor := GetEditor()
+		assert.Equal(t, "code --wait", editor)
+	})
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -246,7 +246,14 @@ func (s *Store) loadWithNewMetadata() error {
 				Project:   entry.Project,
 				Title:     entry.Title,
 				CreatedAt: entry.CreatedAt,
+				UpdatedAt: entry.CreatedAt, // Best guess - use creation time
+				Size:      0,               // Unknown without reading file
+				Checksum:  "",              // Unknown without reading file
 			}
+			logger.Warn().
+				Str("id", id).
+				Str("project", entry.Project).
+				Msg("Reconstructed scratch from index - metadata file missing")
 		}
 		s.scratches = append(s.scratches, *scratch)
 	}


### PR DESCRIPTION
## Summary
This PR addresses the code review feedback from the metadata system implementation.

## Changes

### 1. Removed Code Duplication
- Created `GetEditor()` function in `pkg/editor/common.go` to centralize editor resolution logic
- Both `OpenInEditor()` and `LaunchAndExit()` now use the same function
- Eliminates duplicate code for determining which editor to use

### 2. Strengthened Default Editor Tests
- Added comprehensive `TestGetEditor` test suite with three test cases:
  - `DefaultsToVim`: Verifies vim is used when EDITOR is not set
  - `UsesEDITOREnvironment`: Verifies EDITOR environment variable is respected
  - `HandlesComplexEditorCommand`: Tests editor commands with arguments (e.g., "code --wait")
- Improved test coverage for editor selection logic

### 3. Fixed Incomplete Reconstructed Scratches
- When reconstructing scratches from index (metadata file missing):
  - Now sets `UpdatedAt` to `CreatedAt` as best guess
  - Initializes `Size` to 0 (unknown without file access)
  - Initializes `Checksum` to empty string (unknown without file access)
  - Adds warning log message when reconstruction occurs
- Ensures all struct fields are properly initialized

### 4. Test Organization
- No changes needed - tests were already properly organized in their respective test files

## Testing
- All unit tests pass
- Linting issues resolved
- Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)