### PR TITLE
feat: add copy scratch command

### DIFF
--- a/cmd/padz/cli/copy.go
+++ b/cmd/padz/cli/copy.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/arthur-debert/padz/pkg/commands"
+	"github.com/arthur-debert/padz/pkg/project"
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// newCopyCmd creates and returns a new copy command
+func newCopyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     CopyUse,
+		Aliases: []string{"cp"},
+		Short:   CopyShort,
+		Long:    CopyLong,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			allFlag, _ := cmd.Flags().GetBool("all")
+
+			s, err := store.NewStore()
+			if err != nil {
+				log.Fatal().Err(err).Msg(ErrFailedToInitStore)
+			}
+
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Fatal().Err(err).Msg(ErrFailedToGetWorkingDir)
+			}
+
+			proj, err := project.GetCurrentProject(dir)
+			if err != nil {
+				log.Fatal().Err(err).Msg(ErrFailedToGetProject)
+			}
+
+			if err := commands.Copy(s, allFlag, proj, args[0]); err != nil {
+				log.Fatal().Err(err).Msg(ErrFailedToCopyScratch)
+			}
+
+			log.Info().Msg(SuccessCopiedToClipboard)
+		},
+	}
+}

--- a/cmd/padz/cli/copy_test.go
+++ b/cmd/padz/cli/copy_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"bytes"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCopyCommand(t *testing.T) {
+	// Skip on Windows as clipboard is not supported
+	if runtime.GOOS == "windows" {
+		t.Skip("Clipboard functionality not supported on Windows")
+	}
+
+	// Test that the copy command is available
+	cmd := NewRootCmd()
+
+	// Look for copy command in the command list
+	copyCmd, _, err := cmd.Find([]string{"copy"})
+	if err != nil {
+		t.Fatalf("copy command not found: %v", err)
+	}
+
+	// Test command properties
+	if copyCmd.Use != CopyUse {
+		t.Errorf("Expected Use to be %q, got %q", CopyUse, copyCmd.Use)
+	}
+
+	if copyCmd.Short != CopyShort {
+		t.Errorf("Expected Short to be %q, got %q", CopyShort, copyCmd.Short)
+	}
+
+	if copyCmd.Long != CopyLong {
+		t.Errorf("Expected Long to be %q, got %q", CopyLong, copyCmd.Long)
+	}
+
+	// Test aliases
+	expectedAliases := []string{"cp"}
+	if len(copyCmd.Aliases) != len(expectedAliases) {
+		t.Errorf("Expected %d aliases, got %d", len(expectedAliases), len(copyCmd.Aliases))
+	}
+	for i, alias := range expectedAliases {
+		if i >= len(copyCmd.Aliases) || copyCmd.Aliases[i] != alias {
+			t.Errorf("Expected alias[%d] to be %q, got %q", i, alias, copyCmd.Aliases[i])
+		}
+	}
+
+	// Test that it's in the single scratch group
+	if copyCmd.GroupID != "single" {
+		t.Errorf("expected copy command to be in 'single' group, got '%s'", copyCmd.GroupID)
+	}
+
+	// Test args validation
+	if copyCmd.Args == nil {
+		t.Error("Expected Args to be set")
+	}
+
+	// Test that it requires exactly one argument
+	if err := copyCmd.Args(copyCmd, []string{}); err == nil {
+		t.Error("Expected error with no arguments")
+	}
+	if err := copyCmd.Args(copyCmd, []string{"1", "2"}); err == nil {
+		t.Error("Expected error with multiple arguments")
+	}
+	if err := copyCmd.Args(copyCmd, []string{"1"}); err != nil {
+		t.Errorf("Expected no error with one argument, got: %v", err)
+	}
+
+	// Test flags
+	allFlag := copyCmd.Flag("all")
+	if allFlag == nil {
+		t.Error("Expected 'all' flag to be defined")
+	} else if allFlag.Shorthand != "a" {
+		t.Errorf("Expected 'all' flag shorthand to be 'a', got %q", allFlag.Shorthand)
+	}
+}
+
+func TestCopyCommandInHelp(t *testing.T) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+
+	// Check that copy command appears in help
+	if !strings.Contains(output, "copy") {
+		t.Error("Expected 'copy' command in help output")
+	}
+
+	// Check it's in the right section
+	lines := strings.Split(output, "\n")
+	inSingleSection := false
+	foundCopy := false
+
+	for _, line := range lines {
+		if strings.Contains(line, "SINGLE SCRATCH:") {
+			inSingleSection = true
+		} else if strings.Contains(line, "SCRATCHES:") {
+			inSingleSection = false
+		}
+
+		if inSingleSection && strings.Contains(line, "copy") {
+			foundCopy = true
+			break
+		}
+	}
+
+	if !foundCopy {
+		t.Error("Expected 'copy' command to be in SINGLE SCRATCH section")
+	}
+}

