### PR TITLE
feat: Implement Tree Support (Nesting)

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -119,7 +119,11 @@ pub fn run() -> Result<()> {
             PadCommands::Path { indexes } => handle_paths(&mut ctx, indexes),
         },
         Some(Commands::Data(cmd)) => match cmd {
-            DataCommands::Purge { indexes, yes } => handle_purge(&mut ctx, indexes, yes),
+            DataCommands::Purge {
+                indexes,
+                yes,
+                recursive,
+            } => handle_purge(&mut ctx, indexes, yes, recursive),
             DataCommands::Export {
                 single_file,
                 indexes,
@@ -351,8 +355,13 @@ fn handle_paths(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn handle_purge(ctx: &mut AppContext, indexes: Vec<String>, yes: bool) -> Result<()> {
-    let result = ctx.api.purge_pads(ctx.scope, &indexes, yes)?;
+fn handle_purge(
+    ctx: &mut AppContext,
+    indexes: Vec<String>,
+    yes: bool,
+    recursive: bool,
+) -> Result<()> {
+    let result = ctx.api.purge_pads(ctx.scope, &indexes, yes, recursive)?;
     print_messages(&result.messages);
     Ok(())
 }

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -88,14 +88,18 @@ pub fn run() -> Result<()> {
 
     match cli.command {
         Some(Commands::Core(cmd)) => match cmd {
-            CoreCommands::Create { title, no_editor } => {
+            CoreCommands::Create {
+                title,
+                no_editor,
+                inside,
+            } => {
                 // Join all title words with spaces
                 let title = if title.is_empty() {
                     None
                 } else {
                     Some(title.join(" "))
                 };
-                handle_create(&mut ctx, title, no_editor)
+                handle_create(&mut ctx, title, no_editor, inside)
             }
             CoreCommands::List {
                 search,
@@ -144,7 +148,12 @@ fn init_context(cli: &Cli) -> Result<AppContext> {
     })
 }
 
-fn handle_create(ctx: &mut AppContext, title: Option<String>, no_editor: bool) -> Result<()> {
+fn handle_create(
+    ctx: &mut AppContext,
+    title: Option<String>,
+    no_editor: bool,
+    inside: Option<String>,
+) -> Result<()> {
     let mut final_title = title;
     let mut initial_content = String::new();
     let mut should_open_editor = !no_editor;
@@ -184,10 +193,12 @@ fn handle_create(ctx: &mut AppContext, title: Option<String>, no_editor: bool) -
 
     // Use provided/parsed title or "Untitled" as placeholder
     let title_to_use = final_title.unwrap_or_else(|| "Untitled".to_string());
+    // Convert Option<String> to Option<&str> for API
+    let parent = inside.as_deref();
 
     let result = ctx
         .api
-        .create_pad(ctx.scope, title_to_use, initial_content)?;
+        .create_pad(ctx.scope, title_to_use, initial_content, parent)?;
     print_messages(&result.messages);
 
     // Open editor if requested/appropriate

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -257,6 +257,10 @@ pub enum DataCommands {
         /// Skip confirmation
         #[arg(long, short = 'y')]
         yes: bool,
+
+        /// Required when purging pads that have children (will purge entire subtree)
+        #[arg(long, short = 'r')]
+        recursive: bool,
     },
 
     /// Export pads to a tar.gz archive (or single file with --single-file)

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -144,6 +144,10 @@ pub enum CoreCommands {
         #[arg(long)]
         no_editor: bool,
 
+        /// Create inside another pad (parent selector, e.g. 1 or p1)
+        #[arg(long, short = 'i')]
+        inside: Option<String>,
+
         /// Title words (joined with spaces, optional - opens empty editor if not provided)
         #[arg(trailing_var_arg = true)]
         title: Vec<String>,

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -161,9 +161,10 @@ impl<S: DataStore> PadzApi<S> {
         scope: Scope,
         indexes: &[I],
         skip_confirm: bool,
+        recursive: bool,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        commands::purge::run(&mut self.store, scope, &selectors, skip_confirm)
+        commands::purge::run(&mut self.store, scope, &selectors, skip_confirm, recursive)
     }
 
     pub fn restore_pads<I: AsRef<str>>(

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -156,15 +156,27 @@ impl<S: DataStore> PadzApi<S> {
         commands::update::run(&mut self.store, scope, updates)
     }
 
+    /// Returns a preview of what would be purged without actually deleting.
+    /// Use this to show a confirmation prompt before calling `purge_pads`.
+    pub fn preview_purge<I: AsRef<str>>(
+        &self,
+        scope: Scope,
+        indexes: &[I],
+        recursive: bool,
+    ) -> Result<commands::purge::PurgePreview> {
+        let selectors = parse_selectors(indexes)?;
+        commands::purge::preview(&self.store, scope, &selectors, recursive)
+    }
+
+    /// Permanently deletes pads. Call `preview_purge` first to show confirmation.
     pub fn purge_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
-        skip_confirm: bool,
         recursive: bool,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        commands::purge::run(&mut self.store, scope, &selectors, skip_confirm, recursive)
+        commands::purge::run(&mut self.store, scope, &selectors, recursive)
     }
 
     pub fn restore_pads<I: AsRef<str>>(

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -255,9 +255,8 @@ fn parse_selectors<I: AsRef<str>>(inputs: &[I]) -> Result<Vec<PadSelector>> {
     for input in inputs {
         match parse_index_or_range(input.as_ref()) {
             Ok(selector) => all_selectors.push(selector),
-            Err(_e) => {
-                // Check if it's a specific error (though index.rs now only parses syntax)
-                // If it fails syntax, we assume it's a title search
+            Err(_) => {
+                // Non-index input - treat entire input as title search
                 parse_failed = true;
                 break;
             }
@@ -265,27 +264,13 @@ fn parse_selectors<I: AsRef<str>>(inputs: &[I]) -> Result<Vec<PadSelector>> {
     }
 
     if !parse_failed {
-        // Deduplicate? Paths might be dupe.
-        // We can't easily dedup PadSelector without Hash/Eq, which it should derive.
-        // But PadSelector::Range/Path contains Vec which are Hash/Eq.
-        // But for now let's just return all of them.
-        // To be safe against dupes, we can convert to string and dedup?
-        // Or implement Hash for PadSelector in index.rs (it derived PartialEq, Eq).
-        // Let's assume index.rs added Hash.
-
-        // Wait, PadSelector needs Hash for HashSet.
-        // I'll add Hash to PadSelector derive in index.rs?
-        // It has Vec<DisplayIndex>. DisplayIndex is Hash.
-        // So yes, I should add Hash to PadSelector.
-
+        // Deduplicate while preserving order
         let mut unique_selectors = Vec::new();
-        // Simple dedup
         for s in all_selectors {
             if !unique_selectors.contains(&s) {
                 unique_selectors.push(s);
             }
         }
-
         return Ok(unique_selectors);
     }
 

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -66,10 +66,9 @@
 
 use crate::commands;
 use crate::error::{PadzError, Result};
-use crate::index::{parse_index_or_range, DisplayIndex, PadSelector};
+use crate::index::{parse_index_or_range, PadSelector};
 use crate::model::Scope;
 use crate::store::DataStore;
-use std::collections::HashSet;
 
 /// The main API facade for padz operations.
 ///
@@ -90,8 +89,14 @@ impl<S: DataStore> PadzApi<S> {
         scope: Scope,
         title: String,
         content: String,
+        parent: Option<&str>,
     ) -> Result<commands::CmdResult> {
-        commands::create::run(&mut self.store, scope, title, content)
+        let parent_selector = if let Some(p) = parent {
+            Some(parse_index_or_range(p).map_err(PadzError::Api)?)
+        } else {
+            None
+        };
+        commands::create::run(&mut self.store, scope, title, content, parent_selector)
     }
 
     pub fn get_pads(&self, scope: Scope, filter: PadFilter) -> Result<commands::CmdResult> {
@@ -222,17 +227,15 @@ impl<S: DataStore> PadzApi<S> {
 
 fn parse_selectors<I: AsRef<str>>(inputs: &[I]) -> Result<Vec<PadSelector>> {
     // 1. Try to parse ALL inputs as DisplayIndex (including ranges like "3-5")
-    let mut all_indexes: Vec<DisplayIndex> = Vec::new();
+    let mut all_selectors = Vec::new();
     let mut parse_failed = false;
 
     for input in inputs {
         match parse_index_or_range(input.as_ref()) {
-            Ok(indexes) => all_indexes.extend(indexes),
-            Err(e) => {
-                // Check if it's a range error (explicit error message) vs just not an index
-                if e.contains("Invalid range") || e.contains("cannot mix") {
-                    return Err(PadzError::Api(e));
-                }
+            Ok(selector) => all_selectors.push(selector),
+            Err(_e) => {
+                // Check if it's a specific error (though index.rs now only parses syntax)
+                // If it fails syntax, we assume it's a title search
                 parse_failed = true;
                 break;
             }
@@ -240,14 +243,28 @@ fn parse_selectors<I: AsRef<str>>(inputs: &[I]) -> Result<Vec<PadSelector>> {
     }
 
     if !parse_failed {
-        // Deduplicate while preserving order
-        let mut seen = HashSet::new();
-        let unique_indexes: Vec<DisplayIndex> = all_indexes
-            .into_iter()
-            .filter(|idx| seen.insert(idx.clone()))
-            .collect();
+        // Deduplicate? Paths might be dupe.
+        // We can't easily dedup PadSelector without Hash/Eq, which it should derive.
+        // But PadSelector::Range/Path contains Vec which are Hash/Eq.
+        // But for now let's just return all of them.
+        // To be safe against dupes, we can convert to string and dedup?
+        // Or implement Hash for PadSelector in index.rs (it derived PartialEq, Eq).
+        // Let's assume index.rs added Hash.
 
-        return Ok(unique_indexes.into_iter().map(PadSelector::Index).collect());
+        // Wait, PadSelector needs Hash for HashSet.
+        // I'll add Hash to PadSelector derive in index.rs?
+        // It has Vec<DisplayIndex>. DisplayIndex is Hash.
+        // So yes, I should add Hash to PadSelector.
+
+        let mut unique_selectors = Vec::new();
+        // Simple dedup
+        for s in all_selectors {
+            if !unique_selectors.contains(&s) {
+                unique_selectors.push(s);
+            }
+        }
+
+        return Ok(unique_selectors);
     }
 
     // 2. If any failed (meaning there are non-index strings), treat as ONE search query
@@ -275,17 +292,30 @@ fn parse_selectors_for_deleted<I: AsRef<str>>(inputs: &[I]) -> Result<Vec<PadSel
 /// Normalizes an index string to a deleted index if it's a bare number.
 /// "3" -> "d3", "d3" -> "d3", "p1" -> "p1", "3-5" -> "d3-d5"
 fn normalize_to_deleted_index(s: &str) -> String {
-    // Handle ranges: if it contains a dash (not at start), normalize both parts
     if let Some(dash_pos) = s.find('-') {
         if dash_pos > 0 {
-            let start = &s[..dash_pos];
-            let end = &s[dash_pos + 1..];
-            let norm_start = normalize_single_to_deleted(start);
-            let norm_end = normalize_single_to_deleted(end);
-            return format!("{}-{}", norm_start, norm_end);
+            let start_str = &s[..dash_pos];
+            let end_str = &s[dash_pos + 1..];
+            let normalized_start = normalize_path_for_deleted(start_str);
+            let normalized_end = normalize_path_for_deleted(end_str);
+            return format!("{}-{}", normalized_start, normalized_end);
         }
     }
-    normalize_single_to_deleted(s)
+    normalize_path_for_deleted(s)
+}
+
+/// Normalizes a path string (e.g., "1", "1.2", "p1") for deleted operations.
+/// This means the *last* segment of a path, if it's a bare number, gets prefixed with 'd'.
+/// "3" -> "d3"
+/// "1.2" -> "1.d2"
+/// "p1.2" -> "p1.d2"
+/// "d1.2" -> "d1.d2"
+fn normalize_path_for_deleted(s: &str) -> String {
+    let mut parts: Vec<String> = s.split('.').map(|s| s.to_string()).collect();
+    if let Some(last) = parts.last_mut() {
+        *last = normalize_single_to_deleted(last);
+    }
+    parts.join(".")
 }
 
 /// Normalizes a single index (not a range) to deleted format.
@@ -299,6 +329,8 @@ fn normalize_single_to_deleted(s: &str) -> String {
     }
 }
 
+// parse_index_or_range and parse_path removed (imported from index.rs)
+
 pub use crate::commands::config::ConfigAction;
 pub use commands::get::{PadFilter, PadStatusFilter};
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
@@ -306,7 +338,7 @@ pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    use crate::index::{DisplayIndex, PadSelector};
     #[test]
     fn test_normalize_single_to_deleted() {
         // Bare numbers get 'd' prefix
@@ -346,6 +378,15 @@ mod tests {
         // Single indexes (no range)
         assert_eq!(normalize_to_deleted_index("3"), "d3");
         assert_eq!(normalize_to_deleted_index("d3"), "d3");
+
+        // Hierarchical paths
+        assert_eq!(normalize_to_deleted_index("1.2"), "1.d2");
+        assert_eq!(normalize_to_deleted_index("p1.2"), "p1.d2");
+        assert_eq!(normalize_to_deleted_index("d1.2"), "d1.d2");
+        assert_eq!(normalize_to_deleted_index("1.p2"), "1.p2");
+        assert_eq!(normalize_to_deleted_index("1.d2"), "1.d2");
+        assert_eq!(normalize_to_deleted_index("1.2-1.4"), "1.d2-1.d4");
+        assert_eq!(normalize_to_deleted_index("d1.2-d1.4"), "d1.d2-d1.d4");
     }
 
     #[test]
@@ -355,9 +396,20 @@ mod tests {
         let selectors = parse_selectors_for_deleted(&inputs).unwrap();
 
         assert_eq!(selectors.len(), 3);
-        assert_eq!(selectors[0], PadSelector::Index(DisplayIndex::Deleted(1)));
-        assert_eq!(selectors[1], PadSelector::Index(DisplayIndex::Deleted(3)));
-        assert_eq!(selectors[2], PadSelector::Index(DisplayIndex::Deleted(5)));
+        // They are Paths now
+        assert!(matches!(selectors[0], PadSelector::Path(_)));
+        if let PadSelector::Path(path) = &selectors[0] {
+            assert_eq!(path.len(), 1);
+            assert!(matches!(path[0], DisplayIndex::Deleted(1)));
+        }
+        if let PadSelector::Path(path) = &selectors[1] {
+            assert_eq!(path.len(), 1);
+            assert!(matches!(path[0], DisplayIndex::Deleted(3)));
+        }
+        if let PadSelector::Path(path) = &selectors[2] {
+            assert_eq!(path.len(), 1);
+            assert!(matches!(path[0], DisplayIndex::Deleted(5)));
+        }
     }
 
     #[test]
@@ -366,9 +418,35 @@ mod tests {
         let inputs = vec!["1-3"];
         let selectors = parse_selectors_for_deleted(&inputs).unwrap();
 
-        assert_eq!(selectors.len(), 3);
-        assert_eq!(selectors[0], PadSelector::Index(DisplayIndex::Deleted(1)));
-        assert_eq!(selectors[1], PadSelector::Index(DisplayIndex::Deleted(2)));
-        assert_eq!(selectors[2], PadSelector::Index(DisplayIndex::Deleted(3)));
+        assert_eq!(selectors.len(), 1);
+        match &selectors[0] {
+            PadSelector::Range(start, end) => {
+                assert_eq!(start.len(), 1);
+                assert!(matches!(start[0], DisplayIndex::Deleted(1)));
+                assert_eq!(end.len(), 1);
+                assert!(matches!(end[0], DisplayIndex::Deleted(3)));
+            }
+            _ => panic!("Expected Range"),
+        }
+    }
+
+    #[test]
+    fn test_parse_selectors_for_deleted_with_hierarchical_range() {
+        let inputs = vec!["1.2-1.4"];
+        let selectors = parse_selectors_for_deleted(&inputs).unwrap();
+
+        assert_eq!(selectors.len(), 1);
+        match &selectors[0] {
+            PadSelector::Range(start_path, end_path) => {
+                assert_eq!(start_path.len(), 2);
+                assert!(matches!(start_path[0], DisplayIndex::Regular(1)));
+                assert!(matches!(start_path[1], DisplayIndex::Deleted(2)));
+
+                assert_eq!(end_path.len(), 2);
+                assert!(matches!(end_path[0], DisplayIndex::Regular(1)));
+                assert!(matches!(end_path[1], DisplayIndex::Deleted(4)));
+            }
+            _ => panic!("Expected PadSelector::Range"),
+        }
     }
 }

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -8,8 +8,32 @@ pub fn run<S: DataStore>(
     scope: Scope,
     title: String,
     content: String,
+    parent_selector: Option<crate::index::PadSelector>,
 ) -> Result<CmdResult> {
-    let pad = Pad::new(title, content);
+    let mut pad = Pad::new(title, content);
+
+    if let Some(selector) = parent_selector {
+        // Resolve parent
+        let resolved = super::helpers::resolve_selectors(store, scope, &[selector], false)?;
+
+        match resolved.len() {
+            0 => {
+                return Err(crate::error::PadzError::Api(
+                    "Parent pad not found".to_string(),
+                ))
+            }
+            1 => {
+                let (_, parent_id) = resolved[0];
+                pad.metadata.parent_id = Some(parent_id);
+            }
+            _ => {
+                return Err(crate::error::PadzError::Api(
+                    "Parent selector is ambiguous/multiple matches".to_string(),
+                ))
+            }
+        }
+    }
+
     store.save_pad(&pad, scope)?;
 
     let mut result = CmdResult::default();
@@ -19,4 +43,36 @@ pub fn run<S: DataStore>(
         pad.metadata.title
     )));
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::{DisplayIndex, PadSelector};
+    use crate::store::memory::InMemoryStore;
+
+    #[test]
+    fn creates_nested_pad() {
+        let mut store = InMemoryStore::new();
+        // Create parent
+        run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+
+        // Create child
+        let parent_sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(parent_sel),
+        )
+        .unwrap();
+
+        // Check relationship
+        let pads = store.list_pads(Scope::Project).unwrap();
+        let child = pads.iter().find(|p| p.metadata.title == "Child").unwrap();
+        let parent = pads.iter().find(|p| p.metadata.title == "Parent").unwrap();
+
+        assert_eq!(child.metadata.parent_id, Some(parent.metadata.id));
+    }
 }

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -14,17 +14,64 @@ pub fn run<S: DataStore>(
 ) -> Result<CmdResult> {
     let resolved = resolve_selectors(store, scope, selectors, true)?;
     let mut result = CmdResult::default();
+    // Resetting loop logic entirely
+    // The first `success_count` was unused due to shadowing. Removed it.
 
-    for (display_index, uuid) in resolved {
-        let mut pad = store.get_pad(&uuid, scope)?;
-        pad.metadata.is_deleted = true;
-        pad.metadata.deleted_at = Some(Utc::now());
-        store.save_pad(&pad, scope)?;
-        result.add_message(CmdMessage::success(format!(
-            "Pad deleted ({}): {}",
-            display_index, pad.metadata.title
-        )));
-        result.affected_pads.push(pad);
+    use uuid::Uuid;
+
+    // Check compliance: If any descendant is pinned/protected, we abort.
+    let target_ids: Vec<Uuid> = resolved.iter().map(|(_, id)| *id).collect();
+    let descendants = super::helpers::get_descendant_ids(store, scope, &target_ids)?;
+
+    // Check descendants for protection
+    for descendant_id in descendants {
+        let p = store.get_pad(&descendant_id, scope)?;
+        if p.metadata.delete_protected {
+            // Find pretty name for error? "pX.X" isn't easy to construct without index.
+            // Just use Title.
+            return Err(crate::error::PadzError::Api(format!(
+                "Cannot delete because descendant '{}' is pinned/protected",
+                p.metadata.title
+            )));
+        }
+    }
+
+    for (path, id) in resolved {
+        let s: Vec<String> = path.iter().map(|idx| idx.to_string()).collect();
+        let display = s.join(".");
+
+        // Fetch pad first to return it
+        let pad = match store.get_pad(&id, scope) {
+            Ok(pad) => pad,
+            Err(e) => {
+                result.add_message(CmdMessage::error(format!(
+                    "Failed to find pad {}: {}",
+                    display, e
+                )));
+                continue;
+            }
+        };
+
+        // Soft delete
+        let mut pad_to_update = pad.clone();
+        pad_to_update.metadata.is_deleted = true;
+        pad_to_update.metadata.deleted_at = Some(Utc::now());
+
+        match store.save_pad(&pad_to_update, scope) {
+            Ok(_) => {
+                result.add_message(CmdMessage::success(format!(
+                    "Deleted pad {}: {}",
+                    display, pad.metadata.title
+                )));
+                result.affected_pads.push(pad);
+            }
+            Err(e) => {
+                result.add_message(CmdMessage::error(format!(
+                    "Failed to delete pad {}: {}",
+                    display, e
+                )));
+            }
+        }
     }
 
     Ok(result)
@@ -41,11 +88,11 @@ mod tests {
     #[test]
     fn marks_pad_as_deleted() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Title".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Title".into(), "".into(), None).unwrap();
         run(
             &mut store,
             Scope::Project,
-            &[PadSelector::Index(DisplayIndex::Regular(1))],
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
         )
         .unwrap();
 
@@ -68,7 +115,14 @@ mod tests {
     #[test]
     fn delete_protected_pad_fails() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Protected".into(), "".into()).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Protected".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
 
         // Manually protect the pad (since pin command logic isn't coupled yet or might not be updated yet)
         let pad_id = get::run(&store, Scope::Project, get::PadFilter::default())
@@ -86,7 +140,7 @@ mod tests {
         let result = run(
             &mut store,
             Scope::Project,
-            &[PadSelector::Index(DisplayIndex::Regular(1))],
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
         );
 
         assert!(result.is_err());

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -34,7 +34,8 @@ pub fn run<S: DataStore>(
     // Re-index to get the new deleted indexes
     let indexed = indexed_pads(store, scope)?;
     for uuid in deleted_uuids {
-        if let Some(dp) = find_deleted_pad(&indexed, uuid) {
+        // Find the pad with any index type (deleted pads may have Deleted index)
+        if let Some(dp) = super::helpers::find_pad_by_uuid(&indexed, uuid, |_| true) {
             result.affected_pads.push(DisplayPad {
                 pad: dp.pad.clone(),
                 index: dp.index.clone(),
@@ -45,18 +46,6 @@ pub fn run<S: DataStore>(
     }
 
     Ok(result)
-}
-
-fn find_deleted_pad(pads: &[DisplayPad], uuid: Uuid) -> Option<&DisplayPad> {
-    for dp in pads {
-        if dp.pad.metadata.id == uuid {
-            return Some(dp);
-        }
-        if let Some(found) = find_deleted_pad(&dp.children, uuid) {
-            return Some(found);
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/padzapp/src/commands/export.rs
+++ b/crates/padzapp/src/commands/export.rs
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn test_resolve_pads_exports_active_by_default() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Active".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Active".into(), "".into(), None).unwrap();
 
         let mut del_pad = crate::model::Pad::new("Deleted".into(), "".into());
         del_pad.metadata.is_deleted = true;
@@ -336,7 +336,14 @@ mod tests {
     #[test]
     fn test_write_archive_produces_content() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Test".into(), "Content".into()).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Test".into(),
+            "Content".into(),
+            None,
+        )
+        .unwrap();
         let pads = resolve_pads(&store, Scope::Project, &[]).unwrap();
 
         let mut buf = Vec::new();
@@ -422,11 +429,13 @@ mod tests {
             pad: crate::model::Pad::new("First Pad".into(), "Content one".into()),
             index: DisplayIndex::Regular(1),
             matches: None,
+            children: vec![],
         };
         let pad2 = DisplayPad {
             pad: crate::model::Pad::new("Second Pad".into(), "Content two".into()),
             index: DisplayIndex::Regular(2),
             matches: None,
+            children: vec![],
         };
 
         let output = merge_as_text(&[pad1, pad2]);
@@ -449,11 +458,13 @@ mod tests {
             pad: crate::model::Pad::new("First Pad".into(), "# Internal H1\n\nBody text".into()),
             index: DisplayIndex::Regular(1),
             matches: None,
+            children: vec![],
         };
         let pad2 = DisplayPad {
             pad: crate::model::Pad::new("Second Pad".into(), "## Internal H2\n\nMore body".into()),
             index: DisplayIndex::Regular(2),
             matches: None,
+            children: vec![],
         };
 
         let output = merge_as_markdown(&[pad1, pad2], "My Export");

--- a/crates/padzapp/src/commands/get.rs
+++ b/crates/padzapp/src/commands/get.rs
@@ -256,14 +256,21 @@ mod tests {
     #[test]
     fn test_filters() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Active".into(), "".into()).unwrap();
-        create::run(&mut store, Scope::Project, "Deleted".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Active".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Deleted".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
 
         // Delete the second one
         delete::run(
             &mut store,
             Scope::Project,
-            &[PadSelector::Index(DisplayIndex::Regular(1))],
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
         )
         .unwrap();
 
@@ -309,12 +316,13 @@ mod tests {
     #[test]
     fn test_search() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Foo".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Foo".into(), "".into(), None).unwrap();
         create::run(
             &mut store,
             Scope::Project,
             "Bar".into(),
             "contains foo".into(),
+            None,
         )
         .unwrap();
 

--- a/crates/padzapp/src/commands/get.rs
+++ b/crates/padzapp/src/commands/get.rs
@@ -27,23 +27,76 @@ impl Default for PadFilter {
     }
 }
 
+/// Recursively filters the tree based on status.
+///
+/// Filtering rules:
+/// - **Active**: Show non-deleted pads. Children are recursively filtered (only non-deleted).
+/// - **Deleted**: Show deleted pads with ALL their children (children aren't marked deleted
+///   but are visible under their deleted parent per spec: "unless looking at deleted items").
+/// - **Pinned**: Show pinned pads. Children are recursively filtered for pinned only.
+/// - **All**: Show everything, no filtering.
+fn filter_tree(pads: Vec<DisplayPad>, status: PadStatusFilter) -> Vec<DisplayPad> {
+    pads.into_iter()
+        .filter_map(|dp| filter_pad_recursive(dp, status))
+        .collect()
+}
+
+fn filter_pad_recursive(mut dp: DisplayPad, status: PadStatusFilter) -> Option<DisplayPad> {
+    let dominated = matches_status(&dp.index, status);
+
+    if !dominated {
+        return None;
+    }
+
+    // For Deleted status, show ALL children (they inherit visibility from deleted parent)
+    // For other statuses, recursively filter children
+    if status == PadStatusFilter::Deleted {
+        // Children of a deleted pad are shown as-is (no further filtering)
+        // But we still need to recurse to filter THEIR children if any are deleted
+        dp.children = dp
+            .children
+            .into_iter()
+            .map(filter_children_under_deleted)
+            .collect();
+    } else {
+        dp.children = dp
+            .children
+            .into_iter()
+            .filter_map(|child| filter_pad_recursive(child, status))
+            .collect();
+    }
+
+    Some(dp)
+}
+
+/// When viewing deleted pads, children of a deleted parent are shown.
+/// Those children might have their own children that need filtering.
+fn filter_children_under_deleted(mut dp: DisplayPad) -> DisplayPad {
+    // Show this child (regardless of its own deleted status since parent is deleted)
+    // But recursively process its children
+    dp.children = dp
+        .children
+        .into_iter()
+        .map(filter_children_under_deleted)
+        .collect();
+    dp
+}
+
+fn matches_status(index: &DisplayIndex, status: PadStatusFilter) -> bool {
+    match status {
+        PadStatusFilter::All => true,
+        PadStatusFilter::Active => !matches!(index, DisplayIndex::Deleted(_)),
+        PadStatusFilter::Deleted => matches!(index, DisplayIndex::Deleted(_)),
+        PadStatusFilter::Pinned => matches!(index, DisplayIndex::Pinned(_)),
+    }
+}
+
 pub fn run<S: DataStore>(store: &S, scope: Scope, filter: PadFilter) -> Result<CmdResult> {
-    // 1. Fetch relevant pads based on status to minimize processing
-    // Currently store only has list_pads returning all.
-    // If we want to optimize store access we would need store changes.
-    // For now we fetch all and filter in memory as current implementation does.
     let pads = store.list_pads(scope)?;
     let indexed = index_pads(pads);
 
-    let mut filtered: Vec<DisplayPad> = indexed
-        .into_iter()
-        .filter(|dp| match filter.status {
-            PadStatusFilter::All => true,
-            PadStatusFilter::Active => !matches!(dp.index, DisplayIndex::Deleted(_)),
-            PadStatusFilter::Deleted => matches!(dp.index, DisplayIndex::Deleted(_)),
-            PadStatusFilter::Pinned => matches!(dp.index, DisplayIndex::Pinned(_)),
-        })
-        .collect();
+    // Recursively filter the tree based on status
+    let mut filtered: Vec<DisplayPad> = filter_tree(indexed, filter.status);
 
     // 2. Apply search if needed
     if let Some(term) = &filter.search_term {
@@ -384,5 +437,144 @@ mod tests {
         assert!(joined.contains("five six seven"));
         assert!(!joined.contains("One")); // Should be truncated
         assert!(!joined.contains("eight")); // Should be truncated
+    }
+
+    // Tree-specific filtering tests
+
+    #[test]
+    fn test_active_filter_shows_nested_children() {
+        let mut store = InMemoryStore::new();
+        // Create parent
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        // Create child inside parent
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let res = run(&store, Scope::Project, PadFilter::default()).unwrap();
+
+        // Should have 1 root pad (Parent)
+        assert_eq!(res.listed_pads.len(), 1);
+        assert_eq!(res.listed_pads[0].pad.metadata.title, "Parent");
+        // Parent should have 1 child
+        assert_eq!(res.listed_pads[0].children.len(), 1);
+        assert_eq!(res.listed_pads[0].children[0].pad.metadata.title, "Child");
+    }
+
+    #[test]
+    fn test_active_filter_hides_deleted_child() {
+        let mut store = InMemoryStore::new();
+        // Create parent
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        // Create two children
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child1".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child2".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Delete Child1 (newest child = 1.1)
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![
+                DisplayIndex::Regular(1),
+                DisplayIndex::Regular(1),
+            ])],
+        )
+        .unwrap();
+
+        let res = run(&store, Scope::Project, PadFilter::default()).unwrap();
+
+        // Parent should have only 1 visible child (Child1 deleted)
+        assert_eq!(res.listed_pads.len(), 1);
+        assert_eq!(res.listed_pads[0].children.len(), 1);
+        assert_eq!(res.listed_pads[0].children[0].pad.metadata.title, "Child1");
+    }
+
+    #[test]
+    fn test_deleted_filter_shows_parent_with_children() {
+        let mut store = InMemoryStore::new();
+        // Create parent with child
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Delete the parent (not the child)
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        // View deleted pads
+        let res = run(
+            &store,
+            Scope::Project,
+            PadFilter {
+                status: PadStatusFilter::Deleted,
+                search_term: None,
+            },
+        )
+        .unwrap();
+
+        // Should show deleted parent with its non-deleted child
+        assert_eq!(res.listed_pads.len(), 1);
+        assert_eq!(res.listed_pads[0].pad.metadata.title, "Parent");
+        // Child should be visible under deleted parent (per spec)
+        assert_eq!(res.listed_pads[0].children.len(), 1);
+        assert_eq!(res.listed_pads[0].children[0].pad.metadata.title, "Child");
+    }
+
+    #[test]
+    fn test_active_filter_hides_children_of_deleted_parent() {
+        let mut store = InMemoryStore::new();
+        // Create parent with child
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Delete the parent
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        // View active pads
+        let res = run(&store, Scope::Project, PadFilter::default()).unwrap();
+
+        // Should have no active roots (parent is deleted, child is hidden)
+        assert_eq!(res.listed_pads.len(), 0);
     }
 }

--- a/crates/padzapp/src/commands/helpers.rs
+++ b/crates/padzapp/src/commands/helpers.rs
@@ -16,67 +16,130 @@ pub fn resolve_selectors<S: DataStore>(
     scope: Scope,
     selectors: &[PadSelector],
     check_delete_protection: bool,
-) -> Result<Vec<(DisplayIndex, Uuid)>> {
-    let indexed = indexed_pads(store, scope)?;
+) -> Result<Vec<(Vec<DisplayIndex>, Uuid)>> {
+    let root_pads = indexed_pads(store, scope)?;
 
-    selectors
-        .iter()
-        .map(|selector| match selector {
-            PadSelector::Index(idx) => {
-                 let found = indexed
-                    .iter()
-                    .find(|dp| &dp.index == idx)
-                    .map(|dp| (idx.clone(), dp.pad.metadata.id));
+    // Linearize the tree for range resolution and search
+    let linearized = linearize_tree(&root_pads);
 
-                match found {
-                    Some((idx, id)) => {
-                        if check_delete_protection {
-                            let pad = store.get_pad(&id, scope)?;
-                            if pad.metadata.delete_protected {
-                                return Err(PadzError::Api("Pinned pads are delete protected, unpin then delete it".to_string()));
-                            }
-                        }
-                        Ok((idx, id))
+    let mut results = Vec::new();
+
+    for selector in selectors {
+        match selector {
+            PadSelector::Path(path) => {
+                if let Some((_, pad)) = find_in_linearized(&linearized, path) {
+                    if check_delete_protection && pad.pad.metadata.delete_protected {
+                        return Err(PadzError::Api(
+                            "Pinned pads are delete protected, unpin then delete it".to_string(),
+                        ));
                     }
-                     None => Err(PadzError::Api(format!("Index {} not found in current scope", idx))),
+                    results.push((path.clone(), pad.pad.metadata.id));
+                } else {
+                    let s: Vec<String> = path.iter().map(|idx| idx.to_string()).collect();
+                    return Err(PadzError::Api(format!(
+                        "Index {} not found in current scope",
+                        s.join(".")
+                    )));
                 }
-            },
+            }
+            PadSelector::Range(start_path, end_path) => {
+                let start_idx = linearized
+                    .iter()
+                    .position(|(p, _)| p == start_path)
+                    .ok_or_else(|| {
+                        PadzError::Api(format!("Range start {} not found", fmt_path(start_path)))
+                    })?;
+                let end_idx = linearized
+                    .iter()
+                    .position(|(p, _)| p == end_path)
+                    .ok_or_else(|| {
+                        PadzError::Api(format!("Range end {} not found", fmt_path(end_path)))
+                    })?;
+
+                if start_idx > end_idx {
+                    return Err(PadzError::Api(format!(
+                        "Invalid range: {} appears after {} in the list",
+                        fmt_path(start_path),
+                        fmt_path(end_path)
+                    )));
+                }
+
+                // Collect all items in range inclusive
+                for (path, pad) in linearized.iter().take(end_idx + 1).skip(start_idx) {
+                    if check_delete_protection && pad.pad.metadata.delete_protected {
+                        return Err(PadzError::Api(
+                            "Pinned pads are delete protected, unpin then delete it".to_string(),
+                        ));
+                    }
+                    results.push((path.clone(), pad.pad.metadata.id));
+                }
+            }
             PadSelector::Title(term) => {
                 let term_lower = term.to_lowercase();
-                let matches: Vec<&DisplayPad> = indexed
+                let matches: Vec<&(Vec<DisplayIndex>, &DisplayPad)> = linearized
                     .iter()
-                    .filter(|dp| {
-                        // Match against title
+                    .filter(|(_, dp)| {
                         if dp.pad.metadata.title.to_lowercase().contains(&term_lower) {
                             return true;
                         }
-                        // Match against content (excluding first line if it duplicates title)
-                        // Simplified content match: just check if full content contains it
-                        // This matches get.rs logic roughly but simpler
                         dp.pad.content.to_lowercase().contains(&term_lower)
                     })
                     .collect();
 
                 match matches.len() {
-                    0 => Err(PadzError::Api(format!("No pad found matching \"{}\"", term))),
+                    0 => return Err(PadzError::Api(format!("No pad found matching \"{}\"", term))),
                     1 => {
-                        let id = matches[0].pad.metadata.id;
-                         if check_delete_protection {
-                             // We already have the pad in matches[0].pad, no need to refetch
-                             if matches[0].pad.metadata.delete_protected {
-                                 return Err(PadzError::Api("Pinned pads are delete protected, unpin then delete it".to_string()));
-                             }
-                         }
-                        Ok((matches[0].index.clone(), id))
+                        let (path, dp) = matches[0];
+                        if check_delete_protection && dp.pad.metadata.delete_protected {
+                             return Err(PadzError::Api("Pinned pads are delete protected, unpin then delete it".to_string()));
+                        }
+                        results.push((path.clone(), dp.pad.metadata.id));
                     },
-                    n => Err(PadzError::Api(format!(
+                    n => return Err(PadzError::Api(format!(
                         "Term \"{}\" matches multiple paths, add more to make it unique(matched {} pads). Please be more specific.",
                         term, n
                     ))),
                 }
             }
-        })
-        .collect()
+        }
+    }
+
+    Ok(results)
+}
+
+fn linearize_tree(roots: &[DisplayPad]) -> Vec<(Vec<DisplayIndex>, &DisplayPad)> {
+    let mut result = Vec::new();
+    for pad in roots {
+        linearize_recursive(pad, Vec::new(), &mut result);
+    }
+    result
+}
+
+fn linearize_recursive<'a>(
+    pad: &'a DisplayPad,
+    parent_path: Vec<DisplayIndex>,
+    result: &mut Vec<(Vec<DisplayIndex>, &'a DisplayPad)>,
+) {
+    let mut current_path = parent_path;
+    current_path.push(pad.index.clone());
+
+    result.push((current_path.clone(), pad));
+
+    for child in &pad.children {
+        linearize_recursive(child, current_path.clone(), result);
+    }
+}
+
+fn find_in_linearized<'a>(
+    linearized: &'a [(Vec<DisplayIndex>, &'a DisplayPad)],
+    path: &[DisplayIndex],
+) -> Option<&'a (Vec<DisplayIndex>, &'a DisplayPad)> {
+    linearized.iter().find(|(p, _)| p == path)
+}
+
+pub fn fmt_path(path: &[DisplayIndex]) -> String {
+    let s: Vec<String> = path.iter().map(|idx| idx.to_string()).collect();
+    s.join(".")
 }
 
 pub fn pads_by_selectors<S: DataStore>(
@@ -87,13 +150,61 @@ pub fn pads_by_selectors<S: DataStore>(
 ) -> Result<Vec<DisplayPad>> {
     let resolved = resolve_selectors(store, scope, selectors, check_delete_protection)?;
     let mut pads = Vec::with_capacity(resolved.len());
-    for (index, id) in resolved {
+    for (path, id) in resolved {
         let pad = store.get_pad(&id, scope)?;
+        // We need search matches logic for DisplayPad if we want it?
+        // But we are constructing it from scratch here without children.
+        // It's flattened.
+        // And the index is just the last segment (local), but typically DisplayPad stores local index.
+        // If we want FULL path info in DisplayPad... index.rs struct has local index.
+        // We can reconstruct tree or just return simple items.
+        // The callers of this usually operate on items.
+        // However, DisplayPad requires children field now.
+
+        let local_index = path.last().cloned().unwrap_or(DisplayIndex::Regular(0)); // Should not be empty
+
         pads.push(DisplayPad {
             pad,
-            index,
+            index: local_index,
             matches: None,
+            children: Vec::new(), // Flattened view
         });
     }
     Ok(pads)
+}
+
+pub fn get_descendant_ids<S: DataStore>(
+    store: &S,
+    scope: Scope,
+    target_ids: &[Uuid],
+) -> Result<Vec<Uuid>> {
+    let all_pads = store.list_pads(scope)?;
+    let roots = index_pads(all_pads);
+    let mut descendants = Vec::new();
+
+    for target in target_ids {
+        if let Some(node) = find_node_by_id(&roots, *target) {
+            collect_subtree_ids(node, &mut descendants);
+        }
+    }
+    Ok(descendants)
+}
+
+fn find_node_by_id(pads: &[DisplayPad], id: Uuid) -> Option<&DisplayPad> {
+    for dp in pads {
+        if dp.pad.metadata.id == id {
+            return Some(dp);
+        }
+        if let Some(found) = find_node_by_id(&dp.children, id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn collect_subtree_ids(dp: &DisplayPad, ids: &mut Vec<Uuid>) {
+    for child in &dp.children {
+        ids.push(child.pad.metadata.id);
+        collect_subtree_ids(child, ids);
+    }
 }

--- a/crates/padzapp/src/commands/import.rs
+++ b/crates/padzapp/src/commands/import.rs
@@ -69,7 +69,7 @@ fn import_file<S: DataStore>(store: &mut S, scope: Scope, path: &Path) -> Result
 
 fn import_content<S: DataStore>(store: &mut S, scope: Scope, content_raw: &str) -> Result<usize> {
     if let Some((title, body)) = crate::model::extract_title_and_body(content_raw) {
-        crate::commands::create::run(store, scope, title, body)?;
+        crate::commands::create::run(store, scope, title, body, None)?;
         Ok(1)
     } else {
         // Empty content, treated as ignore

--- a/crates/padzapp/src/commands/paths.rs
+++ b/crates/padzapp/src/commands/paths.rs
@@ -29,12 +29,12 @@ mod tests {
     #[test]
     fn test_get_path() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Pad A".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
 
         let res = run(
             &store,
             Scope::Project,
-            &[PadSelector::Index(DisplayIndex::Regular(1))],
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
         )
         .unwrap();
         assert_eq!(res.pad_paths.len(), 1);
@@ -50,16 +50,16 @@ mod tests {
     #[test]
     fn test_get_multiple_paths() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "Pad A".into(), "".into()).unwrap();
-        create::run(&mut store, Scope::Project, "Pad B".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
 
         // 1 is B, 2 is A
         let res = run(
             &store,
             Scope::Project,
             &[
-                PadSelector::Index(DisplayIndex::Regular(1)),
-                PadSelector::Index(DisplayIndex::Regular(2)),
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(2)]),
             ],
         )
         .unwrap();

--- a/crates/padzapp/src/commands/purge.rs
+++ b/crates/padzapp/src/commands/purge.rs
@@ -5,6 +5,7 @@ use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
 use std::io::{self, Write};
+use uuid::Uuid;
 
 use super::helpers::{indexed_pads, pads_by_selectors};
 
@@ -27,7 +28,18 @@ pub fn run<S: DataStore>(
         pads_by_selectors(store, scope, selectors, true)?
     };
 
-    if pads_to_purge.is_empty() {
+    // 2a. Expand with descendants
+    let target_ids: Vec<Uuid> = pads_to_purge.iter().map(|dp| dp.pad.metadata.id).collect();
+    let descendants = super::helpers::get_descendant_ids(store, scope, &target_ids)?;
+
+    // Combine unique IDs
+    let mut all_ids = target_ids.clone();
+    all_ids.extend(descendants.clone());
+    // remove duplicates if any (though get_descendant_ids checks children)
+    all_ids.sort();
+    all_ids.dedup();
+
+    if all_ids.is_empty() {
         let mut res = CmdResult::default();
         res.add_message(CmdMessage::info("No pads to purge."));
         return Ok(res);
@@ -39,6 +51,10 @@ pub fn run<S: DataStore>(
         for dp in &pads_to_purge {
             println!("  {} {}", dp.index, dp.pad.metadata.title);
         }
+        if !descendants.is_empty() {
+            println!("  ... and {} descendant(s)", descendants.len());
+        }
+
         print!("[Y] To delete: ");
         io::stdout().flush().map_err(PadzError::Io)?;
 
@@ -52,13 +68,31 @@ pub fn run<S: DataStore>(
         }
     }
 
-    // 3. Delete
+    // 3. Delete ALL
     let mut result = CmdResult::default();
+    for id in all_ids {
+        // Fetch title for message logic? pad might be in pads_to_purge or fetched now.
+        // We only reported main targets.
+        // Just delete.
+        // Check if it exists before trying to delete (might be double deleted if loop logic was loose, but we deduped)
+        if store.get_pad(&id, scope).is_ok() {
+            store.delete_pad(&id, scope)?;
+        }
+    }
+
+    // Add success messages for main targets only?
+    // Or just summary?
+    // User expects feedback.
     for dp in pads_to_purge {
-        store.delete_pad(&dp.pad.metadata.id, scope)?;
         result.add_message(CmdMessage::success(format!(
             "Purged: {} {}",
             dp.index, dp.pad.metadata.title
+        )));
+    }
+    if !descendants.is_empty() {
+        result.add_message(CmdMessage::success(format!(
+            "And purged {} descendants",
+            descendants.len()
         )));
     }
 
@@ -76,13 +110,13 @@ mod tests {
     #[test]
     fn purges_deleted_pads() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "A".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
 
         // Delete it
         delete::run(
             &mut store,
             Scope::Project,
-            &[PadSelector::Index(DisplayIndex::Regular(1))],
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
         )
         .unwrap();
 
@@ -126,13 +160,13 @@ mod tests {
     #[test]
     fn purges_specific_pads_even_if_active() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "A".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
 
         // Purge active pad 1
         let res = run(
             &mut store,
             Scope::Project,
-            &[PadSelector::Index(DisplayIndex::Regular(1))],
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
             true,
         )
         .unwrap();
@@ -148,7 +182,7 @@ mod tests {
     #[test]
     fn does_nothing_if_no_deleted_pads() {
         let mut store = InMemoryStore::new();
-        create::run(&mut store, Scope::Project, "A".into(), "".into()).unwrap();
+        create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
 
         // Purge deleted (none)
         let res = run(&mut store, Scope::Project, &[], true).unwrap();
@@ -159,5 +193,68 @@ mod tests {
         // A still exists
         let listed = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
         assert_eq!(listed.listed_pads.len(), 1);
+    }
+
+    #[test]
+    fn purges_recursively() {
+        let mut store = InMemoryStore::new();
+        // Create Parent
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        // Create Child inside Parent (id=1)
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Delete Parent
+        delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        // Verify Child is also effectively hidden/deleted?
+        // Wait, DELETE command logic is soft-delete PARENT only.
+        // Child is implicitly hidden from Active views.
+        // It should appear in Deleted view if parent is indexable.
+
+        let _deleted = get::run(
+            &store,
+            Scope::Project,
+            get::PadFilter {
+                status: get::PadStatusFilter::Deleted,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // Should show Parent (d1).
+        // Since get command output is recursive, we don't know if child is counted in "listed_pads" (only roots).
+        // But purge uses logic to find descendants.
+
+        // Purge Parent
+        let res = run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Deleted(1)])],
+            true,
+        )
+        .unwrap();
+
+        assert!(res.messages[0].content.contains("Purged: d1 Parent"));
+        // Check for descendant message
+        let has_descendant_msg = res
+            .messages
+            .iter()
+            .any(|m| m.content.contains("And purged 1 descendants"));
+        assert!(has_descendant_msg);
+
+        // Verify Store is empty
+        let all_pads = store.list_pads(Scope::Project).unwrap();
+        assert_eq!(all_pads.len(), 0);
     }
 }

--- a/crates/padzapp/src/commands/restore.rs
+++ b/crates/padzapp/src/commands/restore.rs
@@ -34,8 +34,10 @@ pub fn run<S: DataStore>(
     // Re-index to get the new regular indexes
     let indexed = indexed_pads(store, scope)?;
     for uuid in restored_uuids {
-        // Search tree recursively for restored pad with Regular index
-        if let Some(dp) = find_restored_pad(&indexed, uuid) {
+        // Restored pads get Regular index
+        if let Some(dp) = super::helpers::find_pad_by_uuid(&indexed, uuid, |idx| {
+            matches!(idx, DisplayIndex::Regular(_))
+        }) {
             result.affected_pads.push(DisplayPad {
                 pad: dp.pad.clone(),
                 index: dp.index.clone(),
@@ -46,18 +48,6 @@ pub fn run<S: DataStore>(
     }
 
     Ok(result)
-}
-
-fn find_restored_pad(pads: &[DisplayPad], uuid: Uuid) -> Option<&DisplayPad> {
-    for dp in pads {
-        if dp.pad.metadata.id == uuid && matches!(dp.index, DisplayIndex::Regular(_)) {
-            return Some(dp);
-        }
-        if let Some(found) = find_restored_pad(&dp.children, uuid) {
-            return Some(found);
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/padzapp/src/store/fs.rs
+++ b/crates/padzapp/src/store/fs.rs
@@ -170,6 +170,7 @@ impl FileStore {
                                             is_deleted: false,
                                             deleted_at: None,
                                             delete_protected: false,
+                                            parent_id: None,
                                             title,
                                         };
                                         meta_map.insert(id, new_meta);
@@ -371,6 +372,7 @@ impl DataStore for FileStore {
                                         is_deleted: false,
                                         deleted_at: None,
                                         delete_protected: false,
+                                        parent_id: None,
                                         title,
                                     };
 

--- a/crates/padzapp/src/store/fs.rs
+++ b/crates/padzapp/src/store/fs.rs
@@ -237,15 +237,9 @@ impl DataStore for FileStore {
     }
 
     fn list_pads(&self, scope: Scope) -> Result<Vec<Pad>> {
-        // Sync before listing to ensure we have the latest state from disk
-        let _ = self.sync(scope); // Ignore errors? Sync failure shouldn't block listing?
-                                  // Better to propagate sync error potentially, but list_pads is generic.
-                                  // Let's log if it fails? or unwrap?
-                                  // Since sync is IO, it can fail.
-                                  // For robustness, maybe just proceed?
-                                  // But if sync fails, the list might be wrong.
-                                  // However, self.get_store_path will fail inside sync anyway if root invalid.
-                                  // And calling sync before getting path here is safer.
+        // Sync before listing to ensure we have the latest state from disk.
+        // Errors are ignored to allow listing even if sync partially fails.
+        let _ = self.sync(scope);
 
         let root = self.get_store_path(scope)?;
         if !root.exists() {
@@ -298,13 +292,8 @@ impl DataStore for FileStore {
     }
 
     fn doctor(&mut self, scope: Scope) -> Result<DoctorReport> {
-        // Reuse sync for the heavy lifting?
-        // Doctor reports stats. Sync is silent.
-        // Let's keep doctor mostly as is but maybe call sync first?
-        // Or implement doctor *as* sync + reporting.
-        // For now, let's leave doctor independent to avoid breaking it during refactor.
-        // Just fixing imports/deps.
-
+        // Doctor performs similar work to sync but returns a detailed report.
+        // Kept separate from sync to provide explicit diagnostics.
         let root = self.get_store_path(scope)?;
         if !root.exists() {
             return Ok(DoctorReport::default());

--- a/crates/padzapp/tests/title_referencing.rs
+++ b/crates/padzapp/tests/title_referencing.rs
@@ -16,15 +16,17 @@ fn setup() -> PadzApi<InMemoryStore> {
         Scope::Project,
         "Groceries".to_string(),
         "Milk, Eggs".to_string(),
+        None,
     )
     .unwrap();
     api.create_pad(
         Scope::Project,
         "Grocery List".to_string(),
         "Bread, Butter".to_string(),
+        None,
     )
     .unwrap();
-    api.create_pad(Scope::Project, "Gold".to_string(), "Au".to_string())
+    api.create_pad(Scope::Project, "Gold".to_string(), "Au".to_string(), None)
         .unwrap();
 
     api

--- a/docs/tree.txt
+++ b/docs/tree.txt
@@ -1,0 +1,81 @@
+# Padz Tree Support Specification
+
+## 1. Hierarchy Model
+
+Padz is moving from a flat list to a nested hierarchy.
+- **Structure**: Core entity is still a `Pad`. A Pad can have an optional `parent_id`.
+- **Depth**: Arbitrary depth is supported.
+- **Ordering**: 
+  - Sibling pads are ordered by Creation Date (Newest first).
+  - Pinned pads appear first in their respective child list (sharded per parent).
+
+## 2. Display Identifiers (DI) & Addressing
+
+### Format
+DIs use **Dot Notation** to represent the path from the root.
+- `X.Y.Z` refers to the Z-th child of the Y-th child of the X-th root pad.
+- **Root**: `1`, `2`... (e.g. `4` is root pad #4)
+- **Nested**: `3.7` (7th child of root #3)
+- **Pinned**: `p1`, `3.p1` (1st pinned pad inside root #3)
+
+### Sharding
+Indexes are bucketed per parent.
+- If Parent A has 3 children, they are `A.1`, `A.2`, `A.3`.
+- If Parent B has 2 children, they are `B.1`, `B.2`.
+- Indexes are NOT globally unique; they are path-dependent. `1` means different things inside A vs B.
+
+## 3. Ranges & Selection
+
+Ranges allow selecting multiple pads via a linearized traversal order.
+
+### Linearization Rule (Pre-Order)
+The "selectable list" is formed by checking the tree depth-first (Parent, then Children).
+Example Tree:
+1. Root A
+   1.1 Child A1
+   1.2 Child A2
+2. Root B
+   2.1 Child B1
+   2.2 Child B2
+3. Root C
+
+Linear Order: `1`, `1.1`, `1.2`, `2`, `2.1`, `2.2`, `3`
+
+### Range Logic
+Format: `Start-End`
+- **Inclusive**: Selects everything from `Start` node up to and including `End` node in the linear order.
+- **Children**: 
+  - Implicitly selects children of *intermediate* nodes (because they appear between start and end in linearization).
+  - Does NOT automatically limit or expand children of the start/end nodes beyond the exact match.
+
+### Examples
+- `1.1-1.2`: Selects `1.1`, `1.2`.
+- `1.1-3`: Selects `1.1`, `1.2`, `2`, `2.1`, `2.2`, `3`. 
+  - Note: `3` is selected, but `3.1` (if it existed) is NOT, because it comes after `3`.
+- `1.2-2.1`: Selects `1.2`, `2`, `2.1`.
+
+## 4. Deletion & State
+
+### Soft Delete (Default)
+`padz delete <selector>`
+- Sets `is_deleted = true` on the target pad(s).
+- **Non-Recursive**: Children are NOT marked deleted. They remain in the database but are effectively hidden because their parent is deleted (unless looking at deleted items).
+- **Rationale**: Restoring a parent allows recovering the exact state of children.
+
+### Hard Delete (Purge)
+`padz purge <selector>`
+- **Recursive**: Permanently removes the target pad AND all its children (safety check required).
+- **Safety Valve**: Purging a parent with existing children requires a `--recursive` flag (or similar confirmation).
+
+## 5. Creation
+
+New CLI Flag: `--inside <selector>` (or `--parent`).
+- `padz create "Note"` -> Creates root pad.
+- `padz create "Child Note" --inside 1` -> Creates child of Pad 1.
+- `padz create "Deep Note" --inside 1.2` -> Creates child of Pad 1.2.
+
+## 6. API Output
+
+The internal `DisplayPad` structure generally reflects the tree.
+API responses should include children vectors.
+Commands like `list` or `search` will return hierarchically structured data where applicable.

--- a/docs/tree.txt
+++ b/docs/tree.txt
@@ -18,11 +18,30 @@ DIs use **Dot Notation** to represent the path from the root.
 - **Nested**: `3.7` (7th child of root #3)
 - **Pinned**: `p1`, `3.p1` (1st pinned pad inside root #3)
 
-### Sharding
-Indexes are bucketed per parent.
+### Sharding (Per-Parent Bucketing)
+Indexes are bucketed per parent. The same pinned/regular/deleted logic that applies at root level
+is applied recursively at each nesting level.
+
+**Regular indexes**:
 - If Parent A has 3 children, they are `A.1`, `A.2`, `A.3`.
 - If Parent B has 2 children, they are `B.1`, `B.2`.
 - Indexes are NOT globally unique; they are path-dependent. `1` means different things inside A vs B.
+
+**Pinned indexes at nested levels**:
+- Each parent maintains its own pinned bucket.
+- A pinned child of pad `1` appears as `1.p1` (first pinned child of pad 1).
+- Deep nesting: `1.2.p1` is the first pinned child of pad `1.2`.
+
+**Dual indexing preserved at all levels**:
+- Just like root pinned pads appear twice (`p1` and their regular index `N`), nested pinned pads
+  also appear twice within their parent's children.
+- Example: If pad `1` has 3 children and the 2nd is pinned:
+  - It appears as `1.p1` (pinned section)
+  - It ALSO appears as `1.2` (regular section, at its chronological position)
+- This ensures stability: unpinning `1.p1` doesn't change its regular index `1.2`.
+
+**Deleted indexes at nested levels**:
+- Deleted children appear in their parent's deleted bucket: `1.d1`, `1.d2`, etc.
 
 ## 3. Ranges & Selection
 

--- a/docs/tree.txt
+++ b/docs/tree.txt
@@ -83,8 +83,10 @@ Format: `Start-End`
 
 ### Hard Delete (Purge)
 `padz purge <selector>`
-- **Recursive**: Permanently removes the target pad AND all its children (safety check required).
-- **Safety Valve**: Purging a parent with existing children requires a `--recursive` flag (or similar confirmation).
+- **Recursive**: Permanently removes the target pad AND all its children.
+- **Safety Valve**: Purging a pad that has children requires the `--recursive` (`-r`) flag.
+  Without this flag, the command fails with an error message.
+- Example: `padz purge 1 -r` to purge pad 1 and all its descendants.
 
 ## 5. Creation
 


### PR DESCRIPTION
This PR implements full tree support for Padz, allowing pads to be nested inside others.

### Features
- **Creation**: `padz create -i <parent>`
- **Listing**: Dot-notation indices (1.1, 1.2) and visual indentation.
- **Management**: Recursive purge and safe deletion checks (blocks parent delete if child is pinned).

Tests added for all new logic.