### PR TITLE
Added design level cargo docs

### DIFF
--- a/docs/architecture_cli_logic_split.txt
+++ b/docs/architecture_cli_logic_split.txt
@@ -1,46 +1,77 @@
 # CLI / Logic Architecture
 
 ## The Problem
-.
-    Shell programs tend to conflate interface and logic by adapting to shell's limitations and strengths. Before you know it logic is outputting strings all over the place and calculations are converting strings to integers. 
-    
-    This makes the program unyieldly and notoriously hard to test. So now you forgo unittests, and do shell integration tests. Now testings is slower and harder. You're parsing the output stings, breaking the code base on small text changes and o 
+
+Shell programs tend to conflate interface and logic by adapting to shell's limitations and strengths. Before you know it, logic is outputting strings all over the place and calculations are converting strings to integers.
+
+This makes the program unwieldy and notoriously hard to test. So you forgo unit tests and do shell integration tests instead. Now testing is slower and harder. You're parsing output strings, breaking the codebase on small text changes, and struggling with test maintenance.
 
 ## The Solution: Strict Layering
 
-Padz enforces a strict uncoupling of the User Interface (CLI) from the Application Logic (API/Commands).
+Padz enforces a strict separation of the User Interface (CLI) from the Application Logic (API/Commands).
 
 ### 1. The CLI Layer (The "Skin")
