### PR TITLE
feat: add restore command for soft-deleted pads

### DIFF
--- a/src/padz/cli/commands.rs
+++ b/src/padz/cli/commands.rs
@@ -117,6 +117,7 @@ pub fn run() -> Result<()> {
             PadCommands::Edit { indexes } => handle_edit(&mut ctx, indexes),
             PadCommands::Open { indexes } => handle_open(&mut ctx, indexes),
             PadCommands::Delete { indexes } => handle_delete(&mut ctx, indexes),
+            PadCommands::Restore { indexes } => handle_restore(&mut ctx, indexes),
             PadCommands::Pin { indexes } => handle_pin(&mut ctx, indexes),
             PadCommands::Unpin { indexes } => handle_unpin(&mut ctx, indexes),
             PadCommands::Path { indexes } => handle_paths(&mut ctx, indexes),
@@ -261,6 +262,12 @@ fn handle_open(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
 
 fn handle_delete(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     let result = ctx.api.delete_pads(ctx.scope, &indexes)?;
+    print_messages(&result.messages);
+    Ok(())
+}
+
+fn handle_restore(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
+    let result = ctx.api.restore_pads(ctx.scope, &indexes)?;
     print_messages(&result.messages);
     Ok(())
 }

--- a/src/padz/cli/setup.rs
+++ b/src/padz/cli/setup.rs
@@ -77,7 +77,7 @@ impl CommandGroup {
     pub fn for_command(name: &str) -> Option<Self> {
         match name {
             "create" | "list" | "search" => Some(CommandGroup::Core),
-            "view" | "edit" | "open" | "delete" | "pin" | "unpin" | "path" => {
+            "view" | "edit" | "open" | "delete" | "restore" | "pin" | "unpin" | "path" => {
                 Some(CommandGroup::Pad)
             }
             "purge" | "export" | "import" => Some(CommandGroup::Data),
@@ -158,6 +158,7 @@ pub fn print_subcommand_help(command: &Option<Commands>) {
             PadCommands::Edit { .. } => "edit",
             PadCommands::Open { .. } => "open",
             PadCommands::Delete { .. } => "delete",
+            PadCommands::Restore { .. } => "restore",
             PadCommands::Pin { .. } => "pin",
             PadCommands::Unpin { .. } => "unpin",
             PadCommands::Path { .. } => "path",
@@ -291,8 +292,16 @@ pub enum PadCommands {
         indexes: Vec<String>,
     },
 
+    /// Restore deleted pads
+    #[command(display_order = 14)]
+    Restore {
+        /// Indexes of deleted pads (e.g. d1 d2 or just 1 2)
+        #[arg(required = true, num_args = 1..)]
+        indexes: Vec<String>,
+    },
+
     /// Pin one or more pads
-    #[command(alias = "p", display_order = 14)]
+    #[command(alias = "p", display_order = 15)]
     Pin {
         /// Indexes of the pads (e.g. 1 3 5)
         #[arg(required = true, num_args = 1..)]
@@ -300,7 +309,7 @@ pub enum PadCommands {
     },
 
     /// Unpin one or more pads
-    #[command(alias = "u", display_order = 15)]
+    #[command(alias = "u", display_order = 16)]
     Unpin {
         /// Indexes of the pads (e.g. p1 p2 p3)
         #[arg(required = true, num_args = 1..)]
@@ -308,7 +317,7 @@ pub enum PadCommands {
     },
 
     /// Print the file path to one or more pads
-    #[command(display_order = 16)]
+    #[command(display_order = 17)]
     Path {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1..)]

--- a/src/padz/commands/mod.rs
+++ b/src/padz/commands/mod.rs
@@ -77,6 +77,7 @@ pub mod init;
 pub mod paths;
 pub mod pinning;
 pub mod purge;
+pub mod restore;
 
 pub mod update;
 pub mod view;

--- a/src/padz/commands/restore.rs
+++ b/src/padz/commands/restore.rs
@@ -1,0 +1,195 @@
+use crate::commands::{CmdMessage, CmdResult};
+use crate::error::Result;
+use crate::index::PadSelector;
+use crate::model::Scope;
+use crate::store::DataStore;
+
+use super::helpers::resolve_selectors;
+
+pub fn run<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    selectors: &[PadSelector],
+) -> Result<CmdResult> {
+    let resolved = resolve_selectors(store, scope, selectors)?;
+    let mut result = CmdResult::default();
+
+    for (display_index, uuid) in resolved {
+        let mut pad = store.get_pad(&uuid, scope)?;
+        pad.metadata.is_deleted = false;
+        pad.metadata.deleted_at = None;
+        // Keep original created_at so the pad appears in its original position
+        store.save_pad(&pad, scope)?;
+        result.add_message(CmdMessage::success(format!(
+            "Pad restored ({}): {}",
+            display_index, pad.metadata.title
+        )));
+        result.affected_pads.push(pad);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{create, delete, get};
+    use crate::index::DisplayIndex;
+    use crate::model::Scope;
+    use crate::store::memory::InMemoryStore;
+
+    #[test]
+    fn restores_deleted_pad() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Title".into(), "".into()).unwrap();
+
+        // Delete it
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Regular(1))],
+        )
+        .unwrap();
+
+        // Verify it's deleted
+        let deleted = get::run(
+            &store,
+            Scope::Project,
+            get::PadFilter {
+                status: get::PadStatusFilter::Deleted,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(deleted.listed_pads.len(), 1);
+        assert!(matches!(
+            deleted.listed_pads[0].index,
+            DisplayIndex::Deleted(1)
+        ));
+
+        // Restore it
+        let result = run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Deleted(1))],
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("Pad restored"));
+        assert!(result.messages[0].content.contains("Title"));
+
+        // Verify it's active again
+        let active = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        assert_eq!(active.listed_pads.len(), 1);
+        assert!(matches!(
+            active.listed_pads[0].index,
+            DisplayIndex::Regular(1)
+        ));
+
+        // Verify deleted list is empty
+        let deleted_after = get::run(
+            &store,
+            Scope::Project,
+            get::PadFilter {
+                status: get::PadStatusFilter::Deleted,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(deleted_after.listed_pads.len(), 0);
+    }
+
+    #[test]
+    fn restores_multiple_pads() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "A".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "B".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "C".into(), "".into()).unwrap();
+
+        // Delete all three
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[
+                PadSelector::Index(DisplayIndex::Regular(1)),
+                PadSelector::Index(DisplayIndex::Regular(2)),
+                PadSelector::Index(DisplayIndex::Regular(3)),
+            ],
+        )
+        .unwrap();
+
+        // Restore two of them
+        let result = run(
+            &mut store,
+            Scope::Project,
+            &[
+                PadSelector::Index(DisplayIndex::Deleted(1)),
+                PadSelector::Index(DisplayIndex::Deleted(3)),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 2);
+
+        // Verify 2 active, 1 deleted
+        let active = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        assert_eq!(active.listed_pads.len(), 2);
+
+        let deleted = get::run(
+            &store,
+            Scope::Project,
+            get::PadFilter {
+                status: get::PadStatusFilter::Deleted,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(deleted.listed_pads.len(), 1);
+    }
+
+    #[test]
+    fn preserves_original_created_at() {
+        let mut store = InMemoryStore::new();
+
+        // Create two pads with a small delay between them
+        create::run(&mut store, Scope::Project, "Older".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Newer".into(), "".into()).unwrap();
+
+        // Get original created_at of the older pad (which is now index 2 since newest first)
+        let original = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let older_pad = original
+            .listed_pads
+            .iter()
+            .find(|dp| dp.pad.metadata.title == "Older")
+            .unwrap();
+        let original_created_at = older_pad.pad.metadata.created_at;
+
+        // Delete and restore the older pad
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Regular(2))],
+        )
+        .unwrap();
+
+        run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Index(DisplayIndex::Deleted(1))],
+        )
+        .unwrap();
+
+        // Verify created_at is preserved
+        let after = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let restored_pad = after
+            .listed_pads
+            .iter()
+            .find(|dp| dp.pad.metadata.title == "Older")
+            .unwrap();
+
+        assert_eq!(restored_pad.pad.metadata.created_at, original_created_at);
+        assert!(!restored_pad.pad.metadata.is_deleted);
+        assert!(restored_pad.pad.metadata.deleted_at.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `padz restore <ids>` command to restore soft-deleted pads back to active status
- Supports bare numbers (`restore 3` → restores `d3`) and explicit deleted indexes (`restore d3`)
- Supports ranges (`restore 1-3` → restores `d1`, `d2`, `d3`) and mixed input
- Preserves original `created_at` date so restored pads maintain their original ordering

## Test plan
- [x] Unit tests for d-prefix normalization (4 tests in `api.rs`)
- [x] Unit tests for restore logic (3 tests in `commands/restore.rs`)
- [x] All 75 tests pass
- [x] Clippy clean
- [x] Manual end-to-end testing: create → delete → restore → verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)