### PR TITLE
fix: Unify pad representation in CmdResult to always use DisplayPad

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -192,8 +192,10 @@ fn handle_create(ctx: &mut AppContext, title: Option<String>, no_editor: bool) -
 
     // Open editor if requested/appropriate
     if should_open_editor && !result.affected_pads.is_empty() {
-        let pad = &result.affected_pads[0];
-        let path = ctx.api.get_path_by_id(ctx.scope, pad.metadata.id)?;
+        let display_pad = &result.affected_pads[0];
+        let path = ctx
+            .api
+            .get_path_by_id(ctx.scope, display_pad.pad.metadata.id)?;
         open_in_editor(&path)?;
 
         // Re-read the pad after editing and copy to clipboard

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -17,6 +17,15 @@
 //! - **I/O operations**: No stdout, stderr, or file formatting
 //! - **Presentation concerns**: Returns data structures, not strings
 //!
+//! ## Consistent Output Representation
+//!
+//! All pad data in [`CmdResult`] uses [`DisplayPad`], which pairs a [`Pad`] with its
+//! canonical [`DisplayIndex`]. This applies to both:
+//! - `affected_pads`: Pads modified by the operation (with post-operation index)
+//! - `listed_pads`: Pads returned for display (with current index)
+//!
+//! Clients receive a uniform representation regardless of the operation type.
+//!
 //! ## Selectors: Multi-IDs and Ranges
 //!
 //! Users often need to act on batches of items (`padz delete 1-3`).

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -1,5 +1,6 @@
 use crate::commands::{CmdMessage, CmdResult};
 use crate::error::Result;
+use crate::index::{DisplayIndex, DisplayPad};
 use crate::model::{Pad, Scope};
 use crate::store::DataStore;
 
@@ -13,7 +14,13 @@ pub fn run<S: DataStore>(
     store.save_pad(&pad, scope)?;
 
     let mut result = CmdResult::default();
-    result.affected_pads.push(pad.clone());
+    // New pad is always the newest, so it gets index 1
+    let display_pad = DisplayPad {
+        pad: pad.clone(),
+        index: DisplayIndex::Regular(1),
+        matches: None,
+    };
+    result.affected_pads.push(display_pad);
     result.add_message(CmdMessage::success(format!(
         "Pad created: {}",
         pad.metadata.title

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -22,11 +22,15 @@
 //! ## Structured Returns
 //!
 //! Commands return [`CmdResult`], not strings. This struct carries:
-//! - `affected_pads`: Pads that were modified
-//! - `listed_pads`: Pads to display (with display indexes)
+//! - `affected_pads`: Pads that were modified (as `DisplayPad` with post-operation index)
+//! - `listed_pads`: Pads to display (as `DisplayPad` with current index)
 //! - `messages`: Structured messages with levels (info, success, warning, error)
 //! - `pad_paths`: File paths (for `path` command)
 //! - `config`: Configuration data (for `config` command)
+//!
+//! Both `affected_pads` and `listed_pads` use [`DisplayPad`], which pairs a [`Pad`]
+//! with its canonical [`DisplayIndex`]. This ensures consistent representation
+//! throughout the API—clients always receive pads with their resolved indexes.
 //!
 //! The UI layer (CLI, web, etc.) then decides how to render this data.
 //!
@@ -61,7 +65,7 @@
 use crate::config::PadzConfig;
 use crate::error::{PadzError, Result};
 use crate::index::DisplayPad;
-use crate::model::{Pad, Scope};
+use crate::model::Scope;
 use std::path::PathBuf;
 
 pub mod config;
@@ -146,7 +150,7 @@ impl CmdMessage {
 
 #[derive(Debug, Default)]
 pub struct CmdResult {
-    pub affected_pads: Vec<Pad>,
+    pub affected_pads: Vec<DisplayPad>,
     pub listed_pads: Vec<DisplayPad>,
     pub pad_paths: Vec<PathBuf>,
     pub config: Option<PadzConfig>,
@@ -158,7 +162,7 @@ impl CmdResult {
         self.messages.push(message);
     }
 
-    pub fn with_affected_pads(mut self, pads: Vec<Pad>) -> Self {
+    pub fn with_affected_pads(mut self, pads: Vec<DisplayPad>) -> Self {
         self.affected_pads = pads;
         self
     }

--- a/crates/padzapp/src/commands/update.rs
+++ b/crates/padzapp/src/commands/update.rs
@@ -1,6 +1,6 @@
 use crate::commands::{CmdMessage, CmdResult, PadUpdate};
 use crate::error::Result;
-use crate::index::PadSelector;
+use crate::index::{DisplayPad, PadSelector};
 use crate::model::Scope;
 use crate::store::DataStore;
 use chrono::Utc;
@@ -35,7 +35,12 @@ pub fn run<S: DataStore>(store: &mut S, scope: Scope, updates: &[PadUpdate]) -> 
             "Pad updated ({}): {}",
             display_index, pad.metadata.title
         )));
-        result.affected_pads.push(pad);
+        // Index doesn't change after update
+        result.affected_pads.push(DisplayPad {
+            pad,
+            index: display_index,
+            matches: None,
+        });
     }
 
     Ok(result)


### PR DESCRIPTION
## Summary

Closes #25

- Changed `CmdResult.affected_pads` from `Vec<Pad>` to `Vec<DisplayPad>` for consistent pad representation throughout the API
- Commands now return `DisplayPad` with correct post-operation indexes
- Updated documentation to reflect the consistent output representation

## Changes

| Command | Post-operation index |
|---------|---------------------|
| create | `Regular(1)` - new pad is always newest |
| delete | Re-indexes, returns `Deleted(N)` |
| update | Unchanged index |
| pin/unpin | Re-indexes, returns `Pinned(N)` or `Regular(N)` |
| restore | Re-indexes, returns `Regular(N)` |

## Benefits

- Single representation for pads throughout the API (`DisplayPad` everywhere)
- Clients can now display indexes for affected pads (e.g., "Created pad 1")
- UUID still accessible via `display_pad.pad.metadata.id` when needed
- Cleaner mental model: API input is display index strings, output is always `DisplayPad`

## Test plan

- [x] All existing tests pass (108 tests)
- [x] No clippy warnings
- [x] Documentation updated in `api.rs` and `commands/mod.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)