### PR TITLE
feat: improve nested repo detection for padz datastore

### DIFF
--- a/live-tests/test_nested_repo_detection.sh
+++ b/live-tests/test_nested_repo_detection.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env zsh
+# Test nested repo detection: child repo should use parent's .padz
+
+set -e
+
+echo "=== Testing Nested Repo Detection ==="
+
+# The live-tests/run script creates a git repo in the temp dir.
+# We need to run `padz init` to create the .padz directory.
+
+echo ""
+echo "Step 0: Initialize padz in parent repo"
+# Manually create .padz since the test dir is inside the real padz repo
+# and `padz init` would find the parent's .padz
+mkdir -p .padz
+echo "Initialized .padz in parent repo"
+
+echo ""
+echo "Step 1: Create a pad in parent repo"
+padz n --no-editor "Parent Pad"
+padz ls
+echo "Created pad in parent repo"
+
+echo ""
+echo "Step 2: Create child repo (git only, no .padz)"
+mkdir -p child-repo
+cd child-repo
+git init --quiet
+echo "Created child-repo with .git but no .padz"
+
+echo ""
+echo "Step 3: Verify from child repo we can see parent's pads"
+padz ls
+
+PAD_COUNT=$(padz ls 2>/dev/null | grep -c "Parent Pad" || echo 0)
+[[ "$PAD_COUNT" -eq "1" ]] && echo "SUCCESS: Child repo sees parent's pad" || { echo "FAILURE: Child repo cannot see parent's pad (count=$PAD_COUNT)"; exit 1; }
+
+echo ""
+echo "Step 4: Create a pad from child repo (should go to parent's .padz)"
+padz n --no-editor "Child Pad"
+padz ls
+
+PAD_COUNT=$(padz ls 2>/dev/null | grep -c "Pad" || echo 0)
+[[ "$PAD_COUNT" -eq "2" ]] && echo "SUCCESS: Pads created from child go to parent's .padz" || { echo "FAILURE: Expected 2 pads, got $PAD_COUNT"; exit 1; }
+
+echo ""
+echo "Step 5: Verify pads are stored in parent's .padz, not child"
+[[ ! -d ".padz" ]] && echo "SUCCESS: No .padz in child repo" || { echo "FAILURE: .padz directory was created in child repo"; exit 1; }
+
+cd ..
+[[ -d ".padz" ]] && echo "SUCCESS: .padz exists in parent repo" || { echo "FAILURE: .padz not found in parent repo"; exit 1; }
+
+echo ""
+echo "Step 6: Test deeply nested repos"
+mkdir -p child-repo/grandchild-repo
+cd child-repo/grandchild-repo
+git init --quiet
+echo "Created grandchild-repo with .git"
+
+padz n --no-editor "Grandchild Pad"
+PAD_COUNT=$(padz ls 2>/dev/null | grep -c "Pad" || echo 0)
+[[ "$PAD_COUNT" -eq "3" ]] && echo "SUCCESS: Deeply nested repos also use ancestor's .padz" || { echo "FAILURE: Expected 3 pads from grandchild, got $PAD_COUNT"; exit 1; }
+
+cd ../..
+
+echo ""
+echo "Step 7: Test child repo with its own .padz takes precedence"
+mkdir -p independent-child
+cd independent-child
+git init --quiet
+mkdir -p .padz
+
+padz n --no-editor "Independent Pad"
+INDEPENDENT_COUNT=$(padz ls 2>/dev/null | grep -c "Independent Pad" || echo 0)
+TOTAL_COUNT=$(padz ls 2>/dev/null | grep -c "Pad" || echo 0)
+
+[[ "$INDEPENDENT_COUNT" -eq "1" && "$TOTAL_COUNT" -eq "1" ]] && echo "SUCCESS: Child with own .padz is independent" || { echo "FAILURE: Expected only 1 independent pad, got total=$TOTAL_COUNT independent=$INDEPENDENT_COUNT"; exit 1; }
+
+cd ..
+
+echo ""
+echo "=== All nested repo detection tests PASSED ==="

--- a/src/padz/init.rs
+++ b/src/padz/init.rs
@@ -2,8 +2,8 @@ use crate::api::{PadzApi, PadzPaths};
 use crate::config::PadzConfig;
 use crate::model::Scope;
 use crate::store::fs::FileStore;
