### PR TITLE
feat: implement --peek option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "padz"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "padz"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21d8ad60dd5b13a4ee6bd8fa2d5d88965c597c67bce32b5fc49c94f55cb50810"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +712,15 @@ checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1030,6 +1071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1148,7 @@ dependencies = [
 name = "padz"
 version = "0.8.7"
 dependencies = [
+ "assert_cmd",
  "chrono",
  "clap",
  "colored",
@@ -1109,6 +1157,7 @@ dependencies = [
  "flate2",
  "once_cell",
  "outstanding",
+ "predicates",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "serde",
@@ -1205,6 +1254,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1594,6 +1673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1834,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "src/outstanding"]
 
 [package]
 name = "padz"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 description = "A fast, project-aware scratch pad for the command line"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "src/outstanding"]
 
 [package]
 name = "padz"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 description = "A fast, project-aware scratch pad for the command line"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ uuid = { version = "1.19.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"
+assert_cmd = "2.0.16"
+predicates = "3.1.2"
 
 [features]
 default = []

--- a/src/outstanding/lib.rs
+++ b/src/outstanding/lib.rs
@@ -435,7 +435,7 @@ pub fn render_with_color<T: Serialize>(
 ) -> Result<String, Error> {
     let theme = theme.resolve();
     let mut env = Environment::new();
-    register_style_filter(&mut env, theme, use_color);
+    register_filters(&mut env, theme, use_color);
 
     env.add_template_owned("_inline".to_string(), template.to_string())?;
     let tmpl = env.get_template("_inline")?;
@@ -485,7 +485,7 @@ impl Renderer {
     /// Creates a new renderer with explicit color control.
     pub fn with_color(theme: Theme, use_color: bool) -> Self {
         let mut env = Environment::new();
-        register_style_filter(&mut env, theme, use_color);
+        register_filters(&mut env, theme, use_color);
         Self { env }
     }
 
@@ -508,8 +508,8 @@ impl Renderer {
     }
 }
 
-/// Registers the `style` filter on a minijinja environment.
-fn register_style_filter(env: &mut Environment<'static>, theme: Theme, use_color: bool) {
+/// Registers all built-in filters on a minijinja environment.
+fn register_filters(env: &mut Environment<'static>, theme: Theme, use_color: bool) {
     let styles = theme.styles.clone();
     env.add_filter("style", move |value: Value, name: String| -> String {
         let text = value.to_string();
@@ -520,6 +520,11 @@ fn register_style_filter(env: &mut Environment<'static>, theme: Theme, use_color
             styles.apply_plain(&name, &text)
         }
     });
+
+    // Filter to append a newline to the value, enabling explicit line break control.
+    // Usage: {{ content | nl }} outputs content followed by \n
+    //        {{ "" | nl }} outputs just \n (a blank line)
+    env.add_filter("nl", |value: Value| -> String { format!("{}\n", value) });
 }
 
 /// Converts an RGB triplet to the nearest ANSI 256-color palette index.

--- a/src/padz/cli/render.rs
+++ b/src/padz/cli/render.rs
@@ -257,7 +257,16 @@ fn render_pad_list_internal(
         }
 
         let peek_data = if peek {
-            Some(format_as_peek(&dp.pad.content, 3))
+            // Strip the first line (title) to avoid duplication
+            let body_lines: Vec<&str> = dp.pad.content.lines().skip(1).collect();
+            let body = body_lines.join("\n");
+
+            let result = format_as_peek(&body, 3);
+            if result.opening_lines.is_empty() {
+                None
+            } else {
+                Some(result)
+            }
         } else {
             None
         };

--- a/src/padz/cli/render.rs
+++ b/src/padz/cli/render.rs
@@ -72,6 +72,7 @@ struct ListData {
     pin_marker: String,
     help_text: String,
     deleted_help: bool,
+    peek: bool,
 }
 
 #[derive(Serialize)]
@@ -129,6 +130,7 @@ fn render_pad_list_internal(
         pin_marker: PIN_MARKER.to_string(),
         help_text: get_grouped_help(),
         deleted_help: false,
+        peek: false,
     };
 
     if pads.is_empty() {
@@ -294,6 +296,7 @@ fn render_pad_list_internal(
         pin_marker: PIN_MARKER.to_string(),
         help_text: String::new(), // Not used when not empty
         deleted_help: show_deleted_help,
+        peek,
     };
 
     match use_color {

--- a/src/padz/cli/setup.rs
+++ b/src/padz/cli/setup.rs
@@ -220,6 +220,10 @@ pub enum CoreCommands {
         /// Show deleted pads
         #[arg(long)]
         deleted: bool,
+
+        /// Peek at pad content
+        #[arg(long)]
+        peek: bool,
     },
 
     /// Search pads (dedicated command)
@@ -235,6 +239,10 @@ pub enum PadCommands {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1..)]
         indexes: Vec<String>,
+
+        /// Peek at pad content
+        #[arg(long)]
+        peek: bool,
     },
 
     /// Edit a pad in the editor

--- a/src/padz/cli/templates/list.tmp
+++ b/src/padz/cli/templates/list.tmp
@@ -13,6 +13,7 @@
     {{ pad.left_pad }}    And {{ pad.more_matches_count }} more results
 {% endif -%}
 {% if pad.peek -%}
+    
     {{ pad.left_pad }}    {{ pad.peek.opening_lines | style("faint") | indent(8) }}
 {% if pad.peek.truncated_count -%}
     
@@ -22,6 +23,7 @@
 {% if pad.peek.closing_lines -%}
     {{ pad.left_pad }}    {{ pad.peek.closing_lines | style("faint") | indent(8) }}
 {% endif -%}
+
 {% endif -%}
 {% endif -%}
 {% endfor -%}

--- a/src/padz/cli/templates/list.tmp
+++ b/src/padz/cli/templates/list.tmp
@@ -15,12 +15,13 @@
 {% if pad.peek -%}
     
     {{ pad.left_pad }}    {{ pad.peek.opening_lines | style("faint") | indent(8) }}
-{% if pad.peek.truncated_count -%}
+{% if pad.peek.truncated_count %}
     
     {{ pad.left_pad }}                      {{ ("... " ~ pad.peek.truncated_count ~ " lines not shown ...") | style("muted") }}
     
 {% endif -%}
 {% if pad.peek.closing_lines -%}
+    
     {{ pad.left_pad }}    {{ pad.peek.closing_lines | style("faint") | indent(8) }}
 {% endif -%}
 

--- a/src/padz/cli/templates/list.tmp
+++ b/src/padz/cli/templates/list.tmp
@@ -1,42 +1,42 @@
-{% if empty %}{{ "No pads yet, create one with `padz create`" | style("muted") }}
-
+{%- if empty -%}
+{{- "No pads yet, create one with `padz create`" | style("muted") | nl -}}
 {{ help_text }}
-{% else -%}
-{% for pad in pads -%}
-{% if pad.is_separator %}
-{% else -%}
-{{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") }}
-{% for match in pad.matches -%}
-    {{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}
-{% endfor -%}
-{% if pad.more_matches_count > 0 -%}
-    {{ pad.left_pad }}    And {{ pad.more_matches_count }} more results
-{% endif -%}
-{% if pad.peek -%}
-    
-    {{ pad.left_pad }}    {{ pad.peek.opening_lines | style("faint") | indent(8) }}
-{% if pad.peek.truncated_count %}
-    
-    {{ pad.left_pad }}                      {{ ("... " ~ pad.peek.truncated_count ~ " lines not shown ...") | style("muted") }}
-    
-{% endif -%}
-{% if pad.peek.closing_lines -%}
-    
-    {{ pad.left_pad }}    {{ pad.peek.closing_lines | style("faint") | indent(8) }}
-{% endif -%}
-
-{% endif -%}
-{% endif -%}
-{% endfor -%}
-{% endif %}
-{% if deleted_help %}
-{{ "Deleted Pads" | style("muted") }}
-
-{{ "These pads are marked for deletion and will be permanently deleted after a month." | style("faint") }}
-{{ "To restore a pad:" | style("faint") }}
-{{ "    padz restore <index>      - Restore specific pads" | style("faint") }}
-{{ "    padz restore              - Restore all deleted pads" | style("faint") }}
-{{ "To permanently delete:" | style("faint") }}
-{{ "    padz purge <index>        - Permanently delete specific pads" | style("faint") }}
-{{ "    padz purge                - Permanently delete all deleted pads" | style("faint") }}
-{% endif %}
+{%- else -%}
+{%- for pad in pads -%}
+{%- if pad.is_separator -%}
+{{- "" | nl -}}
+{%- else -%}
+{{- pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
+{%- for match in pad.matches -%}
+{{- "    " }}{{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}{{ "" | nl -}}
+{%- endfor -%}
+{%- if pad.more_matches_count > 0 -%}
+{{- "    " }}{{ pad.left_pad }}    And {{ pad.more_matches_count }} more results{{ "" | nl -}}
+{%- endif -%}
+{%- if pad.peek -%}
+{{- "" | nl -}}
+{{- "    " }}{{ pad.left_pad }}    {{ pad.peek.opening_lines | style("faint") | indent(8) | nl -}}
+{%- if pad.peek.truncated_count -%}
+{{- "" | nl -}}
+{{- "    " }}{{ pad.left_pad }}                      {{ ("... " ~ pad.peek.truncated_count ~ " lines not shown ...") | style("muted") | nl -}}
+{{- "" | nl -}}
+{%- endif -%}
+{%- if pad.peek.closing_lines -%}
+{{- "    " }}{{ pad.left_pad }}    {{ pad.peek.closing_lines | style("faint") | indent(8) | nl -}}
+{%- endif -%}
+{{- "" | nl -}}
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+{%- if deleted_help -%}
+{{- "Deleted Pads" | style("muted") | nl -}}
+{{- "" | nl -}}
+{{- "These pads are marked for deletion and will be permanently deleted after a month." | style("faint") | nl -}}
+{{- "To restore a pad:" | style("faint") | nl -}}
+{{- "    padz restore <index>      - Restore specific pads" | style("faint") | nl -}}
+{{- "    padz restore              - Restore all deleted pads" | style("faint") | nl -}}
+{{- "To permanently delete:" | style("faint") | nl -}}
+{{- "    padz purge <index>        - Permanently delete specific pads" | style("faint") | nl -}}
+{{- "    padz purge                - Permanently delete all deleted pads" | style("faint") | nl -}}
+{%- endif -%}

--- a/src/padz/cli/templates/list.tmp
+++ b/src/padz/cli/templates/list.tmp
@@ -12,6 +12,17 @@
 {% if pad.more_matches_count > 0 -%}
     {{ pad.left_pad }}    And {{ pad.more_matches_count }} more results
 {% endif -%}
+{% if pad.peek -%}
+    {{ pad.left_pad }}    {{ pad.peek.opening_lines | style("faint") | indent(8) }}
+{% if pad.peek.truncated_count -%}
+    
+    {{ pad.left_pad }}                      {{ ("... " ~ pad.peek.truncated_count ~ " lines not shown ...") | style("muted") }}
+    
+{% endif -%}
+{% if pad.peek.closing_lines -%}
+    {{ pad.left_pad }}    {{ pad.peek.closing_lines | style("faint") | indent(8) }}
+{% endif -%}
+{% endif -%}
 {% endif -%}
 {% endfor -%}
 {% endif %}

--- a/src/padz/lib.rs
+++ b/src/padz/lib.rs
@@ -99,4 +99,5 @@ pub mod error;
 pub mod index;
 pub mod init;
 pub mod model;
+pub mod peek;
 pub mod store;

--- a/src/padz/peek.rs
+++ b/src/padz/peek.rs
@@ -1,0 +1,110 @@
+//! # Peek Preview Logic
+//!
+//! This module handles the formatting of pad content for "peek" views.
+//! It truncates content based on configurable line limits while stripping blank lines.
+
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct PeekResult {
+    pub opening_lines: String,
+    pub truncated_count: Option<usize>,
+    pub closing_lines: Option<String>,
+}
+
+/// Formats raw pad content into a peek view.
+///
+/// Rules:
+/// 1. Blank lines are ignored (stripped).
+/// 2. If content lines <= (peek_line_num * 2) + 3, show full content (no truncation).
+/// 3. Otherwise show:
+///    - Opening lines (up to peek_line_num)
+///    - Truncated count
+///    - Closing lines (up to peek_line_num)
+pub fn format_as_peek(raw_content: &str, peek_line_num: usize) -> PeekResult {
+    // 1. Filter out blank lines
+    let non_blank_lines: Vec<&str> = raw_content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+
+    let total_lines = non_blank_lines.len();
+
+    // 2. Calculate threshold: (peek_line_num * 2) + 3
+    let threshold = (peek_line_num * 2) + 3;
+
+    if total_lines <= threshold {
+        // No truncation needed
+        return PeekResult {
+            opening_lines: non_blank_lines.join("\n"),
+            truncated_count: None,
+            closing_lines: None,
+        };
+    }
+
+    // 3. Truncate
+    let opening = non_blank_lines[..peek_line_num].join("\n");
+    let closing = non_blank_lines[total_lines - peek_line_num..].join("\n");
+    let truncated_cnt = total_lines - (peek_line_num * 2);
+
+    PeekResult {
+        opening_lines: opening,
+        truncated_count: Some(truncated_cnt),
+        closing_lines: Some(closing),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peek_empty() {
+        let res = format_as_peek("", 3);
+        assert_eq!(res.opening_lines, "");
+        assert_eq!(res.truncated_count, None);
+        assert_eq!(res.closing_lines, None);
+    }
+
+    #[test]
+    fn test_peek_short_no_truncation() {
+        // threshold for 3 is (3*2)+3 = 9.
+        // 5 lines < 9.
+        let content = "One\nTwo\nThree\nFour\nFive";
+        let res = format_as_peek(content, 3);
+        assert_eq!(res.opening_lines, "One\nTwo\nThree\nFour\nFive");
+        assert_eq!(res.truncated_count, None);
+        assert_eq!(res.closing_lines, None);
+    }
+
+    #[test]
+    fn test_peek_strips_blanks() {
+        let content = "One\n\nTwo\n   \nThree";
+        let res = format_as_peek(content, 3);
+        assert_eq!(res.opening_lines, "One\nTwo\nThree");
+        assert_eq!(res.truncated_count, None);
+    }
+
+    #[test]
+    fn test_peek_exact_threshold() {
+        // Threshold 9. Input 9 lines.
+        let lines: Vec<String> = (1..=9).map(|i| i.to_string()).collect();
+        let content = lines.join("\n");
+        let res = format_as_peek(&content, 3);
+        assert_eq!(res.opening_lines, content); // Joined lines
+        assert_eq!(res.truncated_count, None);
+    }
+
+    #[test]
+    fn test_peek_truncation() {
+        // Threshold 9. Input 10 lines.
+        // peek=3. opening=3, closing=3. truncated=4 (Wait: 10 - 6 = 4).
+        let lines: Vec<String> = (1..=10).map(|i| i.to_string()).collect();
+        let content = lines.join("\n");
+        let res = format_as_peek(&content, 3);
+
+        assert_eq!(res.opening_lines, "1\n2\n3");
+        assert_eq!(res.truncated_count, Some(4));
+        assert_eq!(res.closing_lines, Some("8\n9\n10".to_string()));
+    }
+}

--- a/tests/peek_integration.rs
+++ b/tests/peek_integration.rs
@@ -1,0 +1,84 @@
+use assert_cmd::Command;
+
+#[test]
+fn test_list_peek() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("db.sqlite");
+
+    // Create a long pad
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.env("PADZ_DB", &db_path)
+        .env("PADZ_HOME", temp_dir.path());
+    cmd.arg("n")
+        .arg("--no-editor")
+        .arg("Long Pad")
+        .assert()
+        .success();
+
+    // Since we created it, we need to update its content to be long enough to truncate
+    // But `create --no-editor` makes an empty pad.
+    // We can't easily edit it via CLI without an editor.
+    // However, we can use `padz config` or just rely on the fact that we can't easily populate it?
+    // Wait, `create` takes no content arg.
+    // Ideally we'd use the library directly but this is an integration test using binary.
+
+    // Maybe we can import a file?
+    let import_file = temp_dir.path().join("long.txt");
+    let lines: Vec<String> = (1..=20).map(|i| format!("Line {}", i)).collect();
+    let content = format!("Long Pad Title\n\n{}", lines.join("\n"));
+    std::fs::write(&import_file, content).unwrap();
+
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path()) // Ensure it uses temp home
+        .arg("import")
+        .arg(import_file.to_str().unwrap())
+        .assert()
+        .success();
+
+    // Now list with peek
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("list")
+        .arg("--peek")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Line 1")) // Opening
+        .stdout(predicates::str::contains("Line 2")) // Limit is 3 (Title, Line 1, Line 2)
+        .stdout(predicates::str::contains("lines not shown")) // Truncation message
+        .stdout(predicates::str::contains("Line 20")); // Closing
+}
+
+#[test]
+fn test_view_peek_truncation() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    // Import a long pad
+    let import_file = temp_dir.path().join("long-view.txt");
+    let lines: Vec<String> = (1..=20).map(|i| format!("ViewLine {}", i)).collect();
+    let content = format!("Long View Title\n\n{}", lines.join("\n"));
+    std::fs::write(&import_file, content).unwrap();
+
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("import")
+        .arg(import_file.to_str().unwrap())
+        .assert()
+        .success();
+
+    // Now view with peek (should reuse list rendering logic)
+    // Index should be 1
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("view")
+        .arg("1")
+        .arg("--peek")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("ViewLine 1"))
+        .stdout(predicates::str::contains("lines not shown"))
+        .stdout(predicates::str::contains("ViewLine 20"));
+}

--- a/tests/peek_integration.rs
+++ b/tests/peek_integration.rs
@@ -1,4 +1,6 @@
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::prelude::*;
 
 #[test]
 fn test_list_peek() {
@@ -81,4 +83,146 @@ fn test_view_peek_truncation() {
         .stdout(predicates::str::contains("ViewLine 1"))
         .stdout(predicates::str::contains("lines not shown"))
         .stdout(predicates::str::contains("ViewLine 20"));
+}
+
+#[test]
+fn test_peek_spacing_and_limits() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    // Create a pad just under limit (9 lines total content -> title + 8 lines)
+    // peek=3. Threshold = (3*2)+3 = 9.
+    // If we have 9 lines of BODY, total content is Title\n\nBody.
+    // But `format_as_peek` takes just the body (as we stripped title in render.rs).
+    // So if body has 9 lines: 9 <= 9 -> Full.
+    // If body has 10 lines: 10 > 9 -> Truncated.
+
+    // Test case 1: 9 lines body (Threshold) - Should be FULL
+    let body_9: Vec<String> = (1..=9).map(|i| format!("Line {}", i)).collect();
+    let content_9 = format!("Title 9\n\n{}", body_9.join("\n"));
+    let path_9 = temp_dir.path().join("limit_9.txt");
+    std::fs::write(&path_9, content_9).unwrap();
+
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("import")
+        .arg(path_9.to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("list")
+        .arg("--peek")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Line 9"))
+        .stdout(predicates::str::contains("lines not shown").not()); // Should NOT show truncation
+
+    // Test case 2: 10 lines body - Should be TRUNCATED with correct spacing
+    let body_10: Vec<String> = (1..=10).map(|i| format!("Line {}", i)).collect();
+    let content_10 = format!("Title 10\n\n{}", body_10.join("\n"));
+    let path_10 = temp_dir.path().join("limit_10.txt");
+    std::fs::write(&path_10, content_10).unwrap();
+
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("import")
+        .arg(path_10.to_str().unwrap())
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("padz").unwrap();
+    let output = cmd
+        .current_dir(temp_dir.path())
+        .env("PADZ_HOME", temp_dir.path())
+        .arg("list")
+        .arg("--peek")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Find output for Title 10
+    // Check for blank line, truncated message, blank line pattern
+    // The truncated message is "... 4 lines not shown ..." (10 - 2*3 = 4)
+    // We expect:
+    // Line 3
+    // <blank>
+    // ... 4 lines not shown ...
+    // <blank>
+    // Line 8
+
+    // Note: The template adds indent.
+    // "    Line 3"
+    // "" (empty line)
+    // "                          ... 4 lines not shown ..."
+    // "" (empty line)
+    // "    Line 8"
+
+    // We can regex verify or just contains
+    // assert!(stdout.contains("Line 3\n\n"), "Missing blank line after opening");
+    // assert!(stdout.contains("\n\n    Line 8"), "Missing blank line before closing");
+    // Indentation makes exact matching tricky, let's look for newlines.
+
+    // Regex for: Line 3 \s* \n \s* \n .* not shown
+    // Since we are mocking tests, let's just assert existence of the full block sequence?
+
+    // Let's assert that "Line 3" is followed by at least two newlines before "... lines not shown"
+    // and "... lines not shown" is followed by at least two newlines before "Line 8".
+    // Or just check if the string "Line 3\n\n" is present (might fail due to indent on next line).
+
+    // Actually, `list.tmp`:
+    // {{ pad.left_pad }}    ... opening_lines ...
+    // <newline>
+    // {{ pad.left_pad }} ... truncated ...
+
+    // If `opening_lines` ends with newline?
+    // In `peek.rs`: opening = non_blank_lines[..3].join("\n").
+    // So "Line 1\nLine 2\nLine 3". No trailing newline.
+
+    // Template:
+    // {{ ... opening_lines ... }}
+    // {% if truncated ... %}
+    // <newline>
+    // {{ ... truncated ... }}
+
+    // So output: "...Line 3\n\n...truncated..."
+    // Yes, that should correspond to one blank line.
+
+    let truncated_idx = stdout
+        .find("... 4 lines not shown ...")
+        .expect("Should fulfill truncation logic");
+    let opening_end = stdout[..truncated_idx]
+        .rfind("Line 3")
+        .expect("Should have opening lines");
+
+    // Check text between opening end and truncation msg
+    let gap = &stdout[opening_end + 6..truncated_idx];
+    // "Line 3" len is 6.
+    // gap should match `\n\n\s*`
+
+    assert!(
+        gap.contains("\n\n"),
+        "Gap between opening and truncation should have blank line. Got: {:?}",
+        gap
+    );
+
+    let closing_start = stdout[truncated_idx..]
+        .find("Line 8")
+        .expect("Should have closing lines")
+        + truncated_idx;
+    let gap2 = &stdout[truncated_idx + "... 4 lines not shown ...".len()..closing_start];
+
+    assert!(
+        gap.contains("\n"),
+        "Gap should have newline. Got: {:?}",
+        gap
+    );
+    // There should be enough vertical space. It depends on how jinja renders newlines+indent.
+    // We expect at least a blank line visually.
+    // "Line 3\n    \n                          ..."
+    // That gives 1 blank line.
 }


### PR DESCRIPTION
Implements the --peek flag for list and view commands to preview pad content.

## Changes
- Implements `format_as_peek` logic.
- Adds `--peek` flag to list and view commands.
- Updates rendering logic to show truncated content.
- Adds integration tests.