### PR TITLE
feat: add file extensions to scratch editor temp files

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -28,7 +28,14 @@ func CreateWithTitle(s *store.Store, project string, content []byte, providedTit
 		if providedTitle != "" {
 			initialContent = []byte(providedTitle + "\n\n")
 		}
-		content, err = editor.OpenInEditor(initialContent)
+
+		// Determine extension based on title
+		extension := ".txt"
+		if strings.HasPrefix(strings.TrimSpace(providedTitle), "#") {
+			extension = ".md"
+		}
+
+		content, err = editor.OpenInEditorWithExtension(initialContent, extension)
 		if err != nil {
 			return err
 		}
@@ -86,8 +93,14 @@ func CreateWithTitleAndContent(s *store.Store, project string, title string, ini
 		editorContent = initialContent
 	}
 
+	// Determine extension based on title
+	extension := ".txt"
+	if strings.HasPrefix(strings.TrimSpace(title), "#") {
+		extension = ".md"
+	}
+
 	// Open editor with prepared content
-	content, err = editor.OpenInEditor(editorContent)
+	content, err = editor.OpenInEditorWithExtension(editorContent, extension)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/arthur-debert/padz/pkg/editor"
 	"github.com/arthur-debert/padz/pkg/store"
 )
@@ -16,7 +18,14 @@ func Open(s *store.Store, all bool, project string, indexStr string) error {
 		return err
 	}
 
-	newContent, err := editor.OpenInEditor(content)
+	// Determine extension based on content
+	extension := ".txt"
+	contentStr := strings.TrimSpace(string(content))
+	if strings.HasPrefix(contentStr, "#") {
+		extension = ".md"
+	}
+
+	newContent, err := editor.OpenInEditorWithExtension(content, extension)
 	if err != nil {
 		return err
 	}

--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -3,18 +3,36 @@ package editor
 import (
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/arthur-debert/padz/pkg/logging"
 )
 
 func OpenInEditor(content []byte) ([]byte, error) {
+	return OpenInEditorWithExtension(content, "")
+}
+
+// OpenInEditorWithExtension opens content in editor with optional extension hint
+func OpenInEditorWithExtension(content []byte, extensionHint string) ([]byte, error) {
 	logger := logging.GetLogger("editor")
 
 	editor := GetEditor()
 
 	logger.Info().Str("editor", editor).Int("content_size", len(content)).Msg("Starting editor session")
 
-	tmpfile, err := os.CreateTemp("", "scratch-")
+	// Determine file extension
+	extension := extensionHint
+	if extension == "" {
+		// Default to .txt if no hint provided
+		extension = ".txt"
+		// Check if content starts with # for markdown
+		contentStr := strings.TrimSpace(string(content))
+		if strings.HasPrefix(contentStr, "#") {
+			extension = ".md"
+		}
+	}
+
+	tmpfile, err := os.CreateTemp("", "scratch-*"+extension)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to create temporary file")
 		return nil, err

--- a/pkg/editor/editor_test.go
+++ b/pkg/editor/editor_test.go
@@ -367,3 +367,96 @@ func TestOpenInEditor_PathLookup(t *testing.T) {
 		t.Errorf("unexpected error with 'true' command: %v", err)
 	}
 }
+
+func TestOpenInEditorWithExtension_ExtensionHandling(t *testing.T) {
+	oldEditor := os.Getenv("EDITOR")
+	defer func() { _ = os.Setenv("EDITOR", oldEditor) }()
+
+	// Create a mock editor that records the filename
+	editorScript := `#!/bin/bash
+echo "$1" > "$1.filename"
+echo "mock editor output" > "$1"
+`
+	mockEditor := createExecutableScript(t, editorScript)
+	defer func() { _ = os.Remove(mockEditor) }()
+
+	_ = os.Setenv("EDITOR", mockEditor)
+
+	tests := []struct {
+		name          string
+		content       []byte
+		extensionHint string
+		expectedExt   string
+	}{
+		{
+			name:          "explicit .txt extension",
+			content:       []byte("plain text"),
+			extensionHint: ".txt",
+			expectedExt:   ".txt",
+		},
+		{
+			name:          "explicit .md extension",
+			content:       []byte("# Markdown"),
+			extensionHint: ".md",
+			expectedExt:   ".md",
+		},
+		{
+			name:          "auto-detect markdown from content",
+			content:       []byte("# This is markdown"),
+			extensionHint: "",
+			expectedExt:   ".md",
+		},
+		{
+			name:          "auto-detect markdown with spaces",
+			content:       []byte("  # This is markdown with spaces"),
+			extensionHint: "",
+			expectedExt:   ".md",
+		},
+		{
+			name:          "default to txt for plain content",
+			content:       []byte("This is plain text"),
+			extensionHint: "",
+			expectedExt:   ".txt",
+		},
+		{
+			name:          "empty content defaults to txt",
+			content:       []byte(""),
+			extensionHint: "",
+			expectedExt:   ".txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := OpenInEditorWithExtension(tt.content, tt.extensionHint)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check if a temp file with the expected extension was created
+			// by looking at temp files in the system
+			tmpDir := os.TempDir()
+			entries, err := os.ReadDir(tmpDir)
+			if err != nil {
+				t.Errorf("couldn't read temp dir: %v", err)
+				return
+			}
+
+			found := false
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), "scratch-") &&
+					strings.HasSuffix(entry.Name(), tt.expectedExt+".filename") {
+					found = true
+					// Cleanup the filename tracker
+					_ = os.Remove(tmpDir + "/" + entry.Name())
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("expected temp file with extension %s not found", tt.expectedExt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add appropriate file extensions (.txt or .md) when opening scratch files in the editor
- Enables proper syntax highlighting and language features in editors
- Implements logic to detect markdown files when title starts with #

## Changes
- Added `OpenInEditorWithExtension` function to support extension hints
- Modified `CreateWithTitle` and `CreateWithTitleAndContent` to detect markdown titles
- Updated `Open` command to detect markdown content
- Added comprehensive tests for extension handling

## Test plan
- [x] Build passes without errors
- [x] All existing tests pass
- [x] Added new tests for extension handling
- [x] Manually tested:
  - Creating plain text scratch gets .txt extension
  - Creating scratch with title starting with # gets .md extension
  - Opening existing scratches detects correct extension from content

Fixes #49

🤖 Generated with [Claude Code](https://claude.ai/code)