### PR TITLE
feat: add export command

### DIFF
--- a/cmd/padz/cli/export.go
+++ b/cmd/padz/cli/export.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"github.com/arthur-debert/padz/pkg/commands"
+	"github.com/arthur-debert/padz/pkg/project"
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// newExportCmd creates and returns a new export command
+func newExportCmd() *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "export [id...]",
+		Short: "Export scratches to files",
+		Long: `Export scratches to files in the specified format.
+
+If no IDs are provided, all scratches in the current project are exported.
+You can specify multiple IDs to export specific scratches.
+
+Files are exported to a directory named padz-export-YYYY-MM-DD-HH-mm
+with filenames in the format: <index>-<title>.<extension>
+
+Examples:
+  padz export                    # Export all scratches as txt
+  padz export --format markdown  # Export all scratches as markdown
+  padz export 1 2 3             # Export specific scratches
+  padz export p1 p2             # Export pinned scratches`,
+		Run: func(cmd *cobra.Command, args []string) {
+			all, _ := cmd.Flags().GetBool("all")
+			global, _ := cmd.Flags().GetBool("global")
+
+			s, err := store.NewStore()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to initialize store")
+			}
+
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to get current working directory")
+			}
+
+			proj, err := project.GetCurrentProject(dir)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to get current project")
+			}
+
+			// Run discovery before exporting
+			if err := s.RunDiscoveryBeforeCommand(); err != nil {
+				log.Warn().Err(err).Msg("Failed to run discovery")
+			}
+
+			// Export scratches
+			if err := commands.Export(s, all, global, proj, args, format); err != nil {
+				log.Fatal().Err(err).Msg("Failed to export scratches")
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", "txt", "Export format (txt or markdown)")
+
+	return cmd
+}

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -144,6 +144,12 @@ func NewRootCmd() *cobra.Command {
 	recoverCmd.GroupID = "multiple"
 	rootCmd.AddCommand(recoverCmd)
 
+	exportCmd := newExportCmd()
+	exportCmd.GroupID = "multiple"
+	exportCmd.Flags().BoolP("all", "a", false, FlagAllDesc)
+	exportCmd.Flags().BoolP("global", "g", false, FlagGlobalDesc)
+	rootCmd.AddCommand(exportCmd)
+
 	return rootCmd
 }
 