-use directories::ProjectDirs;
-use std::path::Path;
+use directories::{BaseDirs, ProjectDirs};
+use std::path::{Path, PathBuf};
 
 pub struct PadzContext {
     pub api: PadzApi<FileStore>,
@@ -11,8 +11,48 @@ pub struct PadzContext {
     pub config: PadzConfig,
 }
 
+/// Find the project root by walking up from cwd looking for a directory
+/// that has both .git and .padz. If a directory has .git but no .padz,
+/// continue searching upward (to support nested repos where parent has padz).
+/// Returns None if no matching directory is found before reaching home or root.
+pub fn find_project_root(cwd: &Path) -> Option<PathBuf> {
+    let home_dir = BaseDirs::new().map(|bd| bd.home_dir().to_path_buf());
+    let mut current = cwd.to_path_buf();
+
+    loop {
+        let git_dir = current.join(".git");
+        let padz_dir = current.join(".padz");
+
+        // Found a repo with padz - use it
+        if git_dir.exists() && padz_dir.exists() {
+            return Some(current);
+        }
+
+        // Check stop conditions: reached home dir or volume root
+        if let Some(ref home) = home_dir {
+            if &current == home {
+                return None;
+            }
+        }
+
+        // Try to move up to parent
+        match current.parent() {
+            Some(parent) if parent != current => {
+                current = parent.to_path_buf();
+            }
+            _ => {
+                // Reached filesystem root
+                return None;
+            }
+        }
+    }
+}
+
 pub fn initialize(cwd: &Path, use_global: bool) -> PadzContext {
-    let project_padz_dir = cwd.join(".padz");
+    // Try to find a project root with both .git and .padz
+    let project_padz_dir = find_project_root(cwd)
+        .map(|root| root.join(".padz"))
+        .unwrap_or_else(|| cwd.join(".padz"));
 
     let proj_dirs =
         ProjectDirs::from("com", "padz", "padz").expect("Could not determine config dir");
@@ -40,4 +80,123 @@ pub fn initialize(cwd: &Path, use_global: bool) -> PadzContext {
     let api = PadzApi::new(store, paths);
 
     PadzContext { api, scope, config }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_find_project_root_with_git_and_padz() {
+        // Setup: single repo with both .git and .padz
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::create_dir(root.join(".padz")).unwrap();
+
+        let result = find_project_root(root);
+        assert_eq!(result, Some(root.to_path_buf()));
+    }
+
+    #[test]
+    fn test_find_project_root_git_only_continues_up() {
+        // Setup: child repo with .git only, parent with both .git and .padz
+        let temp = TempDir::new().unwrap();
+        let parent = temp.path();
+        let child = parent.join("child-repo");
+
+        fs::create_dir(&child).unwrap();
+        fs::create_dir(parent.join(".git")).unwrap();
+        fs::create_dir(parent.join(".padz")).unwrap();
+        fs::create_dir(child.join(".git")).unwrap();
+        // child has NO .padz
+
+        let result = find_project_root(&child);
+        assert_eq!(result, Some(parent.to_path_buf()));
+    }
+
+    #[test]
+    fn test_find_project_root_nested_repos_child_has_padz() {
+        // Setup: child repo with both .git and .padz should be used
+        let temp = TempDir::new().unwrap();
+        let parent = temp.path();
+        let child = parent.join("child-repo");
+
+        fs::create_dir(&child).unwrap();
+        fs::create_dir(parent.join(".git")).unwrap();
+        fs::create_dir(parent.join(".padz")).unwrap();
+        fs::create_dir(child.join(".git")).unwrap();
+        fs::create_dir(child.join(".padz")).unwrap();
+
+        let result = find_project_root(&child);
+        assert_eq!(result, Some(child.clone()));
+    }
+
+    #[test]
+    fn test_find_project_root_deep_nested() {
+        // Setup: deeply nested path finds grandparent with .git and .padz
+        let temp = TempDir::new().unwrap();
+        let grandparent = temp.path();
+        let parent = grandparent.join("parent");
+        let child = parent.join("child");
+
+        fs::create_dir_all(&child).unwrap();
+        fs::create_dir(grandparent.join(".git")).unwrap();
+        fs::create_dir(grandparent.join(".padz")).unwrap();
+        // parent and child have no .git or .padz
+
+        let result = find_project_root(&child);
+        assert_eq!(result, Some(grandparent.to_path_buf()));
+    }
+
+    #[test]
+    fn test_find_project_root_no_git_no_padz() {
+        // Setup: no .git or .padz anywhere in temp dir
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("some").join("deep").join("path");
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = find_project_root(&dir);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_project_root_padz_only_no_git() {
+        // Setup: .padz without .git should not match
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir(root.join(".padz")).unwrap();
+        // No .git
+
+        let result = find_project_root(root);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_project_root_multiple_nested_git_only_repos() {
+        // Setup: multiple nested repos, only topmost has .padz
+        // grandparent-repo/ (.git + .padz)
+        //   parent-repo/ (.git only)
+        //     child-repo/ (.git only)
+        let temp = TempDir::new().unwrap();
+        let grandparent = temp.path();
+        let parent = grandparent.join("parent-repo");
+        let child = parent.join("child-repo");
+
+        fs::create_dir_all(&child).unwrap();
+        fs::create_dir(grandparent.join(".git")).unwrap();
+        fs::create_dir(grandparent.join(".padz")).unwrap();
+        fs::create_dir(parent.join(".git")).unwrap();
+        fs::create_dir(child.join(".git")).unwrap();
+
+        // From child, should find grandparent
+        let result = find_project_root(&child);
+        assert_eq!(result, Some(grandparent.to_path_buf()));
+
+        // From parent, should also find grandparent
+        let result = find_project_root(&parent);
+        assert_eq!(result, Some(grandparent.to_path_buf()));
+    }
 }


### PR DESCRIPTION
## Summary

- Implements improved project/git detection for padz datastore location
- When in a child repo with `.git` but no `.padz`, padz now walks up to find a parent repo with both `.git` and `.padz`
- Enables sharing a single padz store across nested repositories (monorepo pattern)

## Changes

- Added `find_project_root()` function that walks up the directory tree looking for a directory with both `.git` AND `.padz`
- If a directory has `.git` but no `.padz`, continues searching upward (key behavior change)
- Stops at home directory or filesystem root

## Test plan

- [x] Added 7 unit tests covering all detection scenarios
- [x] All 84 existing unit tests pass
- [x] Created live integration test (`live-tests/test_nested_repo_detection.sh`) that verifies:
  - Child repo sees parent's pads
  - Pads created from child go to parent's `.padz`
  - Deeply nested repos work correctly
  - Child repo with its own `.padz` remains independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)