### PR TITLE
feat(cli): differentiate -h short help from padz help

### DIFF
--- a/src/padz/cli/commands.rs
+++ b/src/padz/cli/commands.rs
@@ -43,8 +43,8 @@ use super::render::{
     print_messages, render_full_pads, render_pad_list, render_pad_list_deleted, render_text_list,
 };
 use super::setup::{
-    print_grouped_help, print_help_for_command, print_subcommand_help, Cli, Commands,
-    CompletionShell, CoreCommands, DataCommands, MiscCommands, PadCommands,
+    print_grouped_help, print_help_for_command, print_short_help, print_subcommand_help, Cli,
+    Commands, CompletionShell, CoreCommands, DataCommands, MiscCommands, PadCommands,
 };
 use clap::Parser;
 use padz::api::{ConfigAction, PadFilter, PadStatusFilter, PadzApi};
@@ -78,10 +78,10 @@ struct AppContext {
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
 
-    // Handle help flag - at top level use grouped help, for subcommands use clap's default
+    // Handle help flag - at top level use short help, for subcommands use clap's default
     if cli.help {
         if cli.command.is_none() {
-            print_grouped_help();
+            print_short_help();
         } else {
             print_subcommand_help(&cli.command);
         }

--- a/src/padz/cli/setup.rs
+++ b/src/padz/cli/setup.rs
@@ -97,6 +97,30 @@ impl CommandGroup {
     }
 }
 
+/// Returns the short help output for -h flag
+pub fn get_short_help() -> String {
+    r#"Padz: notes for shell.
+
+padz create (c, new) <title> : creates note in $EDITOR (aliases: new, c)
+
+padz list (ls)               : shows notes (alias: ls, or no args)
+padz search                  : search your notes
+
+padz {view (v), edit (e), delete (d)}: do what they say. (aliases v, e, d)
+padz pin (p) / unpin (u)     : keep your favs on top (aliases p, u)
+
+Deletes are soft deletes, use purge (hard delete) or restore to bring it back.
+
+More: padz help
+"#
+    .to_string()
+}
+
+/// Prints the short help output
+pub fn print_short_help() {
+    print!("{}", get_short_help());
+}
+
 /// Returns the custom grouped help output as a string
 pub fn get_grouped_help() -> String {
     let cmd = Cli::command();


### PR DESCRIPTION
## Summary

- `padz -h` now shows a concise, casual help text for quick reference
- `padz help` shows the full grouped command reference (unchanged from before)
- Short help focuses on most common commands with their aliases

## Test plan

- [x] Verified `padz -h` shows the short help text
- [x] Verified `padz help` shows the full grouped help
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)