### PR TITLE
feat: Leverage Outstanding 0.3.2 with outstanding-clap for styled CLI help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21d8ad60dd5b13a4ee6bd8fa2d5d88965c597c67bce32b5fc49c94f55cb50810"
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,16 +1140,29 @@ dependencies = [
 
 [[package]]
 name = "outstanding"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20f8b19d290c039ca0d47ca2a97be7500f46dbec9847b2824a32c517ca1fa98"
+checksum = "0ad7975648e687cad845e637a6ce46144bf7803b41a35f73ace24bffaafcdc76"
 dependencies = [
  "console",
  "dark-light",
+ "deunicode",
  "minijinja",
  "once_cell",
  "serde",
  "unicode-width",
+]
+
+[[package]]
+name = "outstanding-clap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27aa54c11f4227c6fe5514d67d2ba254b269547ee39e39faa501ecfad872494a"
+dependencies = [
+ "clap",
+ "console",
+ "outstanding",
+ "serde",
 ]
 
 [[package]]
@@ -1159,6 +1178,7 @@ dependencies = [
  "flate2",
  "once_cell",
  "outstanding",
+ "outstanding-clap",
  "predicates",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.53", features = ["derive"] }
 console = "0.15"
 outstanding = "0.3.2"
+outstanding-clap = "0.1.0"
 colored = "3.0.0"
 directories = "6.0.0"
 flate2 = "1.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/padz/main.rs"
 chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.53", features = ["derive"] }
 console = "0.15"
-outstanding = "0.2.2"
+outstanding = "0.3.2"
 colored = "3.0.0"
 directories = "6.0.0"
 flate2 = "1.1.5"

--- a/src/padz/cli/styles.rs
+++ b/src/padz/cli/styles.rs
@@ -45,6 +45,12 @@ pub mod names {
     pub const LIST_TITLE: &str = "list-title";
     pub const DELETED_INDEX: &str = "deleted-index";
     pub const DELETED_TITLE: &str = "deleted-title";
+    // Help styles
+    pub const HELP_HEADER: &str = "help-header";
+    pub const HELP_SECTION: &str = "help-section";
+    pub const HELP_COMMAND: &str = "help-command";
+    pub const HELP_DESC: &str = "help-desc";
+    pub const HELP_USAGE: &str = "help-usage";
 }
 
 pub static PADZ_THEME: Lazy<AdaptiveTheme> =
@@ -70,6 +76,12 @@ fn build_light_theme() -> Theme {
     let list_title = regular.clone(); // Normal text for list titles (not bold)
     let deleted_index = Style::new().color256(rgb_to_ansi256((186, 33, 45))); // Red for deleted indexes
     let deleted_title = muted.clone(); // Muted gray for deleted titles
+                                       // Help styles
+    let help_header = regular.clone().bold();
+    let help_section = Style::new().color256(rgb_to_ansi256((196, 140, 0))).bold();
+    let help_command = Style::new().color256(rgb_to_ansi256((0, 128, 0)));
+    let help_desc = muted.clone();
+    let help_usage = Style::new().cyan();
 
     Theme::new()
         .add(names::REGULAR, regular)
@@ -88,6 +100,11 @@ fn build_light_theme() -> Theme {
         .add(names::LIST_TITLE, list_title)
         .add(names::DELETED_INDEX, deleted_index)
         .add(names::DELETED_TITLE, deleted_title)
+        .add(names::HELP_HEADER, help_header)
+        .add(names::HELP_SECTION, help_section)
+        .add(names::HELP_COMMAND, help_command)
+        .add(names::HELP_DESC, help_desc)
+        .add(names::HELP_USAGE, help_usage)
 }
 
 fn build_dark_theme() -> Theme {
@@ -110,6 +127,12 @@ fn build_dark_theme() -> Theme {
     let list_title = regular.clone(); // Normal text for list titles (not bold)
     let deleted_index = Style::new().color256(rgb_to_ansi256((255, 138, 128))); // Red for deleted indexes
     let deleted_title = muted.clone(); // Muted gray for deleted titles
+                                       // Help styles
+    let help_header = regular.clone().bold();
+    let help_section = Style::new().color256(rgb_to_ansi256((255, 214, 10))).bold();
+    let help_command = Style::new().color256(rgb_to_ansi256((144, 238, 144)));
+    let help_desc = muted.clone();
+    let help_usage = Style::new().cyan();
 
     Theme::new()
         .add(names::REGULAR, regular)
@@ -128,4 +151,9 @@ fn build_dark_theme() -> Theme {
         .add(names::LIST_TITLE, list_title)
         .add(names::DELETED_INDEX, deleted_index)
         .add(names::DELETED_TITLE, deleted_title)
+        .add(names::HELP_HEADER, help_header)
+        .add(names::HELP_SECTION, help_section)
+        .add(names::HELP_COMMAND, help_command)
+        .add(names::HELP_DESC, help_desc)
+        .add(names::HELP_USAGE, help_usage)
 }

--- a/src/padz/cli/templates/help.tmp
+++ b/src/padz/cli/templates/help.tmp
@@ -1,0 +1,14 @@
+{{ about | style("help-header") | nl }}
+{{ "Usage:" | style("help-header") }} {{ usage | style("help-usage") | nl }}
+{%- for group in groups %}
+
+{{ group.title | style("help-section") }}
+{%- for cmd in group.commands %}
+  {{ cmd.name | style("help-command") }}{{ cmd.padding }}{{ cmd.about | style("help-desc") }}
+{%- endfor %}
+{%- endfor %}
+
+{{ "Options:" | style("help-header") }}
+{%- for opt in options %}
+  {{ opt.name | style("help-command") }}{{ opt.padding }}{{ opt.help | style("help-desc") }}
+{%- endfor %}

--- a/src/padz/cli/templates/subcommand_help.tmp
+++ b/src/padz/cli/templates/subcommand_help.tmp
@@ -1,0 +1,18 @@
+{{ about | style("about") | nl }}
+{{ usage | style("usage") | nl }}
+{% if subcommands -%}
+{{ "Commands:" | style("header") }}
+{% for group in subcommands -%}
+{% for cmd in group.commands -%}
+  {{ cmd.name | style("item") }}{{ cmd.padding }}{{ cmd.about | style("desc") }}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}
+{% if options -%}
+{{ "Options:" | style("header") }}
+{% for group in options -%}
+{% for opt in group.options -%}
+  {{ opt.name | style("item") }}{{ opt.padding }}{{ opt.help | style("desc") }}
+{% endfor -%}
+{% endfor -%}
+{% endif -%}


### PR DESCRIPTION
## Summary

- Update outstanding crate to version 0.3.2
- Integrate outstanding-clap for styled CLI help rendering:
  - Grouped help (`padz help`) uses outstanding templates with custom command groupings (Core, Pad, Data, Misc)
  - Subcommand help uses outstanding-clap's `render_help` with custom template
  - Add help-specific styles to light and dark themes (help-header, help-section, help-command, help-desc, help-usage)
  - Colors are adaptive based on terminal background

## Test plan

- [x] `cargo test` - all 111 tests pass
- [x] `padz help` - shows styled grouped help
- [x] `padz -h` - shows styled short help
- [x] `padz help <command>` - shows styled subcommand help
- [x] `padz <command> -h` - shows styled subcommand help
- [x] Colors display correctly in terminal with pseudo-tty

🤖 Generated with [Claude Code](https://claude.com/claude-code)