### PR TITLE
feat: add pinned scratches functionality

### DIFF
--- a/cmd/padz/cli/ls.go
+++ b/cmd/padz/cli/ls.go
@@ -97,7 +97,7 @@ Search results are ranked by:
 			}
 
 			// Normal listing without search
-			scratches := commands.Ls(s, all, global, proj)
+			scratches, originalIndices := commands.LsWithOriginalIndices(s, all, global, proj)
 
 			// Format output
 			format, err := output.GetFormat(outputFormat)
@@ -119,7 +119,7 @@ Search results are ranked by:
 				if err != nil {
 					log.Fatal().Err(err).Msg("Failed to create terminal formatter")
 				}
-				if err := termFormatter.FormatList(scratches, all); err != nil {
+				if err := termFormatter.FormatListWithOriginalIndices(scratches, originalIndices, all); err != nil {
 					log.Fatal().Err(err).Msg("Failed to format list")
 				}
 			} else {

--- a/cmd/padz/cli/pin.go
+++ b/cmd/padz/cli/pin.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/arthur-debert/padz/pkg/commands"
+	"github.com/arthur-debert/padz/pkg/project"
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// newPinCmd creates the pin command
+func newPinCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pin <id>",
+		Short: "Pin a scratch to the top of the list",
+		Long: `Pin a scratch to the top of the list. Pinned scratches appear with a special
+prefix (p1, p2, etc.) and are always shown first when listing scratches.
+
+Maximum of 5 scratches can be pinned at once.`,
+		Args: cobra.ExactArgs(1),
+		Run:  runPin,
+	}
+}
+
+func runPin(cmd *cobra.Command, args []string) {
+	log.Debug().Msg("Starting pin command")
+
+	all, _ := cmd.Flags().GetBool("all")
+	global, _ := cmd.Flags().GetBool("global")
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to get current working directory")
+	}
+
+	proj, err := project.GetCurrentProject(dir)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to get current project")
+	}
+
+	if global {
+		proj = "global"
+	}
+
+	st, err := store.NewStore()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create store")
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := commands.Pin(st, all, global, proj, args[0]); err != nil {
+		log.Error().Err(err).Str("id", args[0]).Msg("Failed to pin scratch")
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Scratch pinned successfully")
+}
+
+// newUnpinCmd creates the unpin command
+func newUnpinCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unpin <id>",
+		Short: "Unpin a scratch",
+		Long: `Unpin a scratch. The scratch will return to its normal position
+in the chronological list.
+
+You can use either the regular index, pinned index (p1, p2), or hash ID.`,
+		Args: cobra.ExactArgs(1),
+		Run:  runUnpin,
+	}
+}
+
+func runUnpin(cmd *cobra.Command, args []string) {
+	log.Debug().Msg("Starting unpin command")
+
+	all, _ := cmd.Flags().GetBool("all")
+	global, _ := cmd.Flags().GetBool("global")
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to get current working directory")
+	}
+
+	proj, err := project.GetCurrentProject(dir)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to get current project")
+	}
+
+	if global {
+		proj = "global"
+	}
+
+	st, err := store.NewStore()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create store")
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := commands.Unpin(st, all, global, proj, args[0]); err != nil {
+		log.Error().Err(err).Str("id", args[0]).Msg("Failed to unpin scratch")
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Scratch unpinned successfully")
+}

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -212,7 +212,7 @@ func shouldRunCreate(args []string) bool {
 	// Check if first arg is a known command or reserved word
 	commands := []string{"ls", "view", "open", "peek", "delete", "path",
 		"copy", "cp", "cleanup", "search", "nuke", "recover", "create", "new", "n",
-		"version", "help", "completion"}
+		"version", "help", "completion", "pin", "unpin"}
 
 	firstArg := strings.ToLower(args[0])
 	for _, cmd := range commands {

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -110,6 +110,18 @@ func NewRootCmd() *cobra.Command {
 	copyCmd.Flags().BoolP("all", "a", false, FlagAllDesc)
 	rootCmd.AddCommand(copyCmd)
 
+	pinCmd := newPinCmd()
+	pinCmd.GroupID = "single"
+	pinCmd.Flags().BoolP("all", "a", false, FlagAllDesc)
+	pinCmd.Flags().BoolP("global", "g", false, FlagGlobalDesc)
+	rootCmd.AddCommand(pinCmd)
+
+	unpinCmd := newUnpinCmd()
+	unpinCmd.GroupID = "single"
+	unpinCmd.Flags().BoolP("all", "a", false, FlagAllDesc)
+	unpinCmd.Flags().BoolP("global", "g", false, FlagGlobalDesc)
+	rootCmd.AddCommand(unpinCmd)
+
 	// Multiple scratches commands
 	lsCmd := newLsCmd()
 	lsCmd.GroupID = "multiple"

--- a/cmd/padz/formatter/terminal.go
+++ b/cmd/padz/formatter/terminal.go
@@ -56,6 +56,21 @@ func (tf *TerminalFormatter) FormatList(scratches []store.Scratch, showProject b
 	return err
 }
 
+func (tf *TerminalFormatter) FormatListWithOriginalIndices(scratches []store.Scratch, originalIndices map[string]int, showProject bool) error {
+	// Convert []store.Scratch to []*store.Scratch
+	scratchPtrs := make([]*store.Scratch, len(scratches))
+	for i := range scratches {
+		scratchPtrs[i] = &scratches[i]
+	}
+
+	output, err := tf.renderer.RenderPadListWithOriginalIndices(scratchPtrs, originalIndices, showProject)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(tf.writer, output)
+	return err
+}
+
 func (tf *TerminalFormatter) FormatSearchResults(results []commands.ScratchWithIndex, showProject bool) error {
 	// Convert to scratch pointers with indices
 	var lines []string

--- a/cmd/padz/templates/renderer.go
+++ b/cmd/padz/templates/renderer.go
@@ -135,7 +135,77 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 	widths := calculateColumnWidths(termWidth, showProject)
 
 	var lines []string
+
+	// First pass: render only pinned scratches with p1, p2 indices
 	pinnedCount := 0
+	hasPinned := false
+	for _, scratch := range scratches {
+		if !scratch.IsPinned {
+			continue
+		}
+		hasPinned = true
+		pinnedCount++
+
+		// Prepare data
+		projectName := ""
+		if scratch.Project == "global" {
+			projectName = "global"
+		} else if scratch.Project != "" {
+			projectName = filepath.Base(scratch.Project)
+		}
+		timeAgo := humanize.Time(scratch.CreatedAt)
+
+		// Build line with proper column alignment
+		var parts []string
+
+		// Pinned index with ⚲ prefix
+		indexStr := fmt.Sprintf("p%d.", pinnedCount)
+		fullIndexStr := "⚲ " + indexStr
+		// Pad based on visible width, not byte length
+		padding := widths.ID - lipgloss.Width(fullIndexStr)
+		indexPadded := strings.Repeat(" ", padding) + fullIndexStr
+
+		// Project (if showing)
+		projectPadded := ""
+		if showProject {
+			project := truncateWithEllipsis(projectName, widths.Project)
+			projectPadded = padRight(project, widths.Project) + "  "
+		}
+
+		// Title
+		title := truncateWithEllipsis(scratch.Title, widths.Title)
+		titlePadded := padRight(title, widths.Title) + "  "
+
+		// Time
+		timePadded := padLeft(timeAgo, widths.Date)
+
+		// Apply styles
+		indexStyle := styles.Get("padIndex")
+		parts = append(parts, strings.Replace(indexPadded, fullIndexStr, indexStyle.Render(fullIndexStr), 1))
+
+		if showProject && projectPadded != "" {
+			projectStyle := styles.Get("padProject")
+			projectText := strings.TrimSpace(projectPadded[:widths.Project])
+			parts = append(parts, strings.Replace(projectPadded, projectText, projectStyle.Render(projectText), 1))
+		}
+
+		titleStyle := styles.Get("padTitle")
+		titleText := strings.TrimSpace(titlePadded[:widths.Title])
+		parts = append(parts, strings.Replace(titlePadded, titleText, titleStyle.Render(titleText), 1))
+
+		timeStyle := styles.Get("padTime")
+		parts = append(parts, strings.Replace(timePadded, timeAgo, timeStyle.Render(timeAgo), 1))
+
+		lines = append(lines, strings.Join(parts, ""))
+	}
+
+	// Add separator if we have pinned items
+	if hasPinned {
+		lines = append(lines, "")
+		lines = append(lines, "")
+	}
+
+	// Second pass: render all scratches with regular indices
 	for i, scratch := range scratches {
 		// Prepare data
 		index := i + 1
@@ -147,17 +217,11 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 		}
 		timeAgo := humanize.Time(scratch.CreatedAt)
 
-		// Build line with proper column alignment (WITHOUT styling first)
+		// Build line with proper column alignment
 		var parts []string
 
-		// Index (right-aligned) - handle pinned index
-		indexStr := ""
-		if scratch.IsPinned {
-			pinnedCount++
-			indexStr = fmt.Sprintf("p%d.", pinnedCount)
-		} else {
-			indexStr = fmt.Sprintf("%d.", index)
-		}
+		// Regular index
+		indexStr := fmt.Sprintf("%d.", index)
 		indexPadded := padLeft(indexStr, widths.ID-1) + " "
 
 		// Project (if showing)
@@ -171,26 +235,24 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 		title := truncateWithEllipsis(scratch.Title, widths.Title)
 		titlePadded := padRight(title, widths.Title) + "  "
 
-		// Time (prepare for right-alignment) - add pin indicator if pinned
+		// Time - add pin indicator at the end if pinned
 		timeStr := timeAgo
 		if scratch.IsPinned {
-			timeStr = "⚲ " + timeAgo
+			timeStr = timeAgo + " ⚲"
 		}
 		timePadded := padLeft(timeStr, widths.Date)
 
-		// Now apply styles to each part
+		// Apply styles
 		indexStyle := styles.Get("padIndex")
 		parts = append(parts, strings.Replace(indexPadded, indexStr, indexStyle.Render(indexStr), 1))
 
 		if showProject && projectPadded != "" {
 			projectStyle := styles.Get("padProject")
-			// Find the actual project text within the padded string
 			projectText := strings.TrimSpace(projectPadded[:widths.Project])
 			parts = append(parts, strings.Replace(projectPadded, projectText, projectStyle.Render(projectText), 1))
 		}
 
 		titleStyle := styles.Get("padTitle")
-		// Find the actual title text within the padded string
 		titleText := strings.TrimSpace(titlePadded[:widths.Title])
 		parts = append(parts, strings.Replace(titlePadded, titleText, titleStyle.Render(titleText), 1))
 
@@ -230,8 +292,8 @@ func getTerminalWidth() int {
 // calculateColumnWidths determines the width for each column
 func calculateColumnWidths(termWidth int, showProject bool) columnWidths {
 	widths := columnWidths{
-		ID:   5,  // "p99. " (p + 2 digits + dot + space)
-		Date: 18, // "⚲ a long while ago"
+		ID:   7,  // "⚲ p99. " (⚲ + space + p + 2 digits + dot + space)
+		Date: 20, // "a long while ago ⚲"
 	}
 
 	if showProject {

--- a/cmd/padz/templates/renderer.go
+++ b/cmd/padz/templates/renderer.go
@@ -135,6 +135,7 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 	widths := calculateColumnWidths(termWidth, showProject)
 
 	var lines []string
+	pinnedCount := 0
 	for i, scratch := range scratches {
 		// Prepare data
 		index := i + 1
@@ -149,8 +150,14 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 		// Build line with proper column alignment (WITHOUT styling first)
 		var parts []string
 
-		// Index (right-aligned)
-		indexStr := fmt.Sprintf("%d.", index)
+		// Index (right-aligned) - handle pinned index
+		indexStr := ""
+		if scratch.IsPinned {
+			pinnedCount++
+			indexStr = fmt.Sprintf("p%d.", pinnedCount)
+		} else {
+			indexStr = fmt.Sprintf("%d.", index)
+		}
 		indexPadded := padLeft(indexStr, widths.ID-1) + " "
 
 		// Project (if showing)
@@ -164,8 +171,12 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 		title := truncateWithEllipsis(scratch.Title, widths.Title)
 		titlePadded := padRight(title, widths.Title) + "  "
 
-		// Time (prepare for right-alignment)
-		timePadded := padLeft(timeAgo, widths.Date)
+		// Time (prepare for right-alignment) - add pin indicator if pinned
+		timeStr := timeAgo
+		if scratch.IsPinned {
+			timeStr = "⚲ " + timeAgo
+		}
+		timePadded := padLeft(timeStr, widths.Date)
 
 		// Now apply styles to each part
 		indexStyle := styles.Get("padIndex")
@@ -184,7 +195,7 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 		parts = append(parts, strings.Replace(titlePadded, titleText, titleStyle.Render(titleText), 1))
 
 		timeStyle := styles.Get("padTime")
-		parts = append(parts, strings.Replace(timePadded, timeAgo, timeStyle.Render(timeAgo), 1))
+		parts = append(parts, strings.Replace(timePadded, timeStr, timeStyle.Render(timeStr), 1))
 
 		lines = append(lines, strings.Join(parts, ""))
 	}
@@ -219,8 +230,8 @@ func getTerminalWidth() int {
 // calculateColumnWidths determines the width for each column
 func calculateColumnWidths(termWidth int, showProject bool) columnWidths {
 	widths := columnWidths{
-		ID:   4,  // "99. " (2 digits + dot + space)
-		Date: 16, // "a long while ago"
+		ID:   5,  // "p99. " (p + 2 digits + dot + space)
+		Date: 18, // "⚲ a long while ago"
 	}
 
 	if showProject {

--- a/cmd/padz/templates/renderer.go
+++ b/cmd/padz/templates/renderer.go
@@ -265,6 +265,153 @@ func (r *Renderer) RenderPadList(scratches []*store.Scratch, showProject bool) (
 	return strings.Join(lines, "\n"), nil
 }
 
+func (r *Renderer) RenderPadListWithOriginalIndices(scratches []*store.Scratch, originalIndices map[string]int, showProject bool) (string, error) {
+	// Get terminal width and calculate column widths
+	termWidth := getTerminalWidth()
+	widths := calculateColumnWidths(termWidth, showProject)
+
+	var lines []string
+
+	// First pass: render only pinned scratches with p1, p2 indices
+	pinnedCount := 0
+	hasPinned := false
+	for _, scratch := range scratches {
+		if !scratch.IsPinned {
+			continue
+		}
+		hasPinned = true
+		pinnedCount++
+
+		// Prepare data
+		projectName := ""
+		if scratch.Project == "global" {
+			projectName = "global"
+		} else if scratch.Project != "" {
+			projectName = filepath.Base(scratch.Project)
+		}
+		timeAgo := humanize.Time(scratch.CreatedAt)
+
+		// Build line with proper column alignment
+		var parts []string
+
+		// Pinned index with ⚲ prefix
+		indexStr := fmt.Sprintf("p%d.", pinnedCount)
+		fullIndexStr := "⚲ " + indexStr
+		// Pad based on visible width, not byte length
+		padding := widths.ID - lipgloss.Width(fullIndexStr)
+		indexPadded := strings.Repeat(" ", padding) + fullIndexStr
+
+		// Project (if showing)
+		projectPadded := ""
+		if showProject {
+			project := truncateWithEllipsis(projectName, widths.Project)
+			projectPadded = padRight(project, widths.Project) + "  "
+		}
+
+		// Title
+		title := truncateWithEllipsis(scratch.Title, widths.Title)
+		titlePadded := padRight(title, widths.Title) + "  "
+
+		// Time
+		timePadded := padLeft(timeAgo, widths.Date)
+
+		// Apply styles
+		indexStyle := styles.Get("padIndex")
+		parts = append(parts, strings.Replace(indexPadded, fullIndexStr, indexStyle.Render(fullIndexStr), 1))
+
+		if showProject && projectPadded != "" {
+			projectStyle := styles.Get("padProject")
+			projectText := strings.TrimSpace(projectPadded[:widths.Project])
+			parts = append(parts, strings.Replace(projectPadded, projectText, projectStyle.Render(projectText), 1))
+		}
+
+		titleStyle := styles.Get("padTitle")
+		titleText := strings.TrimSpace(titlePadded[:widths.Title])
+		parts = append(parts, strings.Replace(titlePadded, titleText, titleStyle.Render(titleText), 1))
+
+		timeStyle := styles.Get("padTime")
+		parts = append(parts, strings.Replace(timePadded, timeAgo, timeStyle.Render(timeAgo), 1))
+
+		lines = append(lines, strings.Join(parts, ""))
+	}
+
+	// Add separator if we have pinned items
+	if hasPinned {
+		lines = append(lines, "")
+		lines = append(lines, "")
+	}
+
+	// Second pass: render all scratches with their original chronological indices
+	for _, scratch := range scratches {
+		// Get the original chronological index for this scratch
+		index, ok := originalIndices[scratch.ID]
+		if !ok {
+			// Fallback to position in current list if not found
+			for i, s := range scratches {
+				if s.ID == scratch.ID {
+					index = i + 1
+					break
+				}
+			}
+		}
+
+		// Prepare data
+		projectName := ""
+		if scratch.Project == "global" {
+			projectName = "global"
+		} else if scratch.Project != "" {
+			projectName = filepath.Base(scratch.Project)
+		}
+		timeAgo := humanize.Time(scratch.CreatedAt)
+
+		// Build line with proper column alignment
+		var parts []string
+
+		// Regular index
+		indexStr := fmt.Sprintf("%d.", index)
+		indexPadded := padLeft(indexStr, widths.ID-1) + " "
+
+		// Project (if showing)
+		projectPadded := ""
+		if showProject {
+			project := truncateWithEllipsis(projectName, widths.Project)
+			projectPadded = padRight(project, widths.Project) + "  "
+		}
+
+		// Title
+		title := truncateWithEllipsis(scratch.Title, widths.Title)
+		titlePadded := padRight(title, widths.Title) + "  "
+
+		// Time - add pin indicator at the end if pinned
+		timeStr := timeAgo
+		if scratch.IsPinned {
+			timeStr = timeAgo + " ⚲"
+		}
+		timePadded := padLeft(timeStr, widths.Date)
+
+		// Apply styles
+		indexStyle := styles.Get("padIndex")
+		parts = append(parts, strings.Replace(indexPadded, indexStr, indexStyle.Render(indexStr), 1))
+
+		if showProject && projectPadded != "" {
+			projectStyle := styles.Get("padProject")
+			projectText := strings.TrimSpace(projectPadded[:widths.Project])
+			parts = append(parts, strings.Replace(projectPadded, projectText, projectStyle.Render(projectText), 1))
+		}
+
+		titleStyle := styles.Get("padTitle")
+		titleText := strings.TrimSpace(titlePadded[:widths.Title])
+		parts = append(parts, strings.Replace(titlePadded, titleText, titleStyle.Render(titleText), 1))
+
+		timeStyle := styles.Get("padTime")
+		parts = append(parts, strings.Replace(timePadded, timeStr, timeStyle.Render(timeStr), 1))
+
+		lines = append(lines, strings.Join(parts, ""))
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
 // Column width definitions
 type columnWidths struct {
 	ID      int

--- a/cmd/padz/templates/renderer_test.go
+++ b/cmd/padz/templates/renderer_test.go
@@ -78,10 +78,10 @@ func TestColumnWidthCalculation(t *testing.T) {
 		showProject bool
 		wantTitle   int
 	}{
-		{80, false, 56},  // 80 - 4 (id) - 16 (date) - 2 - 2 = 56
-		{80, true, 40},   // 80 - 4 (id) - 14 (proj) - 16 (date) - 2 - 2 - 2 = 40
-		{120, false, 96}, // 120 - 4 - 16 - 2 - 2 = 96
-		{120, true, 80},  // 120 - 4 - 14 - 16 - 2 - 2 - 2 = 80
+		{80, false, 53},  // 80 - 5 (id) - 18 (date) - 2 - 2 = 53
+		{80, true, 37},   // 80 - 5 (id) - 14 (proj) - 18 (date) - 2 - 2 - 2 = 37
+		{120, false, 93}, // 120 - 5 - 18 - 2 - 2 = 93
+		{120, true, 77},  // 120 - 5 - 14 - 18 - 2 - 2 - 2 = 77
 	}
 
 	for _, tt := range tests {

--- a/cmd/padz/templates/renderer_test.go
+++ b/cmd/padz/templates/renderer_test.go
@@ -78,10 +78,10 @@ func TestColumnWidthCalculation(t *testing.T) {
 		showProject bool
 		wantTitle   int
 	}{
-		{80, false, 53},  // 80 - 5 (id) - 18 (date) - 2 - 2 = 53
-		{80, true, 37},   // 80 - 5 (id) - 14 (proj) - 18 (date) - 2 - 2 - 2 = 37
-		{120, false, 93}, // 120 - 5 - 18 - 2 - 2 = 93
-		{120, true, 77},  // 120 - 5 - 14 - 18 - 2 - 2 - 2 = 77
+		{80, false, 49},  // 80 - 7 (id) - 20 (date) - 2 - 2 = 49
+		{80, true, 33},   // 80 - 7 (id) - 14 (proj) - 20 (date) - 2 - 2 - 2 = 33
+		{120, false, 89}, // 120 - 7 - 20 - 2 - 2 = 89
+		{120, true, 73},  // 120 - 7 - 14 - 20 - 2 - 2 - 2 = 73
 	}
 
 	for _, tt := range tests {

--- a/docs/dev/pinning.txt
+++ b/docs/dev/pinning.txt
@@ -1,0 +1,74 @@
+Pinned Scratches - Design Specification
+
+Core Concept
+- Pinned scratches appear at the top of padz ls with special "p1", "p2" prefixes
+- They maintain their regular index numbers as well (dual-id system)
+- Maximum 5 pinned scratches (configurable constant)
+- Pinned scratches appear in both pinned section AND regular list
+
+Data Model Changes
+
+1. Update Scratch struct in models.go:
+   type Scratch struct {
+       // existing fields...
+       IsPinned bool      `json:"is_pinned,omitempty"`
+       PinnedAt time.Time `json:"pinned_at,omitempty"`
+   }
+
+2. Add constants in store.go:
+   const MaxPinnedScratches = 5
+
+Display Logic
+
+The Ls function should return scratches in this order:
+1. Pinned scratches (sorted by PinnedAt, newest first)
+2. All scratches (sorted by CreatedAt, newest first)
+
+Example output:
+⚲ p1. Important notes                                              3 days ago
+⚲ p2. Daily standup template                                       1 week ago
+
+1. Latest scratch                                                   1 hour ago
+2. Yesterday's work                                                 1 day ago
+3. Important notes                                              ⚲   3 days ago
+4. Another scratch                                                  4 days ago
+5. Daily standup template                                       ⚲   1 week ago
+
+Commands
+
+1. pin command: padz pin <id>
+   - Accepts regular index or hash ID
+   - Checks if already pinned
+   - Enforces MaxPinnedScratches limit
+   - Sets IsPinned=true and PinnedAt=now
+
+2. unpin command: padz unpin <id|p-id>
+   - Accepts regular index, pinned index (p1, p2), or hash ID
+   - Sets IsPinned=false, clears PinnedAt
+
+ID Resolution
+
+Update GetScratchByIndex to handle:
+- Regular indices (1, 2, 3...)
+- Pinned indices (p1, p2...)
+- Hash IDs (unchanged)
+
+Implementation Steps
+
+1. Store Layer:
+   - Add IsPinned/PinnedAt fields to Scratch
+   - Create GetPinnedScratches() method
+   - Add validation for max pinned limit
+
+2. Commands Layer:
+   - Update Ls to prepend pinned scratches
+   - Create Pin/Unpin commands
+   - Update index resolution logic
+
+3. CLI Layer:
+   - Add pin/unpin commands to CLI
+   - Update display template for pin indicator
+
+4. Search Behavior:
+   - Pinned scratches appear only once in search results
+   - Use regular index, not pinned index in search results

--- a/docs/ids.txt
+++ b/docs/ids.txt
@@ -1,0 +1,18 @@
+The padz identifier system uses a clever dual-identifier approach:
+
+1. Hash IDs (Internal, Permanent)
+- SHA-1 hash of content, stored in /Users/adebert/h/padz/pkg/store/store.go:91
+- Never changes, used for file storage and deduplication
+- Example: a94a8fe5ccb19ba61c4c0873d391e987982fbbd3
+
+2. Integer Indices (User-facing, Dynamic)
+- Calculated on-the-fly based on position in sorted list
+- Always 1-based, with newest scratch as index 1
+- Maintained in idToIndex map during search operations /Users/adebert/h/padz/pkg/commands/search.go:54-57
+
+Key insight: When you run padz delete 15, padz:
+1. Gets all scratches via Ls() in creation order
+2. Maps position 15 to its hash ID
+3. Deletes using the hash ID
+
+During search, the system preserves original indices by creating the idToIndex map before filtering, ensuring stable references regardless of search results order.

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -25,6 +25,36 @@ func Ls(s *store.Store, all, global bool, project string) []store.Scratch {
 	return sortWithPinnedFirst(filtered)
 }
 
+// LsWithOriginalIndices returns scratches sorted with pinned first, plus a map of scratch IDs to their original chronological positions
+func LsWithOriginalIndices(s *store.Store, all, global bool, project string) ([]store.Scratch, map[string]int) {
+	scratches := s.GetScratches()
+
+	// First, get the chronologically sorted list to build the index map
+	var chronological []store.Scratch
+	if all {
+		chronological = sortByCreatedAtDesc(scratches)
+	} else {
+		var filtered []store.Scratch
+		for _, scratch := range scratches {
+			if global && scratch.Project == "global" {
+				filtered = append(filtered, scratch)
+			} else if !global && scratch.Project == project {
+				filtered = append(filtered, scratch)
+			}
+		}
+		chronological = sortByCreatedAtDesc(filtered)
+	}
+
+	// Build map of ID to chronological position
+	originalIndices := make(map[string]int)
+	for i, scratch := range chronological {
+		originalIndices[scratch.ID] = i + 1
+	}
+
+	// Return the pinned-first sorted list and the index map
+	return Ls(s, all, global, project), originalIndices
+}
+
 func sortByCreatedAtDesc(scratches []store.Scratch) []store.Scratch {
 	sorted := make([]store.Scratch, len(scratches))
 	copy(sorted, scratches)

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -5,12 +5,13 @@ import (
 	"github.com/arthur-debert/padz/pkg/store"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 func Ls(s *store.Store, all, global bool, project string) []store.Scratch {
 	scratches := s.GetScratches()
 	if all {
-		return sortByCreatedAtDesc(scratches)
+		return sortWithPinnedFirst(scratches)
 	}
 
 	var filtered []store.Scratch
@@ -21,7 +22,7 @@ func Ls(s *store.Store, all, global bool, project string) []store.Scratch {
 			filtered = append(filtered, scratch)
 		}
 	}
-	return sortByCreatedAtDesc(filtered)
+	return sortWithPinnedFirst(filtered)
 }
 
 func sortByCreatedAtDesc(scratches []store.Scratch) []store.Scratch {
@@ -33,9 +34,49 @@ func sortByCreatedAtDesc(scratches []store.Scratch) []store.Scratch {
 	return sorted
 }
 
+func sortWithPinnedFirst(scratches []store.Scratch) []store.Scratch {
+	sorted := make([]store.Scratch, len(scratches))
+	copy(sorted, scratches)
+	sort.Slice(sorted, func(i, j int) bool {
+		// Pinned items come first
+		if sorted[i].IsPinned != sorted[j].IsPinned {
+			return sorted[i].IsPinned
+		}
+		// Among pinned items, sort by PinnedAt (newest first)
+		if sorted[i].IsPinned && sorted[j].IsPinned {
+			return sorted[i].PinnedAt.After(sorted[j].PinnedAt)
+		}
+		// Among non-pinned items, sort by CreatedAt (newest first)
+		return sorted[i].CreatedAt.After(sorted[j].CreatedAt)
+	})
+	return sorted
+}
+
 func GetScratchByIndex(s *store.Store, all, global bool, project string, indexStr string) (*store.Scratch, error) {
 	scratches := Ls(s, all, global, project)
 
+	// Check if it's a pinned index (p1, p2, etc)
+	if len(indexStr) > 1 && indexStr[0] == 'p' {
+		pinnedIndexStr := indexStr[1:]
+		pinnedIndex, err := strconv.Atoi(pinnedIndexStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pinned index: %s", indexStr)
+		}
+
+		// Count pinned items
+		pinnedCount := 0
+		for i, scratch := range scratches {
+			if scratch.IsPinned {
+				pinnedCount++
+				if pinnedCount == pinnedIndex {
+					return &scratches[i], nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("pinned index out of range: %s", indexStr)
+	}
+
+	// Regular index
 	index, err := strconv.Atoi(indexStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid index: %s", indexStr)
@@ -46,4 +87,23 @@ func GetScratchByIndex(s *store.Store, all, global bool, project string, indexSt
 	}
 
 	return &scratches[index-1], nil
+}
+
+// ResolveScratchID resolves various ID formats (index, pinned index, hash) to a scratch
+func ResolveScratchID(s *store.Store, all, global bool, project string, id string) (*store.Scratch, error) {
+	// Try as index (including pinned index)
+	scratch, err := GetScratchByIndex(s, all, global, project, id)
+	if err == nil {
+		return scratch, nil
+	}
+
+	// Try as hash ID
+	scratches := s.GetScratches()
+	for i := range scratches {
+		if strings.HasPrefix(scratches[i].ID, id) {
+			return &scratches[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("scratch not found: %s", id)
 }

--- a/pkg/commands/pin.go
+++ b/pkg/commands/pin.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// Pin marks a scratch as pinned
+func Pin(s *store.Store, all, global bool, project string, id string) error {
+	// Resolve the scratch
+	scratch, err := ResolveScratchID(s, all, global, project, id)
+	if err != nil {
+		return err
+	}
+
+	// Check if already pinned
+	if scratch.IsPinned {
+		return fmt.Errorf("scratch is already pinned")
+	}
+
+	// Check pinned limit
+	pinned := s.GetPinnedScratches()
+	if len(pinned) >= store.MaxPinnedScratches {
+		return fmt.Errorf("maximum number of pinned scratches (%d) reached", store.MaxPinnedScratches)
+	}
+
+	// Update the scratch
+	scratch.IsPinned = true
+	scratch.PinnedAt = time.Now()
+
+	// Save using atomic update
+	return s.UpdateScratchAtomic(*scratch)
+}
+
+// Unpin removes the pinned status from a scratch
+func Unpin(s *store.Store, all, global bool, project string, id string) error {
+	// Resolve the scratch
+	scratch, err := ResolveScratchID(s, all, global, project, id)
+	if err != nil {
+		return err
+	}
+
+	// Check if not pinned
+	if !scratch.IsPinned {
+		return fmt.Errorf("scratch is not pinned")
+	}
+
+	// Update the scratch
+	scratch.IsPinned = false
+	scratch.PinnedAt = time.Time{} // Zero value
+	return s.UpdateScratchAtomic(*scratch)
+}

--- a/pkg/commands/pin_test.go
+++ b/pkg/commands/pin_test.go
@@ -1,0 +1,375 @@
+package commands
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/arthur-debert/padz/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPin(t *testing.T) {
+	t.Run("pin a scratch successfully", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create a scratch
+		scratch := store.Scratch{
+			ID:        "test123",
+			Project:   project,
+			Title:     "Test Scratch",
+			CreatedAt: time.Now(),
+		}
+		err = st.AddScratch(scratch)
+		require.NoError(t, err)
+
+		// Pin it
+		err = Pin(st, false, false, project, "1")
+		assert.NoError(t, err)
+
+		// Verify it's pinned
+		scratches := st.GetScratches()
+		assert.True(t, scratches[0].IsPinned)
+		assert.NotZero(t, scratches[0].PinnedAt)
+	})
+
+	t.Run("error when scratch already pinned", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create and add a pinned scratch
+		scratch := store.Scratch{
+			ID:        "test123",
+			Project:   project,
+			Title:     "Test Scratch",
+			CreatedAt: time.Now(),
+			IsPinned:  true,
+			PinnedAt:  time.Now(),
+		}
+		err = st.AddScratch(scratch)
+		require.NoError(t, err)
+
+		// Try to pin it again
+		err = Pin(st, false, false, project, "1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "already pinned")
+	})
+
+	t.Run("error when max pinned scratches reached", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create max pinned scratches
+		for i := 0; i < store.MaxPinnedScratches; i++ {
+			scratch := store.Scratch{
+				ID:        fmt.Sprintf("test%d", i),
+				Project:   project,
+				Title:     "Test Scratch",
+				CreatedAt: time.Now().Add(-time.Duration(i) * time.Hour),
+				IsPinned:  true,
+				PinnedAt:  time.Now(),
+			}
+			err = st.AddScratch(scratch)
+			require.NoError(t, err)
+		}
+
+		// Create one more unpinned
+		scratch := store.Scratch{
+			ID:        "test-unpinned",
+			Project:   project,
+			Title:     "Test Scratch",
+			CreatedAt: time.Now().Add(-time.Duration(store.MaxPinnedScratches+1) * time.Hour),
+		}
+		err = st.AddScratch(scratch)
+		require.NoError(t, err)
+
+		// Try to pin it
+		err = Pin(st, false, false, project, fmt.Sprintf("%d", store.MaxPinnedScratches+1))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "maximum number of pinned scratches")
+	})
+
+	t.Run("pin by hash ID", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create a scratch
+		scratch := store.Scratch{
+			ID:        "abc123def456",
+			Project:   project,
+			Title:     "Test Scratch",
+			CreatedAt: time.Now(),
+		}
+		err = st.AddScratch(scratch)
+		require.NoError(t, err)
+
+		// Pin by partial hash
+		err = Pin(st, false, false, project, "abc123")
+		assert.NoError(t, err)
+
+		// Verify it's pinned
+		scratches := st.GetScratches()
+		assert.True(t, scratches[0].IsPinned)
+	})
+}
+
+func TestUnpin(t *testing.T) {
+	t.Run("unpin a scratch successfully", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create a pinned scratch
+		scratch := store.Scratch{
+			ID:        "test123",
+			Project:   project,
+			Title:     "Test Scratch",
+			CreatedAt: time.Now(),
+			IsPinned:  true,
+			PinnedAt:  time.Now(),
+		}
+		err = st.AddScratch(scratch)
+		require.NoError(t, err)
+
+		// Unpin it
+		err = Unpin(st, false, false, project, "1")
+		assert.NoError(t, err)
+
+		// Verify it's unpinned
+		scratches := st.GetScratches()
+		assert.False(t, scratches[0].IsPinned)
+		assert.Zero(t, scratches[0].PinnedAt)
+	})
+
+	t.Run("error when scratch not pinned", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create an unpinned scratch
+		scratch := store.Scratch{
+			ID:        "test123",
+			Project:   project,
+			Title:     "Test Scratch",
+			CreatedAt: time.Now(),
+		}
+		err = st.AddScratch(scratch)
+		require.NoError(t, err)
+
+		// Try to unpin it
+		err = Unpin(st, false, false, project, "1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not pinned")
+	})
+
+	t.Run("unpin by pinned index", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create multiple scratches, some pinned
+		scratches := []store.Scratch{
+			{
+				ID:        "pinned1",
+				Project:   project,
+				Title:     "Pinned 1",
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+				IsPinned:  true,
+				PinnedAt:  time.Now().Add(-10 * time.Minute),
+			},
+			{
+				ID:        "pinned2",
+				Project:   project,
+				Title:     "Pinned 2",
+				CreatedAt: time.Now().Add(-2 * time.Hour),
+				IsPinned:  true,
+				PinnedAt:  time.Now().Add(-5 * time.Minute), // Newer pinned time
+			},
+			{
+				ID:        "unpinned",
+				Project:   project,
+				Title:     "Unpinned",
+				CreatedAt: time.Now(),
+			},
+		}
+
+		for _, s := range scratches {
+			err = st.AddScratch(s)
+			require.NoError(t, err)
+		}
+
+		// Unpin using p1 (should be pinned2 as it has newer PinnedAt)
+		err = Unpin(st, false, false, project, "p1")
+		assert.NoError(t, err)
+
+		// Verify correct scratch was unpinned
+		updated := st.GetScratches()
+		for _, s := range updated {
+			if s.ID == "pinned2" {
+				assert.False(t, s.IsPinned)
+			}
+		}
+	})
+}
+
+func TestGetScratchByIndex_PinnedIndices(t *testing.T) {
+	cfg, cleanup := testutil.SetupTestEnvironment(t)
+	defer cleanup()
+
+	st, err := store.NewStoreWithConfig(cfg)
+	require.NoError(t, err)
+	project := "test-project"
+
+	// Create scratches with specific order
+	scratches := []store.Scratch{
+		{
+			ID:        "newest",
+			Project:   project,
+			Title:     "Newest",
+			CreatedAt: time.Now(),
+		},
+		{
+			ID:        "pinned-old",
+			Project:   project,
+			Title:     "Old but pinned",
+			CreatedAt: time.Now().Add(-48 * time.Hour),
+			IsPinned:  true,
+			PinnedAt:  time.Now().Add(-10 * time.Minute),
+		},
+		{
+			ID:        "pinned-newer",
+			Project:   project,
+			Title:     "Pinned newer",
+			CreatedAt: time.Now().Add(-24 * time.Hour),
+			IsPinned:  true,
+			PinnedAt:  time.Now().Add(-5 * time.Minute),
+		},
+		{
+			ID:        "middle",
+			Project:   project,
+			Title:     "Middle",
+			CreatedAt: time.Now().Add(-12 * time.Hour),
+		},
+	}
+
+	for _, s := range scratches {
+		err = st.AddScratch(s)
+		require.NoError(t, err)
+	}
+
+	// Test pinned indices
+	t.Run("p1 returns first pinned", func(t *testing.T) {
+		scratch, err := GetScratchByIndex(st, false, false, project, "p1")
+		assert.NoError(t, err)
+		assert.Equal(t, "pinned-newer", scratch.ID) // Newer PinnedAt time
+	})
+
+	t.Run("p2 returns second pinned", func(t *testing.T) {
+		scratch, err := GetScratchByIndex(st, false, false, project, "p2")
+		assert.NoError(t, err)
+		assert.Equal(t, "pinned-old", scratch.ID)
+	})
+
+	t.Run("regular index 1 returns first in sorted list", func(t *testing.T) {
+		scratch, err := GetScratchByIndex(st, false, false, project, "1")
+		assert.NoError(t, err)
+		assert.Equal(t, "pinned-newer", scratch.ID) // Pinned items come first
+	})
+
+	t.Run("regular index 3 returns first non-pinned", func(t *testing.T) {
+		scratch, err := GetScratchByIndex(st, false, false, project, "3")
+		assert.NoError(t, err)
+		assert.Equal(t, "newest", scratch.ID) // First non-pinned by creation time
+	})
+
+	t.Run("invalid pinned index", func(t *testing.T) {
+		_, err := GetScratchByIndex(st, false, false, project, "p3")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "pinned index out of range")
+	})
+}
+
+func TestLs_WithPinned(t *testing.T) {
+	cfg, cleanup := testutil.SetupTestEnvironment(t)
+	defer cleanup()
+
+	st, err := store.NewStoreWithConfig(cfg)
+	require.NoError(t, err)
+	project := "test-project"
+
+	// Create scratches
+	now := time.Now()
+	scratches := []store.Scratch{
+		{
+			ID:        "newest",
+			Project:   project,
+			Title:     "Newest",
+			CreatedAt: now,
+		},
+		{
+			ID:        "pinned1",
+			Project:   project,
+			Title:     "Pinned 1",
+			CreatedAt: now.Add(-48 * time.Hour),
+			IsPinned:  true,
+			PinnedAt:  now.Add(-5 * time.Minute),
+		},
+		{
+			ID:        "middle",
+			Project:   project,
+			Title:     "Middle",
+			CreatedAt: now.Add(-24 * time.Hour),
+		},
+		{
+			ID:        "pinned2",
+			Project:   project,
+			Title:     "Pinned 2",
+			CreatedAt: now.Add(-72 * time.Hour),
+			IsPinned:  true,
+			PinnedAt:  now.Add(-10 * time.Minute),
+		},
+	}
+
+	for _, s := range scratches {
+		err = st.AddScratch(s)
+		require.NoError(t, err)
+	}
+
+	// Get sorted list
+	result := Ls(st, false, false, project)
+
+	// Verify order: pinned first (by PinnedAt), then others (by CreatedAt)
+	assert.Equal(t, 4, len(result))
+	assert.Equal(t, "pinned1", result[0].ID) // Newer PinnedAt
+	assert.Equal(t, "pinned2", result[1].ID) // Older PinnedAt
+	assert.Equal(t, "newest", result[2].ID)  // Newest CreatedAt
+	assert.Equal(t, "middle", result[3].ID)  // Older CreatedAt
+}

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -10,6 +10,8 @@ type Scratch struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	Size      int64     `json:"size,omitempty"`
 	Checksum  string    `json:"checksum,omitempty"`
+	IsPinned  bool      `json:"is_pinned,omitempty"`
+	PinnedAt  time.Time `json:"pinned_at,omitempty"`
 }
 
 // IndexEntry represents minimal scratch info for the master index

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	dataDirName      = "scratch"
-	metadataFileName = "metadata.json"
+	dataDirName        = "scratch"
+	metadataFileName   = "metadata.json"
+	MaxPinnedScratches = 5
 )
 
 type Store struct {
@@ -70,6 +71,21 @@ func (s *Store) GetScratches() []Scratch {
 	logger := logging.GetLogger("store")
 	logger.Debug().Int("scratch_count", len(s.scratches)).Msg("Retrieved all scratches")
 	return s.scratches
+}
+
+func (s *Store) GetPinnedScratches() []Scratch {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	logger := logging.GetLogger("store")
+	var pinned []Scratch
+	for _, scratch := range s.scratches {
+		if scratch.IsPinned {
+			pinned = append(pinned, scratch)
+		}
+	}
+	logger.Debug().Int("pinned_count", len(pinned)).Msg("Retrieved pinned scratches")
+	return pinned
 }
 
 func (s *Store) SaveScratches(scratches []Scratch) error {


### PR DESCRIPTION
## Summary
- Implements pinned scratches feature to keep frequently used scratches at the top of the list
- Adds pin/unpin commands with support for dual-id system (p1, p2 prefixes + regular indices)
- Limits pinned scratches to 5 (configurable constant)

## Implementation Details

### Data Model Changes
- Added `IsPinned` and `PinnedAt` fields to the `Scratch` struct
- Added `MaxPinnedScratches` constant (set to 5)

### New Commands
- `padz pin <id>` - Pin a scratch to the top of the list
- `padz unpin <id>` - Unpin a scratch

### Display Changes
- Pinned scratches appear at the top with special prefixes (p1, p2, etc.)
- Pin indicator (⚲) shows in the time column for pinned items
- Updated column widths to accommodate pinned indices and indicators

### ID Resolution
- Supports regular indices (1, 2, 3...)
- Supports pinned indices (p1, p2...)
- Supports hash IDs (partial or full)
- Pinned scratches can be referenced by either their pinned index or regular index

## Design Documentation

The full design specification is available at `/docs/dev/pinning.txt`

## Test Plan
- [x] Unit tests for pin/unpin commands
- [x] Tests for pinned index resolution
- [x] Tests for sorting with pinned items
- [x] All existing tests pass
- [ ] Manual testing of CLI commands
- [ ] Test display formatting with various terminal widths

🤖 Generated with Claude Code