### PR TITLE
UI tweaks for list view styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "padz"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "chrono",
  "clap",

--- a/src/padz/cli/commands.rs
+++ b/src/padz/cli/commands.rs
@@ -39,7 +39,9 @@
 //! - `handle_*()`: Per-command handlers that call API and format output
 //! - `print_*()`: Output formatting functions
 
-use super::render::{print_messages, render_full_pads, render_pad_list, render_text_list};
+use super::render::{
+    print_messages, render_full_pads, render_pad_list, render_pad_list_deleted, render_text_list,
+};
 use super::setup::{
     print_grouped_help, print_help_for_command, print_subcommand_help, Cli, Commands,
     CompletionShell, CoreCommands, DataCommands, MiscCommands, PadCommands,
@@ -191,7 +193,11 @@ fn handle_list(ctx: &mut AppContext, search: Option<String>, deleted: bool) -> R
     let result = ctx.api.get_pads(ctx.scope, filter)?;
 
     // Use outstanding-based rendering
-    let output = render_pad_list(&result.listed_pads);
+    let output = if deleted {
+        render_pad_list_deleted(&result.listed_pads)
+    } else {
+        render_pad_list(&result.listed_pads)
+    };
     print!("{}", output);
 
     print_messages(&result.messages);

--- a/src/padz/cli/styles.rs
+++ b/src/padz/cli/styles.rs
@@ -42,6 +42,7 @@ pub mod names {
     pub const TIME: &str = "time";
     // Semantic list styles
     pub const LIST_INDEX: &str = "list-index";
+    pub const LIST_TITLE: &str = "list-title";
     pub const DELETED_INDEX: &str = "deleted-index";
     pub const DELETED_TITLE: &str = "deleted-title";
 }
@@ -66,6 +67,7 @@ fn build_light_theme() -> Theme {
     let time = muted.clone().italic();
     // Semantic list styles
     let list_index = Style::new().color256(rgb_to_ansi256((196, 140, 0))); // Yellow/gold for regular indexes
+    let list_title = regular.clone(); // Normal text for list titles (not bold)
     let deleted_index = Style::new().color256(rgb_to_ansi256((186, 33, 45))); // Red for deleted indexes
     let deleted_title = muted.clone(); // Muted gray for deleted titles
 
@@ -83,6 +85,7 @@ fn build_light_theme() -> Theme {
         .add(names::TITLE, title)
         .add(names::TIME, time)
         .add(names::LIST_INDEX, list_index)
+        .add(names::LIST_TITLE, list_title)
         .add(names::DELETED_INDEX, deleted_index)
         .add(names::DELETED_TITLE, deleted_title)
 }
@@ -104,6 +107,7 @@ fn build_dark_theme() -> Theme {
     let time = muted.clone().italic();
     // Semantic list styles
     let list_index = Style::new().color256(rgb_to_ansi256((255, 214, 10))); // Yellow for regular indexes
+    let list_title = regular.clone(); // Normal text for list titles (not bold)
     let deleted_index = Style::new().color256(rgb_to_ansi256((255, 138, 128))); // Red for deleted indexes
     let deleted_title = muted.clone(); // Muted gray for deleted titles
 
@@ -121,6 +125,7 @@ fn build_dark_theme() -> Theme {
         .add(names::TITLE, title)
         .add(names::TIME, time)
         .add(names::LIST_INDEX, list_index)
+        .add(names::LIST_TITLE, list_title)
         .add(names::DELETED_INDEX, deleted_index)
         .add(names::DELETED_TITLE, deleted_title)
 }

--- a/src/padz/cli/styles.rs
+++ b/src/padz/cli/styles.rs
@@ -40,6 +40,10 @@ pub mod names {
     pub const INFO: &str = "info";
     pub const TITLE: &str = "title";
     pub const TIME: &str = "time";
+    // Semantic list styles
+    pub const LIST_INDEX: &str = "list-index";
+    pub const DELETED_INDEX: &str = "deleted-index";
+    pub const DELETED_TITLE: &str = "deleted-title";
 }
 
 pub static PADZ_THEME: Lazy<AdaptiveTheme> =
@@ -60,6 +64,10 @@ fn build_light_theme() -> Theme {
         .on_color256(rgb_to_ansi256((255, 235, 59)));
     let title = regular.clone().bold();
     let time = muted.clone().italic();
+    // Semantic list styles
+    let list_index = Style::new().color256(rgb_to_ansi256((196, 140, 0))); // Yellow/gold for regular indexes
+    let deleted_index = Style::new().color256(rgb_to_ansi256((186, 33, 45))); // Red for deleted indexes
+    let deleted_title = muted.clone(); // Muted gray for deleted titles
 
     Theme::new()
         .add(names::REGULAR, regular)
@@ -74,6 +82,9 @@ fn build_light_theme() -> Theme {
         .add(names::INFO, info)
         .add(names::TITLE, title)
         .add(names::TIME, time)
+        .add(names::LIST_INDEX, list_index)
+        .add(names::DELETED_INDEX, deleted_index)
+        .add(names::DELETED_TITLE, deleted_title)
 }
 
 fn build_dark_theme() -> Theme {
@@ -91,6 +102,10 @@ fn build_dark_theme() -> Theme {
         .on_color256(rgb_to_ansi256((229, 185, 0)));
     let title = regular.clone().bold();
     let time = muted.clone().italic();
+    // Semantic list styles
+    let list_index = Style::new().color256(rgb_to_ansi256((255, 214, 10))); // Yellow for regular indexes
+    let deleted_index = Style::new().color256(rgb_to_ansi256((255, 138, 128))); // Red for deleted indexes
+    let deleted_title = muted.clone(); // Muted gray for deleted titles
 
     Theme::new()
         .add(names::REGULAR, regular)
@@ -105,4 +120,7 @@ fn build_dark_theme() -> Theme {
         .add(names::INFO, info)
         .add(names::TITLE, title)
         .add(names::TIME, time)
+        .add(names::LIST_INDEX, list_index)
+        .add(names::DELETED_INDEX, deleted_index)
+        .add(names::DELETED_TITLE, deleted_title)
 }

--- a/src/padz/cli/templates/list.tmp
+++ b/src/padz/cli/templates/list.tmp
@@ -5,7 +5,7 @@
 {% for pad in pads -%}
 {% if pad.is_separator %}
 {% else -%}
-{{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% else %}{{ pad.title | style("title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") }}
+{{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") }}
 {% for match in pad.matches -%}
     {{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}
 {% endfor -%}

--- a/src/padz/cli/templates/list.tmp
+++ b/src/padz/cli/templates/list.tmp
@@ -5,7 +5,7 @@
 {% for pad in pads -%}
 {% if pad.is_separator %}
 {% else -%}
-{{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted") }}{% else %}{{ pad.index | style("regular") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted") }}{% else %}{{ pad.title | style("title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") }}
+{{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% else %}{{ pad.title | style("title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") }}
 {% for match in pad.matches -%}
     {{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}
 {% endfor -%}
@@ -14,4 +14,15 @@
 {% endif -%}
 {% endif -%}
 {% endfor -%}
+{% endif %}
+{% if deleted_help %}
+{{ "Deleted Pads" | style("muted") }}
+
+{{ "These pads are marked for deletion and will be permanently deleted after a month." | style("faint") }}
+{{ "To restore a pad:" | style("faint") }}
+{{ "    padz restore <index>      - Restore specific pads" | style("faint") }}
+{{ "    padz restore              - Restore all deleted pads" | style("faint") }}
+{{ "To permanently delete:" | style("faint") }}
+{{ "    padz purge <index>        - Permanently delete specific pads" | style("faint") }}
+{{ "    padz purge                - Permanently delete all deleted pads" | style("faint") }}
 {% endif %}

--- a/src/padz/model.rs
+++ b/src/padz/model.rs
@@ -117,7 +117,8 @@ pub fn normalize_pad_content(title: &str, body: &str) -> (String, String) {
     // Let's truncate metadata title but keep full title in content.
 
     let display_title = if clean_title.chars().count() > 60 {
-        clean_title.chars().take(60).collect::<String>()
+        let truncated: String = clean_title.chars().take(59).collect();
+        format!("{}…", truncated)
     } else {
         clean_title.to_string()
     };
@@ -210,7 +211,12 @@ mod tests {
     fn test_normalize_truncates_title_metadata() {
         let long_title = "a".repeat(100);
         let (title, content) = normalize_pad_content(&long_title, "Body");
-        assert_eq!(title.len(), 60);
+        // Title should be 59 chars + ellipsis = 60 chars total
+        assert_eq!(title.chars().count(), 60);
+        assert!(
+            title.ends_with('…'),
+            "Truncated title should end with ellipsis"
+        );
         assert_eq!(content, format!("{}\n\nBody", long_title));
     }
 


### PR DESCRIPTION
## Summary

- Yellow indexes for regular pads in list view
- Red indexes and muted gray titles for deleted pads
- Added help text for `padz list --deleted` explaining restore/purge commands
- Non-bold titles in list view (new `list-title` semantic style)

## Changes

**New semantic styles** in `styles.rs`:
- `list-index` → yellow/gold for regular pad numbers
- `list-title` → normal text (not bold) for list titles
- `deleted-index` → red for deleted pad numbers
- `deleted-title` → muted gray for deleted pad titles

**Updated template** (`list.tmp`):
- Uses new semantic styles for proper separation of concerns
- Added `deleted_help` conditional block with usage instructions

**Updated render.rs**:
- Added `render_pad_list_deleted()` for deleted list view with help text

## Result

```
# padz list
    1. First Note                       now
     ↑ yellow  ↑ normal (not bold)

# padz list --deleted
    d1. Second Note                     now
     ↑ red    ↑ muted gray

Deleted Pads
...help text...
```

## Test plan

- [x] All existing tests pass
- [x] Manual verification of styling in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)