--- a/cmd/padz/cli/msgs.go
+++ b/cmd/padz/cli/msgs.go
@@ -96,6 +96,19 @@ const (
 	CleanupSuccessFormat = "Cleaned up scratches older than %d days."
 )
 
+// Copy command messages
+const (
+	CopyUse   = "copy <index>"
+	CopyShort = "Copy a scratch to the clipboard"
+	CopyLong  = `Copy the content of a scratch to the system clipboard.
+
+The scratch is identified by its index number from the 'padz ls' output.
+Use the --all flag to select from all scratches across all projects.`
+
+	ErrFailedToCopyScratch   = "Failed to copy scratch to clipboard"
+	SuccessCopiedToClipboard = "Copied to clipboard"
+)
+
 // Search command messages
 const (
 	SearchUse   = "search [term]"

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -105,6 +105,11 @@ func NewRootCmd() *cobra.Command {
 	pathCmd.Flags().BoolP("all", "a", false, FlagAllDesc)
 	rootCmd.AddCommand(pathCmd)
 
+	copyCmd := newCopyCmd()
+	copyCmd.GroupID = "single"
+	copyCmd.Flags().BoolP("all", "a", false, FlagAllDesc)
+	rootCmd.AddCommand(copyCmd)
+
 	// Multiple scratches commands
 	lsCmd := newLsCmd()
 	lsCmd.GroupID = "multiple"
@@ -194,7 +199,7 @@ func shouldRunCreate(args []string) bool {
 
 	// Check if first arg is a known command or reserved word
 	commands := []string{"ls", "view", "open", "peek", "delete", "path",
-		"cleanup", "search", "nuke", "recover", "create", "new", "n",
+		"copy", "cp", "cleanup", "search", "nuke", "recover", "create", "new", "n",
 		"version", "help", "completion"}
 
 	firstArg := strings.ToLower(args[0])

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"github.com/arthur-debert/padz/pkg/clipboard"
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// Copy retrieves a scratch by index and copies its content to the clipboard
+func Copy(s *store.Store, all bool, project string, indexStr string) error {
+	scratch, err := GetScratchByIndex(s, all, false, project, indexStr)
+	if err != nil {
+		return err
+	}
+
+	content, err := readScratchFile(scratch.ID)
+	if err != nil {
+		return err
+	}
+
+	if err := clipboard.Copy(content); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -1,0 +1,189 @@
+package commands
+
+import (
+	"bytes"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+func TestCopy(t *testing.T) {
+	// Skip on Windows as clipboard is not supported
+	if runtime.GOOS == "windows" {
+		t.Skip("Clipboard functionality not supported on Windows")
+	}
+
+	// Check if clipboard commands are available
+	var clipboardCmd string
+	switch runtime.GOOS {
+	case "darwin":
+		clipboardCmd = "pbpaste"
+	case "linux":
+		// Try xclip first, then xsel
+		if _, err := exec.LookPath("xclip"); err == nil {
+			clipboardCmd = "xclip"
+		} else if _, err := exec.LookPath("xsel"); err == nil {
+			clipboardCmd = "xsel"
+		} else {
+			t.Skip("Neither xclip nor xsel found in PATH")
+		}
+	default:
+		t.Skip("Unsupported operating system for clipboard tests")
+	}
+
+	// Make sure the clipboard command actually works
+	if _, err := exec.Command(clipboardCmd, "-help").CombinedOutput(); err != nil {
+		t.Skipf("Clipboard command %s not working properly", clipboardCmd)
+	}
+
+	// Setup test environment
+	setup := SetupCommandTest(t)
+	defer setup.Cleanup()
+
+	s := setup.Store
+
+	// Create test scratches
+	scratch1 := store.Scratch{
+		ID:        "test1",
+		Project:   "project1",
+		Title:     "First scratch",
+		CreatedAt: time.Now(),
+	}
+	scratch2 := store.Scratch{
+		ID:        "test2",
+		Project:   "project1",
+		Title:     "Second scratch",
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	scratch3 := store.Scratch{
+		ID:        "test3",
+		Project:   "project2",
+		Title:     "Third scratch",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+	}
+
+	// Add scratches to store
+	if err := s.AddScratch(scratch1); err != nil {
+		t.Fatalf("Failed to add scratch1: %v", err)
+	}
+	if err := s.AddScratch(scratch2); err != nil {
+		t.Fatalf("Failed to add scratch2: %v", err)
+	}
+	if err := s.AddScratch(scratch3); err != nil {
+		t.Fatalf("Failed to add scratch3: %v", err)
+	}
+
+	// Save content for each scratch
+	content1 := []byte("Content of first scratch")
+	content2 := []byte("Content of second scratch")
+	content3 := []byte("Content of third scratch")
+
+	if err := saveScratchFile(scratch1.ID, content1); err != nil {
+		t.Fatalf("Failed to save content1: %v", err)
+	}
+	if err := saveScratchFile(scratch2.ID, content2); err != nil {
+		t.Fatalf("Failed to save content2: %v", err)
+	}
+	if err := saveScratchFile(scratch3.ID, content3); err != nil {
+		t.Fatalf("Failed to save content3: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		all             bool
+		project         string
+		indexStr        string
+		expectedContent []byte
+		expectError     bool
+	}{
+		{
+			name:            "copy scratch by index in project",
+			all:             false,
+			project:         "project1",
+			indexStr:        "1",
+			expectedContent: content1,
+			expectError:     false,
+		},
+		{
+			name:            "copy scratch by index across all projects",
+			all:             true,
+			project:         "",
+			indexStr:        "3",
+			expectedContent: content3,
+			expectError:     false,
+		},
+		{
+			name:        "copy with invalid index",
+			all:         false,
+			project:     "project1",
+			indexStr:    "99",
+			expectError: true,
+		},
+		{
+			name:        "copy with non-numeric index",
+			all:         false,
+			project:     "project1",
+			indexStr:    "abc",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Copy(s, tt.all, tt.project, tt.indexStr)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Give clipboard operation time to complete
+			time.Sleep(100 * time.Millisecond)
+
+			// Read clipboard content
+			var cmd *exec.Cmd
+			switch runtime.GOOS {
+			case "darwin":
+				cmd = exec.Command("pbpaste")
+			case "linux":
+				if clipboardCmd == "xclip" {
+					cmd = exec.Command("xclip", "-selection", "clipboard", "-o")
+				} else {
+					cmd = exec.Command("xsel", "--clipboard", "--output")
+				}
+			}
+
+			output, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("Failed to read clipboard: %v", err)
+			}
+
+			if !bytes.Equal(output, tt.expectedContent) {
+				t.Errorf("Clipboard content mismatch\nExpected: %q\nGot: %q", tt.expectedContent, output)
+			}
+		})
+	}
+}
+
+func TestCopyNonExistentScratch(t *testing.T) {
+	// Setup test environment
+	setup := SetupCommandTest(t)
+	defer setup.Cleanup()
+
+	s := setup.Store
+
+	// Try to copy a scratch that doesn't exist
+	err := Copy(s, false, "project1", "1")
+	if err == nil {
+		t.Errorf("Expected error when copying non-existent scratch, but got none")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `padz copy <index>` command to copy scratch content to system clipboard
- Support for macOS (pbcopy) and Linux (xclip/xsel) 
- Include `cp` alias for convenience

## Changes
- Added `Copy` function in `pkg/commands` to handle clipboard operations
- Added CLI command implementation with proper error handling
- Used existing clipboard package for cross-platform support
- Added comprehensive tests for both command and CLI layers
- Updated help messages and command registration

## Test plan
- [x] Build passes without errors
- [x] All tests pass (including new tests)
- [x] Manually tested on macOS:
  - `padz copy 1` - copies scratch content to clipboard
  - `padz cp 1` - alias works correctly
  - Error handling for invalid indices
- [x] Command appears in help under "SINGLE SCRATCH" section
- [x] Skips gracefully on Windows (not supported)

Fixes #51

🤖 Generated with [Claude Code](https://claude.ai/code)