### PR TITLE
feat: Smart Create Content (Clipboard & Piped Input)

### DIFF
--- a/live-tests/smart_create.sh
+++ b/live-tests/smart_create.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+echo "--- Starting Smart Create Tests ---"
+
+echo "1. Testing Piped Input..."
+echo -e "Piped Title\n\nPiped Body" | padz create
+
+echo "Listing pads to verify Piped Input..."
+padz list | grep "Piped Title" || exit 1
+padz view 1 | grep "Piped Body" || exit 1
+
+echo "PASS: Piped input test"
+
+echo "2. Testing Clipboard..."
+
+mkdir -p ./bin
+
+# Create mock pbpaste using checking single line writes
+echo '#!/bin/sh' > ./bin/pbpaste
+echo 'echo "Clipboard Title"' >> ./bin/pbpaste
+echo 'echo ""' >> ./bin/pbpaste
+echo 'echo "Clipboard Body"' >> ./bin/pbpaste
+chmod +x ./bin/pbpaste
+
+# Create fake editor to avoid blocking
+echo '#!/bin/sh' > ./bin/fake-editor
+chmod +x ./bin/fake-editor
+
+# Add to PATH and set EDITOR
+export PATH="$(pwd)/bin:$PATH"
+export EDITOR="fake-editor"
+
+echo "Running padz create (from clipboard)..."
+# Must redirect stdin from /dev/null to prevent padz from reading the rest of this script
+# because the test runner feeds the script via stdin/redirection.
+padz create </dev/null
+
+echo "Listing pads to verify Clipboard Input..."
+padz list | grep "Clipboard Title" || exit 1
+# Assuming newest is 1
+padz view 1 | grep "Clipboard Body" || exit 1
+
+echo "PASS: Clipboard test"
+echo "--- All Tests Passed ---"

--- a/src/padz/clipboard.rs
+++ b/src/padz/clipboard.rs
@@ -139,6 +139,96 @@ pub fn format_for_clipboard(title: &str, content: &str) -> String {
     }
 }
 
+/// Reads text from the system clipboard in an OS-specific way.
+/// - macOS: uses pbpaste
+/// - Linux: uses xclip or xsel
+/// - Windows: uses powershell Get-Clipboard
+pub fn get_from_clipboard() -> Result<String> {
+    #[cfg(target_os = "macos")]
+    {
+        get_macos()
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        get_linux()
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        get_windows()
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        Err(PadzError::Api(
+            "Clipboard not supported on this platform".to_string(),
+        ))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn get_macos() -> Result<String> {
+    let output = Command::new("pbpaste")
+        .output()
+        .map_err(|e| PadzError::Api(format!("Failed to execute pbpaste: {}", e)))?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout)
+            .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e)))
+    } else {
+        Err(PadzError::Api("pbpaste exited with error".to_string()))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn get_linux() -> Result<String> {
+    // Try xclip first
+    let result = Command::new("xclip")
+        .args(["-selection", "clipboard", "-o"])
+        .output();
+
+    match result {
+        Ok(output) if output.status.success() => {
+            return String::from_utf8(output.stdout)
+                .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e)));
+        }
+        _ => {}
+    }
+
+    // Try xsel as fallback
+    let result = Command::new("xsel")
+        .args(["--clipboard", "--output"])
+        .output();
+
+    match result {
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
+            .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e))),
+        Ok(_) => Err(PadzError::Api("xsel exited with error".to_string())),
+        Err(e) => Err(PadzError::Api(format!(
+            "Failed to execute xclip or xsel: {}. Install xclip or xsel.",
+            e
+        ))),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn get_windows() -> Result<String> {
+    let output = Command::new("powershell")
+        .args(["-command", "Get-Clipboard"])
+        .output()
+        .map_err(|e| PadzError::Api(format!("Failed to execute powershell: {}", e)))?;
+
+    if output.status.success() {
+        // PowerShell Get-Clipboard usually returns text with \r\n, trim if needed or keep as is?
+        // Let's keep as is but convert bytes.
+        String::from_utf8(output.stdout)
+            .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e)))
+    } else {
+        Err(PadzError::Api("powershell exited with error".to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds support for creating pads from:
1. Clipboard content (when no title is provided).
2. Piped input (skips editor).

Includes cross-platform clipboard support and live tests.