### PR TITLE
Add --single-file export for merging pads into one document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1109,8 @@ dependencies = [
  "flate2",
  "once_cell",
  "outstanding",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "serde",
  "serde_json",
  "tar",
@@ -1213,6 +1224,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.10.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b27c0d365d60ff3e085007911d73419e5664de48155d558ebfa84d117a5109"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -1668,6 +1707,12 @@ dependencies = [
  "tempfile",
  "winapi",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "padz"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ colored = "3.0.0"
 directories = "6.0.0"
 flate2 = "1.1.5"
 once_cell = "1.19"
+pulldown-cmark = "0.12"
+pulldown-cmark-to-cmark = "17"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tar = "0.4.44"

--- a/src/padz/api.rs
+++ b/src/padz/api.rs
@@ -133,6 +133,16 @@ impl<S: DataStore> PadzApi<S> {
         commands::export::run(&self.store, scope, &selectors)
     }
 
+    pub fn export_pads_single_file<I: AsRef<str>>(
+        &self,
+        scope: Scope,
+        indexes: &[I],
+        title: &str,
+    ) -> Result<commands::CmdResult> {
+        let selectors = parse_selectors(indexes)?;
+        commands::export::run_single_file(&self.store, scope, &selectors, title)
+    }
+
     pub fn import_pads(
         &mut self,
         scope: Scope,

--- a/src/padz/cli/commands.rs
+++ b/src/padz/cli/commands.rs
@@ -117,7 +117,10 @@ pub fn run() -> Result<()> {
         },
         Some(Commands::Data(cmd)) => match cmd {
             DataCommands::Purge { indexes, yes } => handle_purge(&mut ctx, indexes, yes),
-            DataCommands::Export { indexes } => handle_export(&mut ctx, indexes),
+            DataCommands::Export {
+                single_file,
+                indexes,
+            } => handle_export(&mut ctx, indexes, single_file),
             DataCommands::Import { paths } => handle_import(&mut ctx, paths),
         },
         Some(Commands::Misc(cmd)) => match cmd {
@@ -285,8 +288,17 @@ fn handle_purge(ctx: &mut AppContext, indexes: Vec<String>, yes: bool) -> Result
     Ok(())
 }
 
-fn handle_export(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
-    let result = ctx.api.export_pads(ctx.scope, &indexes)?;
+fn handle_export(
+    ctx: &mut AppContext,
+    indexes: Vec<String>,
+    single_file: Option<String>,
+) -> Result<()> {
+    let result = if let Some(title) = single_file {
+        ctx.api
+            .export_pads_single_file(ctx.scope, &indexes, &title)?
+    } else {
+        ctx.api.export_pads(ctx.scope, &indexes)?
+    };
     print_messages(&result.messages);
     Ok(())
 }

--- a/src/padz/cli/setup.rs
+++ b/src/padz/cli/setup.rs
@@ -300,9 +300,13 @@ pub enum DataCommands {
         yes: bool,
     },
 
-    /// Export pads to a tar.gz archive
+    /// Export pads to a tar.gz archive (or single file with --single-file)
     #[command(display_order = 21)]
     Export {
+        /// Export all pads to a single file with this title (format detected from extension: .md for markdown, otherwise text)
+        #[arg(long, value_name = "TITLE")]
+        single_file: Option<String>,
+
         /// Indexes of the pads (e.g. 1 2) - if omitted, exports all active pads
         #[arg(required = false, num_args = 0..)]
         indexes: Vec<String>,


### PR DESCRIPTION
## Summary

- Adds `--single-file <TITLE>` option to `padz export` command
- Exports all selected pads into a single file instead of a tar.gz archive
- Format-aware: detects from file extension (`.md` for markdown, otherwise text)
- For markdown: proper header hierarchy using pulldown-cmark AST parsing

## Changes

- **New dependencies**: `pulldown-cmark` and `pulldown-cmark-to-cmark` for proper markdown parsing
- **Core logic** in `commands/export.rs`:
  - `bump_markdown_headers()` - bumps all header levels by 2 using AST
  - `merge_as_text()` - plain text with `===` separators
  - `merge_as_markdown()` - export title as H1, pad titles as H2, bumped content
- **CLI integration**: new `--single-file` option with format detection
- **10 new unit tests** for header bumping, merging, and filename sanitization

## Usage

```bash
# Export all pads to markdown
padz export --single-file "My Notes.md"

# Export all pads to text
padz export --single-file "My Notes.txt"

# Export specific pads
padz export --single-file "Selected.md" 1 2 3
```

## Test plan

- [x] Unit tests for format detection, header bumping, text/markdown merging
- [x] Unit tests for filename sanitization with extensions
- [x] Integration test with actual pad content and header bumping verification
- [x] All 80 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)