@@ -212,7 +218,7 @@ func shouldRunCreate(args []string) bool {
 	// Check if first arg is a known command or reserved word
 	commands := []string{"ls", "view", "open", "peek", "delete", "path",
 		"copy", "cp", "cleanup", "search", "nuke", "recover", "create", "new", "n",
-		"version", "help", "completion", "pin", "unpin"}
+		"version", "help", "completion", "pin", "unpin", "export"}
 
 	firstArg := strings.ToLower(args[0])
 	for _, cmd := range commands {

--- a/pkg/commands/export.go
+++ b/pkg/commands/export.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// Export exports scratches to files in the specified format
+func Export(s *store.Store, all, global bool, project string, ids []string, format string) error {
+	var scratches []store.Scratch
+
+	if len(ids) == 0 {
+		// Export all scratches
+		scratches = Ls(s, all, global, project)
+	} else {
+		// Export specific scratches
+		for _, id := range ids {
+			scratch, err := ResolveScratchID(s, all, global, project, id)
+			if err != nil {
+				return fmt.Errorf("scratch not found: %s", id)
+			}
+			scratches = append(scratches, *scratch)
+		}
+	}
+
+	if len(scratches) == 0 {
+		return fmt.Errorf("no scratches to export")
+	}
+
+	// Create export directory
+	dirName := fmt.Sprintf("padz-export-%s", time.Now().Format("2006-01-02-15-04"))
+	if err := os.MkdirAll(dirName, 0755); err != nil {
+		return fmt.Errorf("failed to create export directory: %w", err)
+	}
+
+	// Export each scratch
+	exported := 0
+	for i, scratch := range scratches {
+		index := i + 1 // 1-based index
+		filename := generateFilename(index, scratch.Title, format)
+		filepath := filepath.Join(dirName, filename)
+
+		content, err := readScratchFile(scratch.ID)
+		if err != nil {
+			return fmt.Errorf("failed to read scratch content: %w", err)
+		}
+
+		if err := os.WriteFile(filepath, content, 0644); err != nil {
+			return fmt.Errorf("failed to write file %s: %w", filename, err)
+		}
+		exported++
+	}
+
+	fmt.Printf("Exported %d scratches to %s\n", exported, dirName)
+	return nil
+}
+
+// generateFilename creates a filename from index and title
+func generateFilename(index int, title string, format string) string {
+	// Sanitize title
+	sanitized := strings.ToLower(strings.TrimSpace(title))
+
+	// Replace spaces with dashes
+	sanitized = strings.ReplaceAll(sanitized, " ", "-")
+
+	// Remove special characters, keep only alphanumeric and dashes
+	reg := regexp.MustCompile(`[^a-z0-9\-]+`)
+	sanitized = reg.ReplaceAllString(sanitized, "")
+
+	// Truncate to 24 characters
+	if len(sanitized) > 24 {
+		sanitized = sanitized[:24]
+	}
+
+	// Remove trailing dashes
+	sanitized = strings.Trim(sanitized, "-")
+
+	// Determine extension
+	ext := ".txt"
+	if format == "markdown" || format == "md" {
+		ext = ".md"
+	}
+
+	return fmt.Sprintf("%d-%s%s", index, sanitized, ext)
+}

--- a/pkg/commands/export_test.go
+++ b/pkg/commands/export_test.go
@@ -1,0 +1,325 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/arthur-debert/padz/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExport(t *testing.T) {
+	t.Run("export all scratches as txt", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create test scratches
+		scratches := []struct {
+			title   string
+			content string
+		}{
+			{"First Scratch", "This is the first scratch content"},
+			{"Second Note", "This is the second note content"},
+			{"Third Item", "This is the third item content"},
+		}
+
+		for _, s := range scratches {
+			err := CreateWithTitle(st, project, []byte(s.content), s.title)
+			require.NoError(t, err)
+		}
+
+		// Change to temp directory
+		tmpDir := t.TempDir()
+		oldDir, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			if err := os.Chdir(oldDir); err != nil {
+				t.Logf("Failed to change back to original directory: %v", err)
+			}
+		}()
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+
+		// Export all
+		err = Export(st, false, false, project, nil, "txt")
+		assert.NoError(t, err)
+
+		// Check export directory exists
+		entries, err := os.ReadDir(".")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(entries))
+		assert.True(t, entries[0].IsDir())
+		assert.True(t, strings.HasPrefix(entries[0].Name(), "padz-export-"))
+
+		// Check exported files
+		exportDir := entries[0].Name()
+		files, err := os.ReadDir(exportDir)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(files))
+
+		// Check filenames and content (in reverse chronological order)
+		expectedFiles := []struct {
+			name    string
+			content string
+		}{
+			{"1-third-item.txt", "This is the third item content"},
+			{"2-second-note.txt", "This is the second note content"},
+			{"3-first-scratch.txt", "This is the first scratch content"},
+		}
+
+		for i, expected := range expectedFiles {
+			assert.Equal(t, expected.name, files[i].Name())
+			content, err := os.ReadFile(filepath.Join(exportDir, files[i].Name()))
+			require.NoError(t, err)
+			assert.Equal(t, expected.content, string(content))
+		}
+	})
+
+	t.Run("export specific scratches", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create test scratches
+		for i := 1; i <= 5; i++ {
+			content := fmt.Sprintf("Content for scratch %d", i)
+			err := Create(st, project, []byte(content))
+			require.NoError(t, err)
+		}
+
+		// Change to temp directory
+		tmpDir := t.TempDir()
+		oldDir, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			if err := os.Chdir(oldDir); err != nil {
+				t.Logf("Failed to change back to original directory: %v", err)
+			}
+		}()
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+
+		// Export specific ones
+		err = Export(st, false, false, project, []string{"1", "3", "5"}, "txt")
+		assert.NoError(t, err)
+
+		// Check exported files
+		entries, err := os.ReadDir(".")
+		require.NoError(t, err)
+		exportDir := entries[0].Name()
+		files, err := os.ReadDir(exportDir)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(files))
+
+		// Files should be numbered 1, 2, 3 based on export order
+		assert.Equal(t, "1-content-for-scratch-5.txt", files[0].Name())
+		assert.Equal(t, "2-content-for-scratch-3.txt", files[1].Name())
+		assert.Equal(t, "3-content-for-scratch-1.txt", files[2].Name())
+	})
+
+	t.Run("export as markdown", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create a scratch
+		err = CreateWithTitle(st, project, []byte("# Markdown Content\n\nThis is markdown"), "Markdown Content")
+		require.NoError(t, err)
+
+		// Change to temp directory
+		tmpDir := t.TempDir()
+		oldDir, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			if err := os.Chdir(oldDir); err != nil {
+				t.Logf("Failed to change back to original directory: %v", err)
+			}
+		}()
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+
+		// Export as markdown
+		err = Export(st, false, false, project, nil, "markdown")
+		assert.NoError(t, err)
+
+		// Check file extension
+		entries, err := os.ReadDir(".")
+		require.NoError(t, err)
+		exportDir := entries[0].Name()
+		files, err := os.ReadDir(exportDir)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(files))
+		assert.True(t, strings.HasSuffix(files[0].Name(), ".md"))
+		assert.Equal(t, "1-markdown-content.md", files[0].Name())
+	})
+
+	t.Run("export pinned scratches", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Create and pin some scratches
+		for i := 1; i <= 3; i++ {
+			err := Create(st, project, []byte(fmt.Sprintf("Content %d", i)))
+			require.NoError(t, err)
+		}
+
+		// Pin the second one
+		err = Pin(st, false, false, project, "2")
+		require.NoError(t, err)
+
+		// Change to temp directory
+		tmpDir := t.TempDir()
+		oldDir, err := os.Getwd()
+		require.NoError(t, err)
+		defer func() {
+			if err := os.Chdir(oldDir); err != nil {
+				t.Logf("Failed to change back to original directory: %v", err)
+			}
+		}()
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+
+		// Export using pinned index
+		err = Export(st, false, false, project, []string{"p1"}, "txt")
+		assert.NoError(t, err)
+
+		// Check exported file
+		entries, err := os.ReadDir(".")
+		require.NoError(t, err)
+		exportDir := entries[0].Name()
+		files, err := os.ReadDir(exportDir)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(files))
+		assert.Equal(t, "1-content-2.txt", files[0].Name())
+	})
+
+	t.Run("error on non-existent scratch", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Try to export non-existent scratch
+		err = Export(st, false, false, project, []string{"999"}, "txt")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "scratch not found: 999")
+	})
+
+	t.Run("error on no scratches to export", func(t *testing.T) {
+		cfg, cleanup := testutil.SetupTestEnvironment(t)
+		defer cleanup()
+
+		st, err := store.NewStoreWithConfig(cfg)
+		require.NoError(t, err)
+		project := "test-project"
+
+		// Try to export from empty store
+		err = Export(st, false, false, project, nil, "txt")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no scratches to export")
+	})
+
+	t.Run("filename sanitization", func(t *testing.T) {
+		// Test cases for filename generation
+		testCases := []struct {
+			title    string
+			expected string
+		}{
+			{"Title With Spaces", "1-title-with-spaces.txt"},
+			{"UPPERCASE TITLE", "1-uppercase-title.txt"},
+			{"Title@With#Special$Chars%", "1-titlewithspecialchars.txt"},
+			{"Title-With-Dashes", "1-title-with-dashes.txt"},
+			{"Very Long Title That Should Be Truncated To Twenty Four", "1-very-long-title-that-sho.txt"},
+			{"   Leading and Trailing Spaces   ", "1-leading-and-trailing-spa.txt"},
+		}
+
+		for i, tc := range testCases {
+			t.Run(tc.title, func(t *testing.T) {
+				cfg, cleanup := testutil.SetupTestEnvironment(t)
+				defer cleanup()
+
+				st, err := store.NewStoreWithConfig(cfg)
+				require.NoError(t, err)
+				project := "test-project"
+
+				// Change to temp directory
+				tmpDir := t.TempDir()
+				oldDir, err := os.Getwd()
+				require.NoError(t, err)
+				defer func() {
+					if err := os.Chdir(oldDir); err != nil {
+						t.Logf("Failed to change back to original directory: %v", err)
+					}
+				}()
+				err = os.Chdir(tmpDir)
+				require.NoError(t, err)
+
+				// Create scratch with specific title
+				err = CreateWithTitle(st, project, []byte("content"), tc.title)
+				require.NoError(t, err)
+
+				// Export the scratch
+				err = Export(st, false, false, project, nil, "txt")
+				assert.NoError(t, err)
+
+				// Check filename
+				entries, err := os.ReadDir(".")
+				require.NoError(t, err)
+				assert.Equal(t, 1, len(entries), "Test case %d: %s", i, tc.title)
+				exportDir := entries[0].Name()
+				files, err := os.ReadDir(exportDir)
+				require.NoError(t, err)
+				assert.Equal(t, 1, len(files), "Test case %d: %s", i, tc.title)
+				assert.Equal(t, tc.expected, files[0].Name(), "Test case %d: %s", i, tc.title)
+			})
+		}
+	})
+}
+
+func TestGenerateFilename(t *testing.T) {
+	testCases := []struct {
+		name     string
+		index    int
+		title    string
+		format   string
+		expected string
+	}{
+		{"simple txt", 1, "Hello World", "txt", "1-hello-world.txt"},
+		{"simple md", 1, "Hello World", "markdown", "1-hello-world.md"},
+		{"with special chars", 2, "Test@#$%File", "txt", "2-testfile.txt"},
+		{"uppercase", 3, "UPPERCASE", "txt", "3-uppercase.txt"},
+		{"long title", 4, "This is a very long title that should be truncated", "txt", "4-this-is-a-very-long-titl.txt"},
+		{"trailing spaces", 5, "  spaces  ", "txt", "5-spaces.txt"},
+		{"multiple dashes", 6, "one--two---three", "txt", "6-one--two---three.txt"},
+		{"ending with dash", 7, "ending-", "txt", "7-ending.txt"},
+		{"only special chars", 8, "@#$%^&*()", "txt", "8-.txt"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := generateFilename(tc.index, tc.title, tc.format)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Added `padz export` command to export scratches to files
- Support for txt and markdown formats
- Export all scratches or specific IDs

## Features
- Export to timestamped directory: `padz-export-YYYY-MM-DD-HH-mm`
- Smart filename generation: `<index>-<sanitized-title>.<extension>`
- Title sanitization (lowercase, spaces to dashes, max 24 chars)
- Support for pinned scratch indices (p1, p2, etc)

## Usage Examples
```bash
padz export                    # Export all scratches as txt
padz export --format markdown  # Export all scratches as markdown  
padz export 1 2 3             # Export specific scratches
padz export p1 p2             # Export pinned scratches
```

## Test plan
- [x] Unit tests for all functionality
- [x] Manual testing of export command
- [x] Tested with different formats (txt, markdown)
- [x] Tested with pinned scratches
- [x] Filename sanitization works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)