### PR TITLE
feat: add show-data-file command

### DIFF
--- a/cmd/padz/cli/global_flag_test.go
+++ b/cmd/padz/cli/global_flag_test.go
@@ -12,17 +12,18 @@ import (
 func TestGlobalFlagConsistency(t *testing.T) {
 	// Commands that should have --global flag
 	commandsWithGlobal := map[string]bool{
-		"create": true,
-		"view":   true,
-		"open":   true, // Should have but currently doesn't
-		"peek":   true,
-		"delete": true, // Should have but currently doesn't
-		"path":   true, // Should have but currently doesn't
-		"copy":   true, // Should have but currently doesn't
-		"pin":    true,
-		"unpin":  true,
-		"ls":     true,
-		"export": true,
+		"create":         true,
+		"view":           true,
+		"open":           true,
+		"peek":           true,
+		"delete":         true,
+		"path":           true,
+		"copy":           true,
+		"pin":            true,
+		"unpin":          true,
+		"ls":             true,
+		"export":         true,
+		"show-data-file": true,
 	}
 
 	rootCmd := NewRootCmd()

--- a/cmd/padz/cli/msgs.go
+++ b/cmd/padz/cli/msgs.go
@@ -139,3 +139,14 @@ Use --all to delete all scratches across all scopes.`
 	NukeNoPadsFound = "No pads found to delete."
 	NukeCancelled   = "Nuke cancelled."
 )
+
+// ShowDataFile command messages
+const (
+	ShowDataFileUse   = "show-data-file"
+	ShowDataFileShort = "Show the path to the data directory used by padz"
+	ShowDataFileLong  = `Show the path to the data directory used by padz.
+
+This command displays the directory where padz stores all scratch files and metadata.
+Note that both global and local scratches are stored in the same location - the --global
+flag only affects which scratches are filtered/displayed, not where they are stored.`
+)

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -227,7 +227,7 @@ func shouldRunCreate(args []string) bool {
 	// Check if first arg is a known command or reserved word
 	commands := []string{"ls", "view", "open", "peek", "delete", "path",
 		"copy", "cp", "cleanup", "search", "nuke", "recover", "create", "new", "n",
-		"version", "help", "completion", "pin", "unpin", "export"}
+		"version", "help", "completion", "pin", "unpin", "export", "show-data-file"}
 
 	firstArg := strings.ToLower(args[0])
 	for _, cmd := range commands {

--- a/cmd/padz/cli/root.go
+++ b/cmd/padz/cli/root.go
@@ -154,6 +154,11 @@ func NewRootCmd() *cobra.Command {
 	exportCmd.Flags().BoolP("global", "g", false, FlagGlobalDesc)
 	rootCmd.AddCommand(exportCmd)
 
+	// Utility commands (not grouped)
+	showDataFileCmd := newShowDataFileCmd()
+	showDataFileCmd.Flags().BoolP("global", "g", false, FlagGlobalDesc)
+	rootCmd.AddCommand(showDataFileCmd)
+
 	return rootCmd
 }
 

--- a/cmd/padz/cli/show_data_file.go
+++ b/cmd/padz/cli/show_data_file.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/arthur-debert/padz/pkg/commands"
+	"github.com/arthur-debert/padz/pkg/output"
+	"github.com/arthur-debert/padz/pkg/store"
+	"github.com/rs/zerolog/log"
+
+	"github.com/spf13/cobra"
+)
+
+// newShowDataFileCmd creates and returns a new show-data-file command
+func newShowDataFileCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   ShowDataFileUse,
+		Short: ShowDataFileShort,
+		Long:  ShowDataFileLong,
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Note: the global flag doesn't affect the data file location
+			// All scratches are stored in the same place
+
+			s, err := store.NewStore()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to initialize store")
+			}
+
+			result, err := commands.ShowDataFile(s)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to get data file path")
+			}
+
+			// Format output
+			format, formatErr := output.GetFormat(outputFormat)
+			if formatErr != nil {
+				log.Fatal().Err(formatErr).Msg("Failed to get output format")
+			}
+
+			formatter := output.NewFormatter(format, nil)
+
+			// For plain/term format, output the path directly
+			if format == output.PlainFormat || format == output.TermFormat {
+				if err := formatter.FormatString(result.Path); err != nil {
+					log.Fatal().Err(err).Msg("Failed to format output")
+				}
+			} else {
+				// For JSON, we need to encode the result manually since there's no FormatShowDataFile method
+				if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+					log.Fatal().Err(err).Msg("Failed to format output")
+				}
+			}
+		},
+	}
+}

--- a/cmd/padz/cli/show_data_file_test.go
+++ b/cmd/padz/cli/show_data_file_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestShowDataFileCommand(t *testing.T) {
+	// Test that the command is properly configured
+	cmd := newShowDataFileCmd()
+
+	if cmd.Use != ShowDataFileUse {
+		t.Errorf("expected Use to be %q, got %q", ShowDataFileUse, cmd.Use)
+	}
+
+	if cmd.Short != ShowDataFileShort {
+		t.Errorf("expected Short to be %q, got %q", ShowDataFileShort, cmd.Short)
+	}
+
+	if cmd.Long != ShowDataFileLong {
+		t.Errorf("expected Long to be %q, got %q", ShowDataFileLong, cmd.Long)
+	}
+
+	// Test that it expects no arguments
+	if err := cmd.Args(cmd, []string{}); err != nil {
+		t.Errorf("unexpected error with no arguments: %v", err)
+	}
+
+	if err := cmd.Args(cmd, []string{"extra"}); err == nil {
+		t.Error("expected error with extra argument")
+	}
+}
+
+func TestShowDataFileCommandFlags(t *testing.T) {
+	// The flag is added by root.go when integrating the command
+	rootCmd := NewRootCmd()
+
+	// Find the show-data-file command
+	var showDataFileCmd *cobra.Command
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "show-data-file" {
+			showDataFileCmd = cmd
+			break
+		}
+	}
+
+	if showDataFileCmd == nil {
+		t.Fatal("show-data-file command not found")
+	}
+
+	// Check that it has the global flag
+	globalFlag := showDataFileCmd.Flag("global")
+	if globalFlag == nil {
+		t.Error("expected show-data-file command to have --global flag")
+	}
+}
+
+func TestShowDataFileCommandRun(t *testing.T) {
+	// Test that the Run function is defined
+	cmd := newShowDataFileCmd()
+	if cmd.Run == nil {
+		t.Error("expected Run function to be defined")
+	}
+}

--- a/pkg/commands/show_data_file.go
+++ b/pkg/commands/show_data_file.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"github.com/arthur-debert/padz/pkg/store"
+)
+
+// ShowDataFileResult contains the data file path information
+type ShowDataFileResult struct {
+	Path string `json:"path"`
+}
+
+// ShowDataFile returns the path to the data file used by padz
+func ShowDataFile(s *store.Store) (*ShowDataFileResult, error) {
+	// Get the base scratch directory path
+	path, err := store.GetScratchPath()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ShowDataFileResult{
+		Path: path,
+	}, nil
+}

--- a/pkg/commands/show_data_file_test.go
+++ b/pkg/commands/show_data_file_test.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShowDataFile(t *testing.T) {
+	setup := SetupCommandTest(t)
+	defer setup.Cleanup()
+
+	// Test showing data file path
+	result, err := ShowDataFile(setup.Store)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The result should contain a path
+	if result.Path == "" {
+		t.Error("expected non-empty path")
+	}
+
+	// The path should contain "scratch" directory name
+	if !strings.Contains(result.Path, "scratch") {
+		t.Errorf("expected path to contain 'scratch', got: %s", result.Path)
+	}
+
+	// In test environment, it should contain the test data path
+	if !strings.Contains(result.Path, "/test/data") {
+		t.Errorf("expected test path to contain '/test/data', got: %s", result.Path)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds new `padz show-data-file` command to display the data directory path
- Supports `--global` flag for consistency with other commands
- Includes comprehensive test coverage

## Description

This PR adds a new utility command `padz show-data-file` that displays the path to the data directory where padz stores all scratch files and metadata.

### Features

- **Simple path output**: Returns just the path in plain/term format for easy scripting
- **JSON support**: Returns structured `{"path": "..."}` in JSON format
- **Global flag support**: Accepts `--global` flag for consistency, though it shows the same path since all data is stored in one location

### Implementation Notes

1. The command returns the base directory where padz stores its data (e.g., `~/.local/share/scratch/` on Linux/macOS)
2. Both global and local scratches are stored in the same location - the `--global` flag only affects filtering, not storage location
3. The command is placed outside the command groups as it's a utility command, not related to single or multiple scratches

### Use Cases

- **Debugging**: Quickly find where padz stores its data
- **Backup/Migration**: Identify the directory to backup or migrate
- **Integration**: Other tools can query padz for its data location
- **Troubleshooting**: Help users understand storage structure

## Testing

- [x] Unit tests for the commands package implementation
- [x] CLI tests for command structure and flags
- [x] Global flag consistency tests updated
- [x] All existing tests pass
- [x] Manual testing confirms command works correctly

## Example Usage

```bash
$ padz show-data-file
/Users/username/Library/Application Support/scratch

$ padz show-data-file --format json
{"path":"/Users/username/Library/Application Support/scratch"}

$ padz show-data-file --global
/Users/username/Library/Application Support/scratch
```

🤖 Generated with [Claude Code](https://claude.ai/code)