### PR TITLE
feat: allow referencing pads by title or search term

### DIFF
--- a/src/padz/commands/delete.rs
+++ b/src/padz/commands/delete.rs
@@ -1,17 +1,18 @@
 use crate::commands::{CmdMessage, CmdResult};
 use crate::error::Result;
+use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
 use chrono::Utc;
 
-use super::helpers::resolve_indexes;
+use super::helpers::resolve_selectors;
 
 pub fn run<S: DataStore>(
     store: &mut S,
     scope: Scope,
-    indexes: &[crate::index::DisplayIndex],
+    selectors: &[PadSelector],
 ) -> Result<CmdResult> {
-    let resolved = resolve_indexes(store, scope, indexes)?;
+    let resolved = resolve_selectors(store, scope, selectors)?;
     let mut result = CmdResult::default();
 
     for (display_index, uuid) in resolved {
@@ -41,7 +42,12 @@ mod tests {
     fn marks_pad_as_deleted() {
         let mut store = InMemoryStore::new();
         create::run(&mut store, Scope::Project, "Title".into(), "".into()).unwrap();
-        run(&mut store, Scope::Project, &[DisplayIndex::Regular(1)]).unwrap();
+        run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Regular(1))],
+        )
+        .unwrap();
 
         let deleted = get::run(
             &store,

--- a/src/padz/commands/export.rs
+++ b/src/padz/commands/export.rs
@@ -2,6 +2,7 @@ use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::index::DisplayIndex;
 use crate::index::DisplayPad;
+use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
 use chrono::Utc;
@@ -10,11 +11,11 @@ use flate2::Compression;
 use std::fs::File;
 use std::io::Write;
 
-use super::helpers::{indexed_pads, pads_by_indexes};
+use super::helpers::{indexed_pads, pads_by_selectors};
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, indexes: &[DisplayIndex]) -> Result<CmdResult> {
+pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
     // 1. Resolve pads
-    let pads = resolve_pads(store, scope, indexes)?;
+    let pads = resolve_pads(store, scope, selectors)?;
 
     if pads.is_empty() {
         let mut res = CmdResult::default();
@@ -38,15 +39,15 @@ pub fn run<S: DataStore>(store: &S, scope: Scope, indexes: &[DisplayIndex]) -> R
 fn resolve_pads<S: DataStore>(
     store: &S,
     scope: Scope,
-    indexes: &[DisplayIndex],
+    selectors: &[PadSelector],
 ) -> Result<Vec<DisplayPad>> {
-    if indexes.is_empty() {
+    if selectors.is_empty() {
         Ok(indexed_pads(store, scope)?
             .into_iter()
             .filter(|dp| !matches!(dp.index, DisplayIndex::Deleted(_)))
             .collect())
     } else {
-        pads_by_indexes(store, scope, indexes)
+        pads_by_selectors(store, scope, selectors)
     }
 }
 

--- a/src/padz/commands/get.rs
+++ b/src/padz/commands/get.rs
@@ -249,6 +249,7 @@ fn extract_context(line: &str, term_lower: &str, context_words: usize) -> Vec<Ma
 mod tests {
     use super::*;
     use crate::commands::{create, delete};
+    use crate::index::PadSelector;
     use crate::model::Scope;
     use crate::store::memory::InMemoryStore;
 
@@ -259,7 +260,12 @@ mod tests {
         create::run(&mut store, Scope::Project, "Deleted".into(), "".into()).unwrap();
 
         // Delete the second one
-        delete::run(&mut store, Scope::Project, &[DisplayIndex::Regular(1)]).unwrap();
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Regular(1))],
+        )
+        .unwrap();
 
         // 1. Test Active
         let res = run(

--- a/src/padz/commands/helpers.rs
+++ b/src/padz/commands/helpers.rs
@@ -9,31 +9,58 @@ pub fn indexed_pads<S: DataStore>(store: &S, scope: Scope) -> Result<Vec<Display
     Ok(index_pads(pads))
 }
 
-pub fn resolve_indexes<S: DataStore>(
+use crate::index::PadSelector;
+
+pub fn resolve_selectors<S: DataStore>(
     store: &S,
     scope: Scope,
-    indexes: &[DisplayIndex],
+    selectors: &[PadSelector],
 ) -> Result<Vec<(DisplayIndex, Uuid)>> {
     let indexed = indexed_pads(store, scope)?;
 
-    indexes
+    selectors
         .iter()
-        .map(|idx| {
-            indexed
+        .map(|selector| match selector {
+            PadSelector::Index(idx) => indexed
                 .iter()
                 .find(|dp| &dp.index == idx)
                 .map(|dp| (idx.clone(), dp.pad.metadata.id))
-                .ok_or_else(|| PadzError::Api(format!("Index {} not found in current scope", idx)))
+                .ok_or_else(|| PadzError::Api(format!("Index {} not found in current scope", idx))),
+            PadSelector::Title(term) => {
+                let term_lower = term.to_lowercase();
+                let matches: Vec<&DisplayPad> = indexed
+                    .iter()
+                    .filter(|dp| {
+                        // Match against title
+                        if dp.pad.metadata.title.to_lowercase().contains(&term_lower) {
+                            return true;
+                        }
+                        // Match against content (excluding first line if it duplicates title)
+                        // Simplified content match: just check if full content contains it
+                        // This matches get.rs logic roughly but simpler
+                        dp.pad.content.to_lowercase().contains(&term_lower)
+                    })
+                    .collect();
+
+                match matches.len() {
+                    0 => Err(PadzError::Api(format!("No pad found matching \"{}\"", term))),
+                    1 => Ok((matches[0].index.clone(), matches[0].pad.metadata.id)),
+                    n => Err(PadzError::Api(format!(
+                        "Term \"{}\" matches multiple paths, add more to make it unique(matched {} pads). Please be more specific.",
+                        term, n
+                    ))),
+                }
+            }
         })
         .collect()
 }
 
-pub fn pads_by_indexes<S: DataStore>(
+pub fn pads_by_selectors<S: DataStore>(
     store: &S,
     scope: Scope,
-    indexes: &[DisplayIndex],
+    selectors: &[PadSelector],
 ) -> Result<Vec<DisplayPad>> {
-    let resolved = resolve_indexes(store, scope, indexes)?;
+    let resolved = resolve_selectors(store, scope, selectors)?;
     let mut pads = Vec::with_capacity(resolved.len());
     for (index, id) in resolved {
         let pad = store.get_pad(&id, scope)?;

--- a/src/padz/commands/paths.rs
+++ b/src/padz/commands/paths.rs
@@ -1,13 +1,13 @@
 use crate::commands::CmdResult;
 use crate::error::Result;
-use crate::index::DisplayIndex;
+use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
 
-use super::helpers::resolve_indexes;
+use super::helpers::resolve_selectors;
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, indexes: &[DisplayIndex]) -> Result<CmdResult> {
-    let resolved = resolve_indexes(store, scope, indexes)?;
+pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+    let resolved = resolve_selectors(store, scope, selectors)?;
     let mut paths = Vec::with_capacity(resolved.len());
 
     for (_, uuid) in resolved {
@@ -22,6 +22,7 @@ pub fn run<S: DataStore>(store: &S, scope: Scope, indexes: &[DisplayIndex]) -> R
 mod tests {
     use super::*;
     use crate::commands::create;
+    use crate::index::DisplayIndex;
     use crate::model::Scope;
     use crate::store::memory::InMemoryStore;
 
@@ -30,7 +31,12 @@ mod tests {
         let mut store = InMemoryStore::new();
         create::run(&mut store, Scope::Project, "Pad A".into(), "".into()).unwrap();
 
-        let res = run(&store, Scope::Project, &[DisplayIndex::Regular(1)]).unwrap();
+        let res = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Regular(1))],
+        )
+        .unwrap();
         assert_eq!(res.pad_paths.len(), 1);
         // InMemoryStore generates fake paths, just check it returns something valid-ish
         // for testing. But wait, InMemoryStore's get_pad_path might return a generic path.
@@ -51,7 +57,10 @@ mod tests {
         let res = run(
             &store,
             Scope::Project,
-            &[DisplayIndex::Regular(1), DisplayIndex::Regular(2)],
+            &[
+                PadSelector::Index(DisplayIndex::Regular(1)),
+                PadSelector::Index(DisplayIndex::Regular(2)),
+            ],
         )
         .unwrap();
         assert_eq!(res.pad_paths.len(), 2);

--- a/src/padz/commands/pinning.rs
+++ b/src/padz/commands/pinning.rs
@@ -1,35 +1,35 @@
 use crate::commands::{CmdMessage, CmdResult};
 use crate::error::Result;
-use crate::index::DisplayIndex;
+use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
 use chrono::Utc;
 
-use super::helpers::resolve_indexes;
+use super::helpers::resolve_selectors;
 
 pub fn pin<S: DataStore>(
     store: &mut S,
     scope: Scope,
-    indexes: &[DisplayIndex],
+    selectors: &[PadSelector],
 ) -> Result<CmdResult> {
-    pin_state(store, scope, indexes, true)
+    pin_state(store, scope, selectors, true)
 }
 
 pub fn unpin<S: DataStore>(
     store: &mut S,
     scope: Scope,
-    indexes: &[DisplayIndex],
+    selectors: &[PadSelector],
 ) -> Result<CmdResult> {
-    pin_state(store, scope, indexes, false)
+    pin_state(store, scope, selectors, false)
 }
 
 fn pin_state<S: DataStore>(
     store: &mut S,
     scope: Scope,
-    indexes: &[DisplayIndex],
+    selectors: &[PadSelector],
     is_pinned: bool,
 ) -> Result<CmdResult> {
-    let resolved = resolve_indexes(store, scope, indexes)?;
+    let resolved = resolve_selectors(store, scope, selectors)?;
     let mut result = CmdResult::default();
 
     for (display_index, uuid) in resolved {
@@ -64,8 +64,8 @@ mod tests {
         create::run(&mut store, Scope::Project, "A".into(), "".into()).unwrap();
         create::run(&mut store, Scope::Project, "B".into(), "".into()).unwrap();
 
-        let idx = DisplayIndex::Regular(1);
-        pin(&mut store, Scope::Project, slice::from_ref(&idx)).unwrap();
+        let sel = PadSelector::Index(DisplayIndex::Regular(1));
+        pin(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
         let result = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
         assert!(result
@@ -78,9 +78,9 @@ mod tests {
     fn unpinning_removes_pinned_flag() {
         let mut store = InMemoryStore::new();
         create::run(&mut store, Scope::Project, "A".into(), "".into()).unwrap();
-        let idx = DisplayIndex::Regular(1);
-        pin(&mut store, Scope::Project, slice::from_ref(&idx)).unwrap();
-        unpin(&mut store, Scope::Project, slice::from_ref(&idx)).unwrap();
+        let sel = PadSelector::Index(DisplayIndex::Regular(1));
+        pin(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+        unpin(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
         let result = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
         assert!(result

--- a/src/padz/commands/view.rs
+++ b/src/padz/commands/view.rs
@@ -1,12 +1,12 @@
 use crate::commands::CmdResult;
 use crate::error::Result;
-use crate::index::DisplayIndex;
+use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
 
-use super::helpers::pads_by_indexes;
+use super::helpers::pads_by_selectors;
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, indexes: &[DisplayIndex]) -> Result<CmdResult> {
-    let pads = pads_by_indexes(store, scope, indexes)?;
+pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+    let pads = pads_by_selectors(store, scope, selectors)?;
     Ok(CmdResult::default().with_listed_pads(pads))
 }

--- a/src/padz/index.rs
+++ b/src/padz/index.rs
@@ -32,6 +32,22 @@ impl std::fmt::Display for DisplayIndex {
     }
 }
 
+/// A user input to select a pad, either by its index or a search term for its title.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PadSelector {
+    Index(DisplayIndex),
+    Title(String),
+}
+
+impl std::fmt::Display for PadSelector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PadSelector::Index(idx) => write!(f, "{}", idx),
+            PadSelector::Title(t) => write!(f, "\"{}\"", t),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DisplayPad {
     pub pad: Pad,

--- a/tests/title_referencing.rs
+++ b/tests/title_referencing.rs
@@ -1,0 +1,114 @@
+use padz::api::PadzApi;
+use padz::commands::PadzPaths;
+use padz::model::Scope;
+use padz::store::memory::InMemoryStore;
+
+fn setup() -> PadzApi<InMemoryStore> {
+    let store = InMemoryStore::new();
+    let paths = PadzPaths {
+        project: Some(std::path::PathBuf::from(".padz")),
+        global: std::path::PathBuf::from(".padz"),
+    };
+    let mut api = PadzApi::new(store, paths);
+
+    // Create some pads
+    api.create_pad(
+        Scope::Project,
+        "Groceries".to_string(),
+        "Milk, Eggs".to_string(),
+    )
+    .unwrap();
+    api.create_pad(
+        Scope::Project,
+        "Grocery List".to_string(),
+        "Bread, Butter".to_string(),
+    )
+    .unwrap();
+    api.create_pad(Scope::Project, "Gold".to_string(), "Au".to_string())
+        .unwrap();
+
+    api
+}
+
+#[test]
+fn test_referencing_by_index() {
+    let api = setup();
+    // 1 -> Gold (newest/shortest title logic? Default is newest first)
+    // Created Order: Groceries, Grocery List, Gold.
+    // Indexing: Gold (1), Grocery List (2), Groceries (3).
+
+    let res = api.view_pads(Scope::Project, &["1"]).unwrap();
+    assert_eq!(res.listed_pads.len(), 1);
+    assert_eq!(res.listed_pads[0].pad.metadata.title, "Gold");
+
+    let res = api.view_pads(Scope::Project, &["3"]).unwrap();
+    assert_eq!(res.listed_pads.len(), 1);
+    assert_eq!(res.listed_pads[0].pad.metadata.title, "Groceries");
+}
+
+#[test]
+fn test_referencing_multiple_indexes() {
+    let api = setup();
+    let res = api.view_pads(Scope::Project, &["1", "2"]).unwrap();
+    assert_eq!(res.listed_pads.len(), 2);
+    // Gold and Grocery List
+}
+
+#[test]
+fn test_referencing_by_title_exact() {
+    let api = setup();
+    let res = api.view_pads(Scope::Project, &["Gold"]).unwrap();
+    assert_eq!(res.listed_pads.len(), 1);
+    assert_eq!(res.listed_pads[0].pad.metadata.title, "Gold");
+}
+
+#[test]
+fn test_referencing_by_title_partial() {
+    let api = setup();
+    // "Gold" is matched by "old"
+    let res = api.view_pads(Scope::Project, &["old"]).unwrap();
+    assert_eq!(res.listed_pads.len(), 1);
+    assert_eq!(res.listed_pads[0].pad.metadata.title, "Gold");
+}
+
+#[test]
+fn test_referencing_by_title_multi_word_arg() {
+    let api = setup();
+    // "Grocery List" matched by "Grocery List" (passed as separate args by shell simulation)
+    // Actually view_pads takes &[String]. The CLI passes ["Grocery", "List"].
+    let res = api.view_pads(Scope::Project, &["Grocery", "List"]).unwrap();
+    assert_eq!(res.listed_pads.len(), 1);
+    assert_eq!(res.listed_pads[0].pad.metadata.title, "Grocery List");
+}
+
+#[test]
+fn test_referencing_ambiguous() {
+    let api = setup();
+    // "Gro" matches "Groceries" and "Grocery List"
+    let res = api.view_pads(Scope::Project, &["Gro"]);
+    assert!(res.is_err());
+    let err = res.err().unwrap().to_string();
+    assert!(err.contains("matches multiple paths"));
+    assert!(err.contains("matched 2 pads"));
+}
+
+#[test]
+fn test_referencing_mixed_treated_as_title() {
+    let api = setup();
+    // "1" and "Gold". "1" is index, "Gold" is title.
+    // Should be treated as title search "1 Gold".
+    // "Gold" pad content is "Au". Title "Gold".
+    // Search "1 Gold" -> No match.
+
+    let res = api.view_pads(Scope::Project, &["1", "Gold"]);
+    assert!(res.is_err());
+    let err = res.err().unwrap().to_string();
+    assert!(err.contains("No pad found matching \"1 Gold\""));
+}
+
+#[test]
+fn test_referencing_mixed_no_match() {
+    let api = setup();
+    let res = api.view_pads(Scope::Project, &["1", "Grocery"]);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
Implements title-based pad referencing. allowing users to select pads by their title search terms in addition to canonical indexes.

## Changes

### Core & API
- **Added PadSelector**: An enum in index.rs that represents either an Index(DisplayIndex) or Title(String).
- **API Helper parse_selectors**:
  - Tries to parse all arguments as numeric indexes.
  - **Ambiguity Rule**: If *any* argument is non-numeric, the entire list is joined into a single title search term.
- **API Methods**: Updated view_pads, delete_pads, pin_pads, unpin_pads, purge_pads, export_pads, pad_paths to use parsing logic.

### Commands
- **Resolving Selectors**: Refactored helpers::resolve_indexes into resolve_selectors.
  - Implements search logic: matches if title contains term OR content contains term (case-insensitive).
  - Enforces uniqueness: Errors if 0 matches or >1 matches.