--   **Location**: [`src/padz/cli`](file:///src/padz/cli)
--   **Key Function**: `padz::cli::commands::run`
+-   **Location**: `src/padz/cli/`
+-   **Entry Point**: `src/padz/cli/commands.rs` — function `run`
 -   **Responsibility**:
     -   Translates `argv` into Rust types (via `clap`).
-    -   Initializes the `AppContext`.
+    -   Initializes the `AppContext` (API, scope, config).
     -   Calls the API.
-    -   Renders the `CmdResult` to stdout using `padz::cli::render`.
--   **Constraint**: *Never* makes decisions about state. It only asks the API to do things.
+    -   Renders the `CmdResult` to stdout using `src/padz/cli/render.rs`.
+-   **Constraint**: *Never* makes decisions about business state. It only asks the API to do things.
 
 ### 2. The API Layer (The "Facade")
--   **Location**: [`src/padz/api.rs`](file:///src/padz/api.rs)
--   **Key Struct**: `PadzApi`
+-   **Location**: `src/padz/api.rs`
+-   **Key Struct**: `PadzApi<S: DataStore>`
 -   **Responsibility**:
-    -   **The Boundary**: This is where the edges meet the core.
-    -   **Translation**: Converts user-facing concepts (Display Indexes `1-3`) into internal concepts (UUIDs).
+    -   **The Boundary**: Where the edges meet the core.
+    -   **Translation**: Converts user-facing concepts (Display Indexes like `1-3`) into internal concepts (UUIDs).
     -   **Dispatch**: Routes requests to the appropriate command module.
     -   **Isolation**: Returns `Result<CmdResult>`, a data structure describing what happened, *not* a string to print.
+-   **Generic Over Storage**: `PadzApi<FileStore>` in production, `PadzApi<InMemoryStore>` in tests.
 
 ### 3. The Command Layer (The "Brain")
--   **Location**: [`src/padz/commands/*.rs`](file:///src/padz/commands)
+-   **Location**: `src/padz/commands/*.rs`
 -   **Responsibility**:
     -   Pure business logic.
-    -   Validates state (e.g., "Pad `abc` exists?", "Is it pinned?").
+    -   Validates state (e.g., "Does this pad exist?", "Is it pinned?").
     -   Mutates the `DataStore`.
--   **Testing**: Unit tested heavily with in-memory stores.
+-   **Testing**: Unit tested heavily with in-memory stores. No I/O dependencies.
+
+### 4. The Store Layer (The "Memory")
+-   **Location**: `src/padz/store/`
+-   **Trait**: `DataStore` (defined in `src/padz/store/mod.rs`)
+-   **Implementations**:
+    -   `FileStore`: Production filesystem storage
+    -   `InMemoryStore`: Test-only in-memory storage
 
 ## Data Flow Example: `padz delete 1`
 
+```
+┌─────────┐     ┌─────────┐     ┌──────────┐     ┌─────────┐
+│   CLI   │ ──▶ │   API   │ ──▶ │ Commands │ ──▶ │  Store  │
+└─────────┘     └─────────┘     └──────────┘     └─────────┘
+   "1"         DisplayIndex      UUID-XYZ        file ops
+              → PadSelector    → is_deleted=true
+```
+
 1.  **CLI**: `clap` parses `1`. `handle_delete` receives `vec!["1"]`.
-2.  **API**: `PadzApi::delete_pads` calls `parse_selectors` to map `"1"` -> `UUID-XYZ`.
-3.  **Command**: `commands::delete::run` receives `[UUID-XYZ]`. It checks if `UUID-XYZ` is protected. If not, it tells store to mark as deleted.
-4.  **Return**: Command returns `CmdResult` saying "Deleted 1 pad".
-5.  **CLI**: `render` prints "Deleted 1 pad" in red.
+2.  **API**: `PadzApi::delete_pads` calls `parse_selectors` to map `"1"` → `PadSelector::Index(Regular(1))`.
+3.  **Command**: `commands::delete::run` resolves index to `UUID-XYZ`. Checks if protected. Marks as deleted.
+4.  **Return**: Command returns `CmdResult` with message "Deleted 1 pad".
+5.  **CLI**: `render::print_messages` outputs the message.
+
+## Testing Strategy
+
+| Layer | Test Type | What to Test |
+|-------|-----------|--------------|
+| CLI | Integration | Arg parsing, output formatting |
+| API | Unit | Dispatch correctness, input normalization |
+| Commands | Unit | Business logic, state transitions |
+| Store | Unit | Read/write operations, sync behavior |
+
+This separation enables:
+-   Fast, isolated unit tests for business logic
+-   Easy mocking of storage for deterministic tests
+-   UI changes without touching business logic
+-   Alternative UIs (web, TUI) using the same API

--- a/docs/architecture_cli_logic_split.txt
+++ b/docs/architecture_cli_logic_split.txt
@@ -1,0 +1,46 @@
+# CLI / Logic Architecture
+
+## The Problem
+.
+    Shell programs tend to conflate interface and logic by adapting to shell's limitations and strengths. Before you know it logic is outputting strings all over the place and calculations are converting strings to integers. 
+    
+    This makes the program unyieldly and notoriously hard to test. So now you forgo unittests, and do shell integration tests. Now testings is slower and harder. You're parsing the output stings, breaking the code base on small text changes and o 
+
+## The Solution: Strict Layering
+
+Padz enforces a strict uncoupling of the User Interface (CLI) from the Application Logic (API/Commands).
+
+### 1. The CLI Layer (The "Skin")
+-   **Location**: [`src/padz/cli`](file:///src/padz/cli)
+-   **Key Function**: `padz::cli::commands::run`
+-   **Responsibility**:
+    -   Translates `argv` into Rust types (via `clap`).
+    -   Initializes the `AppContext`.
+    -   Calls the API.
+    -   Renders the `CmdResult` to stdout using `padz::cli::render`.
+-   **Constraint**: *Never* makes decisions about state. It only asks the API to do things.
+
+### 2. The API Layer (The "Facade")
+-   **Location**: [`src/padz/api.rs`](file:///src/padz/api.rs)
+-   **Key Struct**: `PadzApi`
+-   **Responsibility**:
+    -   **The Boundary**: This is where the edges meet the core.
+    -   **Translation**: Converts user-facing concepts (Display Indexes `1-3`) into internal concepts (UUIDs).
+    -   **Dispatch**: Routes requests to the appropriate command module.
+    -   **Isolation**: Returns `Result<CmdResult>`, a data structure describing what happened, *not* a string to print.
+
+### 3. The Command Layer (The "Brain")
+-   **Location**: [`src/padz/commands/*.rs`](file:///src/padz/commands)
+-   **Responsibility**:
+    -   Pure business logic.
+    -   Validates state (e.g., "Pad `abc` exists?", "Is it pinned?").
+    -   Mutates the `DataStore`.
+-   **Testing**: Unit tested heavily with in-memory stores.
+
+## Data Flow Example: `padz delete 1`
+
+1.  **CLI**: `clap` parses `1`. `handle_delete` receives `vec!["1"]`.
+2.  **API**: `PadzApi::delete_pads` calls `parse_selectors` to map `"1"` -> `UUID-XYZ`.
+3.  **Command**: `commands::delete::run` receives `[UUID-XYZ]`. It checks if `UUID-XYZ` is protected. If not, it tells store to mark as deleted.
+4.  **Return**: Command returns `CmdResult` saying "Deleted 1 pad".
+5.  **CLI**: `render` prints "Deleted 1 pad" in red.

--- a/docs/cli_behavior.txt
+++ b/docs/cli_behavior.txt
@@ -1,0 +1,42 @@
+# CLI Behavior Specifics
+
+## The Problem
+
+Standard CLIs are "dumb". They do exactly what they are told, often requiring verbose flags for common actions.
+-   Creating a note from clipboard requires `pbpaste | padz create`.
+-   Creating a quick note requires `padz create -m "Title"`.
+-   Just running `padz` shows help instead of the useful list.
+
+## The Solution: Context-Aware Intelligence
+
+Padz infers intent from the context of execution (Arguments, Stdin, Clipboard).
+
+### 1. Naked Execution (`padz`)
+-   **Behavior**: Running `padz` (no args) defaults to `padz list`.
+-   **Location**: [`padz::cli::commands::run`](file:///src/padz/cli/commands.rs)
+-   **Logic**: If `cli.command` is `None`, dispatch `handle_list`.
+-   **Why**: The "Read" operation is 90% of usage. It should be the path of least resistance.
+
+### 2. Smart Create (`padz create`)
+-   **Location**: [`padz::cli::commands::handle_create`](file:///src/padz/cli/commands.rs)
+
+**Scenario A: Piped Input**
+-   `echo "foo" | padz create`
+-   **Logic**: Detects stdin is not TTY. Reads content.
+-   **Action**: Creates note with content "foo". **Skips Editor**.
+-   **Why**: Scripting/Automation.
+
+**Scenario B: Clipboard (Magic)**
+-   `padz create` (no input, empty stdin)
+-   **Logic**: Checks system clipboard via `padz::clipboard`.
+-   **Action**: Pre-fills editor with clipboard content. **Opens Editor**.
+-   **Why**: "I just copied this snippet, I want to save it." - Removes the `pbpaste` friction but allows review.
+
+**Scenario C: Quick Title**
+-   `padz create "Meeting Notes"`
+-   **Action**: Uses argument as title. Opens editor for body.
+
+### 3. Search Fallback
+-   `padz foo` (where `foo` is not a command)
+-   **Note**: Currently Padz uses explicit subcommands. The "Search" fallback is commonly implemented in `handle_list` argument parsing or a catch-all, but Padz favors explicit `search` or `list --search`.
+-   **Design Choice**: Explicit over implicit for commands to avoid "creating a note named list".

--- a/docs/cli_behavior.txt
+++ b/docs/cli_behavior.txt
@@ -2,7 +2,7 @@
 
 ## The Problem
 
-Standard CLIs are "dumb". They do exactly what they are told, often requiring verbose flags for common actions.
+Standard CLIs are "dumb". They do exactly what they are told, often requiring verbose flags for common actions:
 -   Creating a note from clipboard requires `pbpaste | padz create`.
 -   Creating a quick note requires `padz create -m "Title"`.
 -   Just running `padz` shows help instead of the useful list.
@@ -12,31 +12,43 @@ Standard CLIs are "dumb". They do exactly what they are told, often requiring ve
 Padz infers intent from the context of execution (Arguments, Stdin, Clipboard).
 
 ### 1. Naked Execution (`padz`)
--   **Behavior**: Running `padz` (no args) defaults to `padz list`.
--   **Location**: [`padz::cli::commands::run`](file:///src/padz/cli/commands.rs)
--   **Logic**: If `cli.command` is `None`, dispatch `handle_list`.
+-   **Behavior**: Running `padz` with no arguments defaults to `padz list`.
+-   **Location**: `src/padz/cli/commands.rs` — function `run`
+-   **Logic**: If `cli.command` is `None`, dispatch to `handle_list`.
 -   **Why**: The "Read" operation is 90% of usage. It should be the path of least resistance.
 
 ### 2. Smart Create (`padz create`)
--   **Location**: [`padz::cli::commands::handle_create`](file:///src/padz/cli/commands.rs)
+-   **Location**: `src/padz/cli/commands.rs` — function `handle_create`
 
-**Scenario A: Piped Input**
--   `echo "foo" | padz create`
--   **Logic**: Detects stdin is not TTY. Reads content.
--   **Action**: Creates note with content "foo". **Skips Editor**.
--   **Why**: Scripting/Automation.
+**Priority order for content source:**
 
-**Scenario B: Clipboard (Magic)**
--   `padz create` (no input, empty stdin)
--   **Logic**: Checks system clipboard via `padz::clipboard`.
--   **Action**: Pre-fills editor with clipboard content. **Opens Editor**.
--   **Why**: "I just copied this snippet, I want to save it." - Removes the `pbpaste` friction but allows review.
+1. **Piped Input** (highest priority)
+   -   Detected via `!std::io::stdin().is_terminal()`
+   -   `echo "foo" | padz create`
+   -   Action: Creates pad with piped content. **Skips editor**.
+   -   Why: Scripting/automation use case.
 
-**Scenario C: Quick Title**
--   `padz create "Meeting Notes"`
--   **Action**: Uses argument as title. Opens editor for body.
+2. **Clipboard** (fallback when no pipe and no title arg)
+   -   `padz create` (with something in clipboard)
+   -   Action: Pre-fills editor with clipboard content. **Opens editor** (unless `--no-editor`).
+   -   Why: "I just copied this snippet, I want to save it." Removes `pbpaste` friction but allows review.
 
-### 3. Search Fallback
--   `padz foo` (where `foo` is not a command)
--   **Note**: Currently Padz uses explicit subcommands. The "Search" fallback is commonly implemented in `handle_list` argument parsing or a catch-all, but Padz favors explicit `search` or `list --search`.
--   **Design Choice**: Explicit over implicit for commands to avoid "creating a note named list".
+3. **Title Argument**
+   -   `padz create "Meeting Notes"`
+   -   Action: Uses argument as title. Opens editor for body.
+
+**Editor behavior:**
+-   After saving from editor, the pad content is automatically copied to clipboard.
+-   Use `--no-editor` flag to skip opening the editor.
+
+### 3. View Copies to Clipboard
+-   `padz view 1` displays the pad AND copies its content to clipboard.
+-   When viewing multiple pads, they are joined with `---` separators.
+-   This enables quick "view and paste" workflows.
+
+### 4. Explicit Search
+-   `padz search <term>` — Explicit search command.
+-   `padz list --search <term>` — Search within list.
+-   `padz view <term>` — If term isn't a valid index, treated as title search.
+
+**Design Choice**: Padz favors explicit commands over magic. This prevents confusion like "did I just create a note named 'list'?"

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -2,30 +2,45 @@
 
 ## The Problem
 
-Users need to customize defaults (e.g., "I prefer Markdown over Text"), but requiring them to find, create, and edit a hidden JSON file is a bad UX.
+Users need to customize defaults (e.g., "I prefer Markdown over plain text"), but requiring them to find, create, and edit a hidden JSON file is poor UX.
 
 ## The Solution: Config Command + Hierarchy
 
 Padz exposes configuration as a first-class command, backed by a simple hierarchical lookup.
 
 ### 1. Storage Hierarchy
--   **Location**: [`padz::config`](file:///src/padz/config.rs)
+-   **Location**: `src/padz/config.rs`
 -   **Priority 1: Project Config**: `.padz/config.json`. Overrides everything for this repo.
--   **Priority 2: Global Config**: `~/.config/padz/config.json`. User defaults.
--   **Priority 3: Hardcoded Defaults**: built-in fallbacks (e.g., ext = `.txt`).
+-   **Priority 2: Global Config**: OS-appropriate config directory (via `directories` crate).
+-   **Priority 3: Hardcoded Defaults**: Built-in fallbacks.
 
 ### 2. The Config Command
--   **Location**: [`padz::cli::commands::handle_config`](file:///src/padz/cli/commands.rs)
--   **API**: `PadzApi::config`
+-   **Location**: `src/padz/cli/commands.rs` — function `handle_config`
 -   **Usage**:
-    -   `padz config`: Dump effective config.
-    -   `padz config file-ext`: Get specific value.
-    -   `padz config file-ext .md`: Set value (persists to the active scope's JSON file).
+    -   `padz config` — Show all configuration values.
+    -   `padz config <key>` — Get a specific value.
+    -   `padz config <key> <value>` — Set a value (persists to the active scope's config file).
 
-### 3. Key Settings
--   `file-ext`: Controls the extension used for *new* files.
-    -   *Design*: Changing this doesn't rename old files. Padz supports mixed extensions gracefully (see `Store` docs).
--   `import-extensions`: Controls which files `padz import .` will slurp up.
+### 3. Available Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `file-ext` | `.txt` | Extension for new pad files (e.g., `.md`, `.txt`) |
+| `import-extensions` | `.md, .txt, .text, .lex` | Extensions to look for when running `padz import .` |
+
+### 4. Extension Behavior
+
+**`file-ext`**:
+-   Controls the extension used for *newly created* files only.
+-   Changing this does **not** rename existing files.
+-   Padz reads files with any extension that matches the `pad-{UUID}.*` pattern.
+-   When reading, it tries the configured extension first, then falls back to `.txt`.
+
+**`import-extensions`**:
+-   Comma-separated list of extensions.
+-   Used by `padz import <directory>` to filter which files to import.
+-   Example: `padz config import-extensions ".md, .txt"`
 
 ### Developer Note
-The `PadzConfig` struct uses `serde` for serialization. New settings should be added there with `#[serde(default)]` to ensure backward compatibility with older config files.
+
+The `PadzConfig` struct uses `serde` with `#[serde(default)]` for all fields. This ensures that older config files missing new fields will use defaults without errors.

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -1,0 +1,31 @@
+# Configuration
+
+## The Problem
+
+Users need to customize defaults (e.g., "I prefer Markdown over Text"), but requiring them to find, create, and edit a hidden JSON file is a bad UX.
+
+## The Solution: Config Command + Hierarchy
+
+Padz exposes configuration as a first-class command, backed by a simple hierarchical lookup.
+
+### 1. Storage Hierarchy
+-   **Location**: [`padz::config`](file:///src/padz/config.rs)
+-   **Priority 1: Project Config**: `.padz/config.json`. Overrides everything for this repo.
+-   **Priority 2: Global Config**: `~/.config/padz/config.json`. User defaults.
+-   **Priority 3: Hardcoded Defaults**: built-in fallbacks (e.g., ext = `.txt`).
+
+### 2. The Config Command
+-   **Location**: [`padz::cli::commands::handle_config`](file:///src/padz/cli/commands.rs)
+-   **API**: `PadzApi::config`
+-   **Usage**:
+    -   `padz config`: Dump effective config.
+    -   `padz config file-ext`: Get specific value.
+    -   `padz config file-ext .md`: Set value (persists to the active scope's JSON file).
+
+### 3. Key Settings
+-   `file-ext`: Controls the extension used for *new* files.
+    -   *Design*: Changing this doesn't rename old files. Padz supports mixed extensions gracefully (see `Store` docs).
+-   `import-extensions`: Controls which files `padz import .` will slurp up.
+
+### Developer Note
+The `PadzConfig` struct uses `serde` for serialization. New settings should be added there with `#[serde(default)]` to ensure backward compatibility with older config files.

--- a/docs/content_format.txt
+++ b/docs/content_format.txt
@@ -1,0 +1,51 @@
+# Pad Content: Format and Normalization
+
+## The Problem
+
+Users dump text into notes in chaotic formats.
+-   Sometimes they write a title, sometimes not.
+-   Sometimes they leave 10 blank lines at the top.
+-   Sometimes they pipe in logs.
+
+If we display this raw content in lists/peeks, the UI looks broken. We need a "Canonical Format" without forcing the user to fill out a form.
+
+## The Solution: The Normalization Pipeline
+
+Padz accepts any UTF-8 text but aggressively normalizes it upon save. This ensures that the file on disk and the metadata cache are continually converging toward a clean state.
+
+### 1. The Canonical Format
+
+```text
+Title Line     <-- Line 1 (Non-empty)
+               <-- Line 2 (Blank Separator)
+Body Content   <-- Line 3+ (Trimmed)
+...
+```
+
+### 2. Implementation
+
+-   **Location**: [`padz::model::normalize_pad_content`](file:///src/padz/model.rs)
+-   **Trigger**: Called explicitly by `Pad::new` and implicit via `FileStore::sync` (when adopting orphans).
+
+**The Pipeline**:
+1.  **Input**: Raw string (`"  \n  My Title \n\n  Body  "`).
+2.  **Title Extraction**:
+    -   Explode lines.
+    -   Take first non-empty line as Title.
+    -   *Logic*: `extract_title_and_body` in `model.rs`.
+3.  **Body Cleaning**:
+    -   Take all remaining lines.
+    -   `trim()` global whitespace (strips leading/trailing newlines).
+4.  **Reassembly**:
+    -   Construct: `format!("{}\n\n{}", title, body)`.
+    -   **Rule**: Always exactly one blank line separator.
+
+### 3. Edge Cases
+
+-   **One-Liner**: "Only Title".
+    -   Normalized to: `"Only Title"` (No trailing newlines/separators).
+-   **Empty Input**:
+    -   Rejected. Padz does not store empty notes. `FileStore` garbage collects them.
+-   **Long Titles**:
+    -   In **File**: Full title stored.
+    -   In **Metadata**: Truncated to 60 chars for table display (`model.rs` handles this during metadata generation).

--- a/docs/content_format.txt
+++ b/docs/content_format.txt
@@ -2,50 +2,52 @@
 
 ## The Problem
 
-Users dump text into notes in chaotic formats.
+Users dump text into notes in chaotic formats:
 -   Sometimes they write a title, sometimes not.
--   Sometimes they leave 10 blank lines at the top.
--   Sometimes they pipe in logs.
+-   Sometimes they leave blank lines at the top.
+-   Sometimes they pipe in logs or code snippets.
 
 If we display this raw content in lists/peeks, the UI looks broken. We need a "Canonical Format" without forcing the user to fill out a form.
 
 ## The Solution: The Normalization Pipeline
 
-Padz accepts any UTF-8 text but aggressively normalizes it upon save. This ensures that the file on disk and the metadata cache are continually converging toward a clean state.
+Padz accepts any UTF-8 text but aggressively normalizes it upon save. This ensures that the file on disk and the metadata cache converge toward a clean, consistent state.
 
 ### 1. The Canonical Format
 
 ```text
-Title Line     <-- Line 1 (Non-empty)
-               <-- Line 2 (Blank Separator)
-Body Content   <-- Line 3+ (Trimmed)
+Title Line     <-- Line 1 (first non-empty line)
+               <-- Line 2 (blank separator)
+Body Content   <-- Line 3+ (remaining content, trimmed)
 ...
 ```
 
 ### 2. Implementation
 
--   **Location**: [`padz::model::normalize_pad_content`](file:///src/padz/model.rs)
--   **Trigger**: Called explicitly by `Pad::new` and implicit via `FileStore::sync` (when adopting orphans).
+-   **Location**: `src/padz/model.rs` — functions `normalize_pad_content`, `extract_title_and_body`, `parse_pad_content`
+-   **Trigger**: Called by `Pad::new` during creation and by `FileStore::sync` when adopting orphan files.
 
 **The Pipeline**:
-1.  **Input**: Raw string (`"  \n  My Title \n\n  Body  "`).
+1.  **Input**: Raw string (e.g., `"  \n  My Title \n\n  Body  "`).
 2.  **Title Extraction**:
-    -   Explode lines.
+    -   Trim leading/trailing whitespace from entire input.
     -   Take first non-empty line as Title.
-    -   *Logic*: `extract_title_and_body` in `model.rs`.
-3.  **Body Cleaning**:
-    -   Take all remaining lines.
-    -   `trim()` global whitespace (strips leading/trailing newlines).
+3.  **Body Extraction**:
+    -   Take all remaining lines after the title.
+    -   Trim leading/trailing whitespace from the body.
 4.  **Reassembly**:
-    -   Construct: `format!("{}\n\n{}", title, body)`.
-    -   **Rule**: Always exactly one blank line separator.
+    -   If body is non-empty: `format!("{}\n\n{}", title, body)`
+    -   If body is empty: Just the title (no trailing newlines)
 
-### 3. Edge Cases
+### 3. Title Truncation
 
--   **One-Liner**: "Only Title".
-    -   Normalized to: `"Only Title"` (No trailing newlines/separators).
--   **Empty Input**:
-    -   Rejected. Padz does not store empty notes. `FileStore` garbage collects them.
--   **Long Titles**:
-    -   In **File**: Full title stored.
-    -   In **Metadata**: Truncated to 60 chars for table display (`model.rs` handles this during metadata generation).
+-   **In File**: The full title is stored as the first line.
+-   **In Metadata**: Truncated to 60 characters for display (59 chars + ellipsis `…`).
+-   This happens in `normalize_pad_content` when generating the display title.
+
+### 4. Edge Cases
+
+-   **One-Liner**: Input `"Only Title"` → Normalized to `"Only Title"` (no separator or body).
+-   **Empty Input**: Rejected. Padz does not store empty pads. `FileStore::sync` garbage collects files that become empty.
+-   **Multiple Blank Lines**: Collapsed to a single separator line between title and body.
+-   **Leading Blank Lines**: Stripped before title extraction.

--- a/docs/identifiers.txt
+++ b/docs/identifiers.txt
@@ -2,7 +2,7 @@
 
 ## The Problem
 
-Padz needs to be referenced by ID. Since it's a CLI tool, the primary interface is text. While `UUID`s are the correct technical choice for unique identification, they are cumbersome to type.
+Pads need to be referenced by ID. Since padz is a CLI tool, the primary interface is text. While `UUID`s are the correct technical choice for unique identification, they are cumbersome to type.
 
 Sequential IDs are the logical user-facing choice. However, naive sequential indexing (e.g., just numbering the current output list 1..N) creates ambiguity and "index drift".
 
@@ -25,7 +25,7 @@ If we naively assigned `1` to "Hi Dad" in this view, running `padz delete 1` bec
 Padz uses a dual-identifier system to balance stability (for storage) and usability (for the user).
 
 1.  **UUID (Internal)**: Immutable, canonical, globally unique.
-2.  **Display Index (External)**: A semi-stable integer generated from a canonical "expected" ordering.
+2.  **Display Index (External)**: A stable integer generated from a canonical ordering.
 
 ### Canonical Ordering
 
@@ -39,9 +39,17 @@ $ padz search Dad
 This ensures that `padz delete 2` always targets "Hi Dad", regardless of the current view.
 
 **Ordering Logic**:
--   **Active Pads**: Reverse chronological order (Newest = 1).
--   **Pinned Pads**: Separate bucket `p1`, `p2`...
+-   **All Pads**: Sorted by `created_at` descending (Newest = 1).
+-   **Pinned Pads**: Get an additional `p1`, `p2`... index (appear in both pinned and regular lists).
 -   **Deleted Pads**: Separate bucket `d1`, `d2`...
+
+### Important: Pinned Pads Have Two Indexes
+
+A pinned pad appears **twice** in the indexed list:
+- Once with a `Pinned` index (`p1`, `p2`, etc.)
+- Once with its canonical `Regular` index (`1`, `2`, etc.)
+
+This is intentional. Users can reference pinned pads by either index. The regular index ensures stability when a pad is unpinned.
 
 ## Implementation Details
 
@@ -49,25 +57,27 @@ This ensures that `padz delete 2` always targets "Hi Dad", regardless of the cur
 
 The mapping from Pad -> Display Index happens dynamically during listing.
 
--   **Location**: [`padz::index::index_pads`](file:///src/padz/index.rs)
+-   **Location**: `src/padz/index.rs` — function `index_pads`
 -   **How it works**:
     1.  Sorts all pads by `created_at` descending.
-    2.  Iterates and assigns `pX`, `N`, `dX` based on state (`is_pinned`, `is_deleted`).
-    3.  Returns a `DisplayPad` struct connecting the `Pad` and its `DisplayIndex`.
+    2.  First pass: Assigns `pX` to pinned, non-deleted pads.
+    3.  Second pass: Assigns `N` to ALL non-deleted pads (including pinned ones).
+    4.  Third pass: Assigns `dX` to deleted pads.
+    5.  Returns a `Vec<DisplayPad>` connecting the `Pad` and its `DisplayIndex`.
 
 **Developer Note**: When implementing list/view commands, **always** use `index_pads` (or the `PadzApi::get_pads` wrapper). Never manually enumerate a list of pads, as you will break the canonical ID association.
 
 ### 2. Resolving Indexes (Input)
 
-Input resolution happens exclusively at the API boundary ("The Edges").
+Input resolution happens exclusively at the API boundary.
 
--   **Location**: [`padz::api::parse_selectors`](file:///src/padz/api.rs)
+-   **Location**: `src/padz/api.rs` — function `parse_selectors`
 -   **Process**: `Input String` -> `DisplayIndex` -> `UUID`
 -   **Design**:
     1.  The user types `padz delete 1`.
     2.  The CLI passes string `"1"` to the API.
-    3.  `padz::api` calls `parse_selectors`, which internally re-runs the canonical `index_pads` to rebuild the map.
-    4.  It finds the UUID currently associated with Index `1`.
-    5.  The command (`padz::commands::delete`) receives the **UUID**, not the index.
+    3.  `parse_selectors` internally calls `parse_index_or_range` to parse the input.
+    4.  The API resolves the index to the UUID using the canonical `index_pads` ordering.
+    5.  The command (`src/padz/commands/delete.rs`) receives the **UUID**, not the index.
 
 **Critical**: Internal business logic (`src/padz/commands/*`) **only** knows about UUIDs. It should never see or handle a `DisplayIndex`. This separation ensures that logic is testable and safe, while the fragility of human-friendly IDs is contained entirely within the API/CLI boundary layer.

--- a/docs/identifiers.txt
+++ b/docs/identifiers.txt
@@ -1,0 +1,73 @@
+# Pad Identifiers: UUID vs Display Index
+
+## The Problem
+
+Padz needs to be referenced by ID. Since it's a CLI tool, the primary interface is text. While `UUID`s are the correct technical choice for unique identification, they are cumbersome to type.
+
+Sequential IDs are the logical user-facing choice. However, naive sequential indexing (e.g., just numbering the current output list 1..N) creates ambiguity and "index drift".
+
+Consider:
+```bash
+$ padz list
+1. Hi Mom
+2. Hi Dad
+```
+
+If the user searches for "Dad":
+```bash
+$ padz search Dad
+1. Hi Dad
+```
+If we naively assigned `1` to "Hi Dad" in this view, running `padz delete 1` becomes dangerous. Is the user deleting "Hi Mom" (Global ID 1) or "Hi Dad" (Search ID 1)?
+
+## The Solution: Dual Identifiers
+
+Padz uses a dual-identifier system to balance stability (for storage) and usability (for the user).
+
+1.  **UUID (Internal)**: Immutable, canonical, globally unique.
+2.  **Display Index (External)**: A semi-stable integer generated from a canonical "expected" ordering.
+
+### Canonical Ordering
+
+Even when filtering or searching, the ID assigned to a pad remains consistent with its position in the full, unfiltered list of active pads.
+
+```bash
+$ padz search Dad
+2. Hi Dad  <-- Still ID 2, even though it's the only result!
+```
+
+This ensures that `padz delete 2` always targets "Hi Dad", regardless of the current view.
+
+**Ordering Logic**:
+-   **Active Pads**: Reverse chronological order (Newest = 1).
+-   **Pinned Pads**: Separate bucket `p1`, `p2`...
+-   **Deleted Pads**: Separate bucket `d1`, `d2`...
+
+## Implementation Details
+
+### 1. Generating Indexes (Output)
+
+The mapping from Pad -> Display Index happens dynamically during listing.
+
+-   **Location**: [`padz::index::index_pads`](file:///src/padz/index.rs)
+-   **How it works**:
+    1.  Sorts all pads by `created_at` descending.
+    2.  Iterates and assigns `pX`, `N`, `dX` based on state (`is_pinned`, `is_deleted`).
+    3.  Returns a `DisplayPad` struct connecting the `Pad` and its `DisplayIndex`.
+
+**Developer Note**: When implementing list/view commands, **always** use `index_pads` (or the `PadzApi::get_pads` wrapper). Never manually enumerate a list of pads, as you will break the canonical ID association.
+
+### 2. Resolving Indexes (Input)
+
+Input resolution happens exclusively at the API boundary ("The Edges").
+
+-   **Location**: [`padz::api::parse_selectors`](file:///src/padz/api.rs)
+-   **Process**: `Input String` -> `DisplayIndex` -> `UUID`
+-   **Design**:
+    1.  The user types `padz delete 1`.
+    2.  The CLI passes string `"1"` to the API.
+    3.  `padz::api` calls `parse_selectors`, which internally re-runs the canonical `index_pads` to rebuild the map.
+    4.  It finds the UUID currently associated with Index `1`.
+    5.  The command (`padz::commands::delete`) receives the **UUID**, not the index.
+
+**Critical**: Internal business logic (`src/padz/commands/*`) **only** knows about UUIDs. It should never see or handle a `DisplayIndex`. This separation ensures that logic is testable and safe, while the fragility of human-friendly IDs is contained entirely within the API/CLI boundary layer.

--- a/docs/scopes.txt
+++ b/docs/scopes.txt
@@ -1,0 +1,39 @@
+# Scopes: Project vs Global
+
+## The Problem
+
+Command line tools typically operate in one of two modes:
+1.  **Global**: Like a centralized database (e.g., standard notes apps).
+2.  **Local**: Only in the current folder (e.g., `git`).
+
+For a developer-focused note tool, neither is sufficient. You want context-aware notes ("TODOs for *this* project") but occasionally need global notes ("Grocery list") without leaving your terminal. Furthermore, in nested repository structures (monorepos), "Local" is ambiguous.
+
+## The Solution: Heuristic Scope Detection
+
+Padz implements a git-aware scope detection algorithm to robustly identify the "Project Root".
+
+### 1. The Scopes
+-   **Project**: Bound to a specific code repository. Data lives in `<repo_root>/.padz`.
+-   **Global**: Bound to the user. Data lives in `~/.local/share/padz`.
+
+### 2. Detection Logic
+
+-   **Location**: [`padz::init::find_project_root`](file:///src/padz/init.rs)
+-   **Algorithm**:
+    1.  Start at `CWD` (Current Working Directory).
+    2.  Check for **Evidence**: Does this directory have `.git` AND `.padz`?
+    3.  **Match**: If yes, this is the Project Root.
+    4.  **No Match**: Move to parent directory.
+    5.  **Stop**: If we hit `HOME` or filesystem root, fail (default to Global or Error depending on strictness).
+
+**Why checks for `.git` AND `.padz`?**
+This dual-check is the strictness filter.
+-   If we just checked `.git`: We might accidentally pollute a parent repo (e.g., checking out a sub-repo inside a larger one).
+-   If we just checked `.padz`: We lose the semantic binding to the "Project".
+
+### Implementation Note
+The scope is resolved during `padz::init::initialize`.
+-   If `-g` flag is present -> Force `Scope::Global`.
+-   Else -> Run `find_project_root`.
+    -   Found -> `Scope::Project(path)`.
+    -   Not Found -> `Scope::Project(CWD)` (but will likely trigger init prompt or error if writing).

--- a/docs/scopes.txt
+++ b/docs/scopes.txt
@@ -13,27 +13,37 @@ For a developer-focused note tool, neither is sufficient. You want context-aware
 Padz implements a git-aware scope detection algorithm to robustly identify the "Project Root".
 
 ### 1. The Scopes
--   **Project**: Bound to a specific code repository. Data lives in `<repo_root>/.padz`.
--   **Global**: Bound to the user. Data lives in `~/.local/share/padz`.
+-   **Project**: Bound to a specific code repository. Data lives in `<repo_root>/.padz/`.
+-   **Global**: Bound to the user. Data lives in the OS-appropriate data directory (via `directories` crate).
 
 ### 2. Detection Logic
 
--   **Location**: [`padz::init::find_project_root`](file:///src/padz/init.rs)
+-   **Location**: `src/padz/init.rs` — function `find_project_root`
 -   **Algorithm**:
     1.  Start at `CWD` (Current Working Directory).
-    2.  Check for **Evidence**: Does this directory have `.git` AND `.padz`?
+    2.  Check for **Evidence**: Does this directory have BOTH `.git` AND `.padz`?
     3.  **Match**: If yes, this is the Project Root.
     4.  **No Match**: Move to parent directory.
-    5.  **Stop**: If we hit `HOME` or filesystem root, fail (default to Global or Error depending on strictness).
+    5.  **Stop**: If we reach `HOME` or filesystem root, return `None`.
 
-**Why checks for `.git` AND `.padz`?**
-This dual-check is the strictness filter.
--   If we just checked `.git`: We might accidentally pollute a parent repo (e.g., checking out a sub-repo inside a larger one).
--   If we just checked `.padz`: We lose the semantic binding to the "Project".
+**Why require both `.git` AND `.padz`?**
+This dual-check is the strictness filter:
+-   If we only checked `.git`: We might accidentally use a parent repo (e.g., when working in a sub-repo inside a monorepo).
+-   If we only checked `.padz`: We lose the semantic binding to the "Project" concept.
 
-### Implementation Note
-The scope is resolved during `padz::init::initialize`.
--   If `-g` flag is present -> Force `Scope::Global`.
--   Else -> Run `find_project_root`.
-    -   Found -> `Scope::Project(path)`.
-    -   Not Found -> `Scope::Project(CWD)` (but will likely trigger init prompt or error if writing).
+The result is that you must explicitly `padz init` in a repo to opt-in to project scope. This prevents accidental pollution of parent directories.
+
+### 3. Scope Resolution Flow
+
+The scope is resolved during `padz::init::initialize`:
+1.  If `-g` flag is present → Force `Scope::Global`.
+2.  Otherwise → Run `find_project_root(cwd)`.
+    -   Found → `Scope::Project`.
+    -   Not Found → `Scope::Project` with `cwd/.padz` as path (may need `init`).
+
+### 4. Nested Repositories
+
+When working in nested repos (e.g., `parent-repo/child-repo`):
+- If only `parent-repo` has `.padz`, starting from `child-repo` will find and use `parent-repo`
+- If both have `.padz`, the innermost one (closest to cwd) wins
+- If neither has `.padz`, scope resolution returns `None` and uses `cwd/.padz` as default

--- a/docs/selectors_and_ranges.txt
+++ b/docs/selectors_and_ranges.txt
@@ -1,0 +1,41 @@
+# Selectors: Multi-IDs and Ranges
+
+## The Problem
+
+Users often need to act on batches of items ("Delete the last 3 notes", "Pin items 1 and 5").
+Typing `padz delete 1 2 3` is okay, but `padz delete 1-3` is better.
+However, range logic is tricky when indexes (pinned vs regular) are involved. Mixing types (`p1-3`) is ambiguous.
+
+## The Solution: Typed Selectors
+
+Padz implements a strong grammar for selecting items. A "Selector" is the user's intent string, which must be parsed and validated before it ever touches the business logic.
+
+### 1. The Grammar
+
+-   **Regular Index**: `N` (e.g., `1`, `42`)
+-   **Pinned Index**: `pX` (e.g., `p1`, `p2`)
+-   **Deleted Index**: `dX` (e.g., `d1`, `d5`)
+-   **Ranges**: `Start-End` (e.g., `1-5`, `p1-p3`)
+    -   **Constraint**: Must be Homogenous. `1-3` is valid. `p1-p3` is valid. `1-p3` is **Invalid**.
+
+### 2. Application Logic
+
+**Phase 1: Parsing (The "What")**
+-   **Location**: [`padz::index::parse_index_or_range`](file:///src/padz/index.rs)
+-   **Role**: Expands string inputs into a list of `DisplayIndex` enums.
+-   **Example**: Input `"1-3"` -> Output `vec![Regular(1), Regular(2), Regular(3)]`.
+
+**Phase 2: Resolution (The "Who")**
+-   **Location**: [`padz::api::parse_selectors`](file:///src/padz/api.rs)
+-   **Role**: Maps `DisplayIndex` -> `UUID` using proper `index_pads` sorting.
+-   **Logic**:
+    1.  Calls `index_pads(store.list())` to get the current state of the world.
+    2.  Finds the UUID corresponding to `Regular(1)`, `Regular(2)`, etc.
+    3.  If any index is out of bounds, returns an Error.
+
+**Phase 3: Fallback (Search)**
+-   If parsing fails (string is not a valid index/range syntax), the entire input is treated as a **Search Term**.
+-   `padz list meeting` -> "meeting" is not an index -> Treated as `padz list --search meeting`.
+
+### Developer Note
+This layered approach means the `commands` module never deals with parsing logic. It simply receives `Vec<Uuid>` or a `SearchTerm` string.

--- a/docs/selectors_and_ranges.txt
+++ b/docs/selectors_and_ranges.txt
@@ -4,38 +4,55 @@
 
 Users often need to act on batches of items ("Delete the last 3 notes", "Pin items 1 and 5").
 Typing `padz delete 1 2 3` is okay, but `padz delete 1-3` is better.
-However, range logic is tricky when indexes (pinned vs regular) are involved. Mixing types (`p1-3`) is ambiguous.
+However, range logic is tricky when different index types (pinned vs regular vs deleted) are involved. Mixing types (`p1-3`) is ambiguous.
 
 ## The Solution: Typed Selectors
 
-Padz implements a strong grammar for selecting items. A "Selector" is the user's intent string, which must be parsed and validated before it ever touches the business logic.
+Padz implements a strict grammar for selecting items. A "Selector" is the user's intent string, which must be parsed and validated before it touches the business logic.
 
 ### 1. The Grammar
 
 -   **Regular Index**: `N` (e.g., `1`, `42`)
 -   **Pinned Index**: `pX` (e.g., `p1`, `p2`)
 -   **Deleted Index**: `dX` (e.g., `d1`, `d5`)
--   **Ranges**: `Start-End` (e.g., `1-5`, `p1-p3`)
-    -   **Constraint**: Must be Homogenous. `1-3` is valid. `p1-p3` is valid. `1-p3` is **Invalid**.
+-   **Ranges**: `Start-End` (e.g., `1-5`, `p1-p3`, `d1-d3`)
+    -   **Constraint**: Ranges must be homogeneous. `1-3` is valid. `p1-p3` is valid. `1-p3` is **invalid**.
+    -   **Constraint**: Start must be ≤ end. `3-5` is valid. `5-3` is **invalid**.
 
-### 2. Application Logic
+### 2. Processing Pipeline
 
 **Phase 1: Parsing (The "What")**
--   **Location**: [`padz::index::parse_index_or_range`](file:///src/padz/index.rs)
+-   **Location**: `src/padz/index.rs` — function `parse_index_or_range`
 -   **Role**: Expands string inputs into a list of `DisplayIndex` enums.
--   **Example**: Input `"1-3"` -> Output `vec![Regular(1), Regular(2), Regular(3)]`.
+-   **Example**: Input `"1-3"` → Output `vec![Regular(1), Regular(2), Regular(3)]`.
 
 **Phase 2: Resolution (The "Who")**
--   **Location**: [`padz::api::parse_selectors`](file:///src/padz/api.rs)
--   **Role**: Maps `DisplayIndex` -> `UUID` using proper `index_pads` sorting.
+-   **Location**: `src/padz/api.rs` — function `parse_selectors`
+-   **Role**: Converts `DisplayIndex` values to `PadSelector` enums.
 -   **Logic**:
-    1.  Calls `index_pads(store.list())` to get the current state of the world.
-    2.  Finds the UUID corresponding to `Regular(1)`, `Regular(2)`, etc.
-    3.  If any index is out of bounds, returns an Error.
+    1.  Attempts to parse all inputs as indexes/ranges.
+    2.  Deduplicates indexes while preserving order.
+    3.  If any input fails to parse as an index, treats the entire input as a **search term**.
+    4.  Returns `Vec<PadSelector>` (either all `Index` variants or a single `Title` variant).
 
-**Phase 3: Fallback (Search)**
--   If parsing fails (string is not a valid index/range syntax), the entire input is treated as a **Search Term**.
--   `padz list meeting` -> "meeting" is not an index -> Treated as `padz list --search meeting`.
+**Phase 3: Execution**
+-   Command modules receive `Vec<PadSelector>` and resolve to UUIDs using `index_pads`.
+-   Out-of-bounds indexes return errors at this stage.
+
+### 3. Search Fallback
+
+If parsing fails (string is not a valid index/range syntax), the entire input is treated as a **search term**:
+-   `padz view meeting` → "meeting" is not an index → Treated as title search.
+-   All input tokens are joined with spaces and become a single search query.
+
+### 4. Special: Restore and Purge
+
+For commands operating on deleted pads (`restore`, `purge`), bare numbers are auto-prefixed with `d`:
+-   `padz restore 3` → Internally becomes `d3`
+-   `padz restore 1-3` → Internally becomes `d1-d3`
+
+This is handled in `src/padz/api.rs` — function `parse_selectors_for_deleted`.
 
 ### Developer Note
-This layered approach means the `commands` module never deals with parsing logic. It simply receives `Vec<Uuid>` or a `SearchTerm` string.
+
+This layered approach means the `commands` module never deals with parsing logic. It receives `Vec<PadSelector>` and works with that abstraction, keeping input handling contained in the API layer.

--- a/docs/store_architecture.txt
+++ b/docs/store_architecture.txt
@@ -7,36 +7,49 @@ Users trust plain text files—they are future-proof and editable by any tool. H
 ## The Solution: Hybrid Store + Self-Healing
 
 Padz maintains a split-brain model:
-1.  **Truth**: Text Files on disk.
+1.  **Truth**: Text files on disk.
 2.  **Cache**: A JSON metadata "database" (`data.json`).
 
-The system is designed to assume the cache is *always dirty*. It lazily self-heals whenever it touches data.
+The system is designed to assume the cache is *always potentially dirty*. It lazily self-heals whenever it touches data.
 
 ### 1. Filesystem Layout (The Truth)
--   **Location**: [`padz::store::fs`](file:///src/padz/store/fs.rs)
--   **Format**: `pad-{UUID}.txt` (or configured ext).
--   **Philosophy**: If a user manually deletes a file, the pad is gone. If they manually create a file, the pad exists.
+-   **Location**: `src/padz/store/fs.rs`
+-   **Format**: `pad-{UUID}.txt` (or configured extension via `file-ext` config).
+-   **Philosophy**: If a user manually deletes a file, the pad is gone. If they manually create a file with the correct naming, the pad is adopted.
 
 ### 2. Metadata Database (The Cache)
 -   **Location**: `data.json` in the store root.
--   **Struct**: `HashMap<Uuid, Metadata>` (see [`padz::model::Metadata`](file:///src/padz/model.rs))
--   **Role**: Stores O(1) access stats: Title, Created Date, Pinned Status, Delete Protection.
+-   **Structure**: `HashMap<Uuid, Metadata>` (see `src/padz/model.rs`)
+-   **Stored Fields**:
+    - `id`: UUID
+    - `created_at`, `updated_at`: Timestamps
+    - `is_pinned`, `pinned_at`: Pin state
+    - `is_deleted`, `deleted_at`: Soft-delete state
+    - `delete_protected`: Protection flag
+    - `title`: Cached title (for fast listing without reading content files)
 
 ### 3. Synchronization (Self-Healing)
 
-The magic happens in `padz::store::fs::FileStore::sync`. This function is lightweight enough to run often.
+The sync logic runs automatically before listing pads. It is lightweight enough to run often.
 
--   **Code**: `FileStore::sync`
+-   **Code**: `FileStore::sync` in `src/padz/store/fs.rs`
 -   **Logic**:
-    1.  **Orphan Adoption**: Scans directory. If `pad-X.txt` exists but `X` is not in DB -> Parse file and Add to DB.
-    2.  **Zombie Cleanup**: If `X` is in DB but `pad-X.txt` is missing -> Remove from DB.
-    3.  **Staleness Check**: If file `mtime` > DB `updated_at` -> Re-parse file content to update cached Title.
-    4.  **Garbage Collection**: If a file is 0 bytes or whitespace only -> Delete it.
+    1.  **Orphan Adoption**: Scans directory. If `pad-X.txt` exists but `X` is not in DB → Parse file and add to DB.
+    2.  **Zombie Cleanup**: If `X` is in DB but `pad-X.txt` is missing → Remove from DB.
+    3.  **Staleness Check**: If file `mtime` > DB `updated_at` → Re-parse file content to update cached title.
+    4.  **Garbage Collection**: If a file is empty or whitespace only → Delete the file and remove from DB.
 
 ### Lifecycle: Deletion
 
--   **Soft Delete**: `is_deleted = true` in Metadata. File is touched but remains.
-    -   *Why*: Instant undo.
+-   **Soft Delete**: Sets `is_deleted = true` in Metadata. The file remains on disk.
+    -   *Why*: Enables instant undo via `restore`.
 -   **Purge**: `commands::purge` calls `store.delete_pad`.
-    -   *Action*: Removes File physicaly AND removes Metadata entry.
-    -   *Why*: Permanent removal.
+    -   *Action*: Removes the file physically AND removes the Metadata entry.
+    -   *Why*: Permanent, irreversible removal.
+
+### File Extension Handling
+
+The store supports mixed file extensions gracefully:
+- New pads use the configured `file-ext` (default `.txt`)
+- When reading, it first tries the configured extension, then falls back to `.txt`
+- Changing the extension doesn't rename existing files

--- a/docs/store_architecture.txt
+++ b/docs/store_architecture.txt
@@ -1,0 +1,42 @@
+# Store and Database Architecture
+
+## The Problem
+
+Users trust plain text files—they are future-proof and editable by any tool. However, scanning and parsing hundreds of text files for every `padz list` command is prohibitively slow. We need the speed of a database with the transparency of files.
+
+## The Solution: Hybrid Store + Self-Healing
+
+Padz maintains a split-brain model:
+1.  **Truth**: Text Files on disk.
+2.  **Cache**: A JSON metadata "database" (`data.json`).
+
+The system is designed to assume the cache is *always dirty*. It lazily self-heals whenever it touches data.
+
+### 1. Filesystem Layout (The Truth)
+-   **Location**: [`padz::store::fs`](file:///src/padz/store/fs.rs)
+-   **Format**: `pad-{UUID}.txt` (or configured ext).
+-   **Philosophy**: If a user manually deletes a file, the pad is gone. If they manually create a file, the pad exists.
+
+### 2. Metadata Database (The Cache)
+-   **Location**: `data.json` in the store root.
+-   **Struct**: `HashMap<Uuid, Metadata>` (see [`padz::model::Metadata`](file:///src/padz/model.rs))
+-   **Role**: Stores O(1) access stats: Title, Created Date, Pinned Status, Delete Protection.
+
+### 3. Synchronization (Self-Healing)
+
+The magic happens in `padz::store::fs::FileStore::sync`. This function is lightweight enough to run often.
+
+-   **Code**: `FileStore::sync`
+-   **Logic**:
+    1.  **Orphan Adoption**: Scans directory. If `pad-X.txt` exists but `X` is not in DB -> Parse file and Add to DB.
+    2.  **Zombie Cleanup**: If `X` is in DB but `pad-X.txt` is missing -> Remove from DB.
+    3.  **Staleness Check**: If file `mtime` > DB `updated_at` -> Re-parse file content to update cached Title.
+    4.  **Garbage Collection**: If a file is 0 bytes or whitespace only -> Delete it.
+
+### Lifecycle: Deletion
+
+-   **Soft Delete**: `is_deleted = true` in Metadata. File is touched but remains.
+    -   *Why*: Instant undo.
+-   **Purge**: `commands::purge` calls `store.delete_pad`.
+    -   *Action*: Removes File physicaly AND removes Metadata entry.
+    -   *Why*: Permanent removal.

--- a/src/padz/api.rs
+++ b/src/padz/api.rs
@@ -17,6 +17,34 @@
 //! - **I/O operations**: No stdout, stderr, or file formatting
 //! - **Presentation concerns**: Returns data structures, not strings
 //!
+//! ## Selectors: Multi-IDs and Ranges
+//!
+//! Users often need to act on batches of items (`padz delete 1-3`).
+//! The API handles parsing and resolution of these selectors.
+//!
+//! ### Selector Grammar
+//!
+//! - **Regular Index**: `N` (e.g., `1`, `42`)
+//! - **Pinned Index**: `pX` (e.g., `p1`, `p2`)
+//! - **Deleted Index**: `dX` (e.g., `d1`, `d5`)
+//! - **Ranges**: `Start-End` (e.g., `1-5`, `p1-p3`)
+//!   - Must be homogeneous: `1-p3` is **invalid**
+//!   - Start must be ≤ end: `5-3` is **invalid**
+//!
+//! ### Processing Pipeline
+//!
+//! 1. **Parsing**: [`crate::index::parse_index_or_range`] expands `"1-3"` → `[Regular(1), Regular(2), Regular(3)]`
+//! 2. **Resolution**: `parse_selectors` converts to `Vec<PadSelector>`, deduplicating while preserving order
+//! 3. **Search Fallback**: If parsing fails, the entire input becomes a title search term
+//!
+//! ### Special: Restore and Purge
+//!
+//! For commands on deleted pads, bare numbers auto-prefix with `d`:
+//! - `padz restore 3` → Internally becomes `d3`
+//! - `padz restore 1-3` → Internally becomes `d1-d3`
+//!
+//! See `parse_selectors_for_deleted` for implementation.
+//!
 //! ## Generic Over DataStore
 //!
 //! `PadzApi<S: DataStore>` is generic over the storage backend:

--- a/src/padz/cli/mod.rs
+++ b/src/padz/cli/mod.rs
@@ -1,3 +1,59 @@
+//! # CLI Behavior
+//!
+//! This is **one possible UI client** for padz—not the application itself.
+//! The CLI is the only place that knows about terminal I/O, exit codes, and output formatting.
+//!
+//! For the overall architecture, see the crate-level documentation in [`crate`].
+//!
+//! ## Context-Aware Intelligence
+//!
+//! Padz infers intent from execution context (Arguments, Stdin, Clipboard).
+//!
+//! ### Naked Execution (`padz`)
+//!
+//! Running `padz` with no arguments defaults to `padz list`.
+//! The "Read" operation is 90% of usage—it should be the path of least resistance.
+//!
+//! ### Smart Create (`padz create`)
+//!
+//! Priority order for content source:
+//!
+//! 1. **Piped Input** (highest priority)
+//!    - `echo "foo" | padz create`
+//!    - Creates pad with piped content. **Skips editor**.
+//!
+//! 2. **Clipboard** (fallback when no pipe and no title arg)
+//!    - `padz create` (with something in clipboard)
+//!    - Pre-fills editor with clipboard content. **Opens editor**.
+//!
+//! 3. **Title Argument**
+//!    - `padz create "Meeting Notes"`
+//!    - Uses argument as title. Opens editor for body.
+//!
+//! After saving from editor, pad content is automatically copied to clipboard.
+//! Use `--no-editor` flag to skip opening the editor.
+//!
+//! ### View Copies to Clipboard
+//!
+//! `padz view 1` displays the pad AND copies its content to clipboard.
+//! When viewing multiple pads, they are joined with `---` separators.
+//!
+//! ### Explicit Search
+//!
+//! - `padz search <term>` — Explicit search command.
+//! - `padz list --search <term>` — Search within list.
+//! - `padz view <term>` — If term isn't a valid index, treated as title search.
+//!
+//! **Design Choice**: Padz favors explicit commands over magic to prevent confusion.
+//!
+//! ## Module Structure
+//!
+//! - `commands`: Per-command handlers that call API and format output
+//! - `render`: Output formatting (tables, colors, messages)
+//! - `setup`: Argument parsing via clap, help text
+//! - `styles`: Terminal styling constants
+//! - `templates`: Output templates
+
 mod commands;
 mod render;
 pub mod setup;

--- a/src/padz/config.rs
+++ b/src/padz/config.rs
@@ -1,3 +1,43 @@
+//! # Configuration
+//!
+//! Padz exposes configuration as a first-class command, backed by a hierarchical lookup.
+//!
+//! ## Storage Hierarchy
+//!
+//! Configuration is resolved in priority order:
+//! 1. **Project Config**: `.padz/config.json` — Overrides everything for this repo.
+//! 2. **Global Config**: OS-appropriate config directory (via `directories` crate).
+//! 3. **Hardcoded Defaults**: Built-in fallbacks.
+//!
+//! ## Available Settings
+//!
+//! | Key | Default | Description |
+//! |-----|---------|-------------|
+//! | `file-ext` | `.txt` | Extension for new pad files (e.g., `.md`, `.txt`) |
+//! | `import-extensions` | `.md, .txt, .text, .lex` | Extensions for `padz import` |
+//!
+//! ## Extension Behavior
+//!
+//! **`file-ext`**:
+//! - Controls the extension for *newly created* files only.
+//! - Changing this does **not** rename existing files.
+//! - When reading, the store tries the configured extension first, then falls back to `.txt`.
+//!
+//! **`import-extensions`**:
+//! - Comma-separated list of extensions.
+//! - Used by `padz import <directory>` to filter which files to import.
+//!
+//! ## CLI Usage
+//!
+//! - `padz config` — Show all configuration values.
+//! - `padz config <key>` — Get a specific value.
+//! - `padz config <key> <value>` — Set a value.
+//!
+//! ## Developer Note
+//!
+//! [`PadzConfig`] uses `serde` with `#[serde(default)]` for all fields.
+//! This ensures older config files missing new fields use defaults without errors.
+
 use crate::error::{PadzError, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;

--- a/src/padz/lib.rs
+++ b/src/padz/lib.rs
@@ -1,15 +1,19 @@
-//! # Padz Architecture
+//! # Padz Architecture: CLI / Logic Separation
 //!
 //! Padz is a **UI-agnostic note-taking library**. This is not a CLI application that happens
 //! to have some library code—it's a library that happens to have a CLI client.
 //!
-//! This distinction drives the entire architecture and should guide all development.
+//! ## The Problem
 //!
-//! ## The Three-Layer Architecture
+//! Shell programs tend to conflate interface and logic. Before you know it, logic is outputting
+//! strings all over the place and calculations are converting strings to integers. This makes
+//! the program unwieldy and hard to test.
+//!
+//! ## The Solution: Strict Layering
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────┐
-//! │  CLI Layer (cli/, wired by main.rs)                         │
+//! │  CLI Layer (cli/)                                           │
 //! │  - Parses arguments, formats output, handles terminal I/O   │
 //! │  - The ONLY place that knows about stdout/stderr/exit codes │
 //! └─────────────────────────────────────────────────────────────┘
@@ -18,8 +22,8 @@
 //! ┌─────────────────────────────────────────────────────────────┐
 //! │  API Layer (api.rs)                                         │
 //! │  - Thin facade over commands                                │
-//! │  - Normalizes inputs (indexes → UUIDs → Pads)               │
-//! │  - Returns structured Result types                          │
+//! │  - Normalizes inputs (indexes → UUIDs)                      │
+//! │  - Returns structured Result<CmdResult>                     │
 //! └─────────────────────────────────────────────────────────────┘
 //!                              │
 //!                              ▼
@@ -38,15 +42,9 @@
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 //!
-//! ## The index System
-//!    
-//! In order to remanin erggnomic, Padz uses a dual id system that provides a mapping between user
-//! friendly IDs (used throughout the cli) to the stable UUIDs at the data store level.
-//! See index.rs for more information.
-//!
 //! ## Key Principle: No I/O Assumptions in Core
 //!
-//! From `api.rs` inward (API, commands, storage), code:
+//! From `api.rs` inward, code:
 //! - Takes regular Rust function arguments
 //! - Returns regular Rust types (`Result<CmdResult>`)
 //! - **Never** writes to stdout/stderr
@@ -55,19 +53,28 @@
 //!
 //! This means the same core could serve a REST API, a browser app, or any other UI.
 //!
+//! ## The Index System
+//!
+//! To remain ergonomic, padz uses a dual ID system mapping user-friendly display indexes
+//! (`1`, `p1`, `d1`) to stable UUIDs at the data store level.
+//! See [`index`] module for details.
+//!
+//! ## Data Flow Example: `padz delete 1`
+//!
+//! 1. **CLI**: `clap` parses `1`. `handle_delete` receives `vec!["1"]`.
+//! 2. **API**: `parse_selectors` maps `"1"` → `PadSelector::Index(Regular(1))`.
+//! 3. **Command**: Resolves to UUID, checks protection, marks as deleted.
+//! 4. **Return**: `CmdResult` with message "Deleted 1 pad".
+//! 5. **CLI**: Renders the message to terminal.
+//!
 //! ## Testing Strategy
 //!
-//! The architecture enables focused testing at each layer:
-//!
-//! 1. **Commands** (`commands/*.rs`): Thorough unit tests of business logic.
-//!    This is where the lion's share of testing lives.
-//!
-//! 2. **API** (`api.rs`): Mock tests verifying correct dispatch and return types.
-//!    Tests that the right command is called with the right arguments—not the logic itself.
-//!
-//! 3. **CLI** (`cli/` + thin `main.rs`): Tests argument parsing and output formatting.
-//!    - Input: craft shell argument strings, verify correct API calls
-//!    - Output: given a `CmdResult`, verify correct terminal output
+//! | Layer | Test Type | What to Test |
+//! |-------|-----------|--------------|
+//! | CLI | Integration | Arg parsing, output formatting |
+//! | API | Unit | Dispatch correctness, input normalization |
+//! | Commands | Unit | Business logic, state transitions |
+//! | Store | Unit | Read/write operations, sync behavior |
 //!
 //! ## Development Workflow
 //!
@@ -75,20 +82,21 @@
 //!
 //! 1. **Logic**: Implement and fully test in `commands/<cmd>.rs`
 //! 2. **API**: Add facade method in `api.rs`, test dispatch
-//! 3. **CLI**: Add handler in `main.rs`, test arg parsing and output
+//! 3. **CLI**: Add handler in `cli/commands.rs`, test arg parsing and output
 //!
 //! ## Module Overview
 //!
-//! - [`api`]: The API facade—entry point for all operations
+//! - [`api`]: The API facade—entry point for all operations. Also handles selector parsing.
 //! - [`commands`]: Business logic for each command
-//! - [`store`]: Storage abstraction and implementations
-//! - [`model`]: Core data types (`Pad`, `Metadata`, `Scope`)
+//! - [`store`]: Storage abstraction and implementations. See module for hybrid store architecture.
+//! - [`model`]: Core data types and content normalization
 //! - [`index`]: Display indexing system (p1, 1, d1 notation)
+//! - [`init`]: Scope detection and context initialization
 //! - [`config`]: Configuration management
 //! - [`editor`]: External editor integration
 //! - [`clipboard`]: Cross-platform clipboard support
 //! - [`error`]: Error types
-//! - `cli`: Argument parsing, printing, templated rendering, and shell completions for the binary (not part of the lib API)
+//! - `cli`: CLI behavior, argument parsing, and output formatting (not part of lib API)
 
 pub mod api;
 pub mod clipboard;

--- a/src/padz/store/mod.rs
+++ b/src/padz/store/mod.rs
@@ -3,52 +3,60 @@
 //! This module defines the storage abstraction for padz. The [`DataStore`] trait
 //! allows the application to work with different storage backends.
 //!
-//! ## Architecture: Lazy Reconciler
+//! ## Hybrid Store Architecture
 //!
-//! Padz uses a **file-system-centric** architecture where the file system is the ultimate
-//! source of truth. The database (`data.json`) acts as a lightweight metadata cache/registry.
+//! Padz maintains a split-brain model:
+//! 1. **Truth**: Text files on disk.
+//! 2. **Cache**: A JSON metadata "database" (`data.json`).
+//!
+//! The system assumes the cache is *always potentially dirty* and self-heals lazily.
 //!
 //! ### Philosophy
-//! - **Files are Truth**: If a file exists in `.padz/`, it is a valid pad. If it is deleted, the pad is gone.
-//! - **Lazy Reconciliation**: The database is updated (reconciled) lazily whenever a "read" operation (like `list`) occurs.
-//! - **Robustness**: Operations are robust against process termination. The editor saves content directly to disk.
-//!   If `padz` crashes or is killed, the file remains safe on disk and will be picked up by the next reconciliation.
+//! - **Files are Truth**: If a file exists in `.padz/`, it is a valid pad. If deleted, the pad is gone.
+//! - **Lazy Reconciliation**: The database is updated whenever a "read" operation occurs.
+//! - **Robustness**: Operations are robust against process termination. The editor saves directly to disk.
 //!
-//! ### Reconciliation Logic
+//! ## Reconciliation Logic
 //!
-//! The reconciliation process (`sync`) runs automatically before listing pads. It handles three key scenarios:
+//! The `sync` process runs automatically before listing pads:
 //!
-//! 1. **Zombie Files** (Database Clean-up)
-//!    - **Condition**: File is listed in `data.json` but does not exist on disk.
-//!    - **Action**: The database entry is removed.
+//! 1. **Orphan Adoption**: `pad-X.txt` exists but `X` not in DB → Parse and add to DB.
+//! 2. **Zombie Cleanup**: `X` in DB but `pad-X.txt` missing → Remove from DB.
+//! 3. **Staleness Check**: File `mtime` > DB `updated_at` → Re-parse to update cached title.
+//! 4. **Garbage Collection**: Empty/whitespace-only file → Delete file and DB entry.
 //!
-//! 2. **Orphaned Files** (Discovery)
-//!    - **Condition**: File exists on disk (`pad-{uuid}.txt`) but has no entry in `data.json`.
-//!    - **Action**: The file is parsed, and a new entry is added to the database.
+//! ## Deletion Lifecycle
 //!
-//! 3. **Empty Files** (Garbage Collection)
-//!    - **Condition**: A file on disk has empty or whitespace-only content.
-//!    - **Action**: The file is deleted from disk, and its database entry is removed.
+//! - **Soft Delete**: Sets `is_deleted = true` in Metadata. File remains on disk for undo.
+//! - **Purge**: Permanently removes both file and metadata entry.
 //!
-//! ### Safety & Recovery
+//! ## File Extension Handling
 //!
-//! This design provides strong safety guarantees:
-//! - **Crash Recovery**: Since the editor operates directly on the file, saving works independently of the `padz` process.
-//!   Any content saved by the editor is "safe" and will be discovered by the Reconciler.
-//! - **External Edits**: Users can manually create or edit files in `.padz/`. The system accepts these as valid changes.
+//! - New pads use the configured `file-ext` (default `.txt`)
+//! - When reading, tries configured extension first, falls back to `.txt`
+//! - Mixed extensions are supported gracefully
+//!
+//! ## Metadata Fields
+//!
+//! The `data.json` stores `HashMap<Uuid, Metadata>` with:
+//! - `id`, `created_at`, `updated_at`: Identity and timestamps
+//! - `is_pinned`, `pinned_at`: Pin state
+//! - `is_deleted`, `deleted_at`: Soft-delete state
+//! - `delete_protected`: Protection flag
+//! - `title`: Cached title for fast listing
 //!
 //! ## Implementations
 //!
 //! - [`fs::FileStore`]: Production implementation of the Lazy Reconciler architecture.
 //! - [`memory::InMemoryStore`]: For testing logic without filesystem I/O.
 //!
-//! ## Storage Format
+//! ## Storage Layout
 //!
 //! ```text
 //! .padz/
-//! ├── data.json           # Metadata Cache (Registry, pinned status, cached titles)
-//! ├── pad-{uuid}.{ext}    # Source of Truth: Pad content
-//! └── config.json         # Scope configuration
+//! ├── data.json           # Metadata Cache
+//! ├── config.json         # Scope configuration
+//! └── pad-{uuid}.{ext}    # Pad content files
 //! ```
 
 use crate::error::Result;


### PR DESCRIPTION
- **docs: Add initial documentation for pad identifiers, scopes, store architecture, and CLI/logic separation.**
- **Improved cargo docs**
