### PR TITLE
Adding more test coverage

### DIFF
--- a/crates/padzapp/src/commands/config.rs
+++ b/crates/padzapp/src/commands/config.rs
@@ -50,3 +50,187 @@ pub fn run(paths: &PadzPaths, scope: Scope, action: ConfigAction) -> Result<CmdR
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_paths(dir: &std::path::Path) -> PadzPaths {
+        PadzPaths {
+            project: Some(dir.to_path_buf()),
+            global: dir.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn show_all_returns_default_config_when_no_file() {
+        let temp = tempdir().unwrap();
+        let paths = make_paths(temp.path());
+
+        let result = run(&paths, Scope::Project, ConfigAction::ShowAll).unwrap();
+
+        assert!(result.config.is_some());
+        let config = result.config.unwrap();
+        assert_eq!(config.file_ext, ".txt");
+    }
+
+    #[test]
+    fn show_all_returns_saved_config() {
+        let temp = tempdir().unwrap();
+        fs::create_dir_all(temp.path()).unwrap();
+
+        // Save a custom config
+        let mut config = PadzConfig::default();
+        config.set_file_ext(".md");
+        config.save(temp.path()).unwrap();
+
+        let paths = make_paths(temp.path());
+        let result = run(&paths, Scope::Project, ConfigAction::ShowAll).unwrap();
+
+        assert!(result.config.is_some());
+        assert_eq!(result.config.unwrap().file_ext, ".md");
+    }
+
+    #[test]
+    fn show_key_returns_value_for_known_key() {
+        let temp = tempdir().unwrap();
+        let paths = make_paths(temp.path());
+
+        let result = run(
+            &paths,
+            Scope::Project,
+            ConfigAction::ShowKey("file-ext".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains(".txt"));
+    }
+
+    #[test]
+    fn show_key_returns_error_for_unknown_key() {
+        let temp = tempdir().unwrap();
+        let paths = make_paths(temp.path());
+
+        let result = run(
+            &paths,
+            Scope::Project,
+            ConfigAction::ShowKey("nonexistent-key".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("Unknown config key"));
+        assert!(result.messages[0].content.contains("nonexistent-key"));
+    }
+
+    #[test]
+    fn set_valid_key_saves_and_returns_success() {
+        let temp = tempdir().unwrap();
+        let paths = make_paths(temp.path());
+
+        let result = run(
+            &paths,
+            Scope::Project,
+            ConfigAction::Set("file-ext".to_string(), ".rs".to_string()),
+        )
+        .unwrap();
+
+        // Check success message
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("file-ext set to"));
+        assert!(result.messages[0].content.contains(".rs"));
+
+        // Check config is updated
+        assert!(result.config.is_some());
+        assert_eq!(result.config.unwrap().file_ext, ".rs");
+
+        // Verify persisted
+        let loaded = PadzConfig::load(temp.path()).unwrap();
+        assert_eq!(loaded.file_ext, ".rs");
+    }
+
+    #[test]
+    fn set_import_extensions_parses_csv() {
+        let temp = tempdir().unwrap();
+        let paths = make_paths(temp.path());
+
+        let result = run(
+            &paths,
+            Scope::Project,
+            ConfigAction::Set("import-extensions".to_string(), ".py, .js, .ts".to_string()),
+        )
+        .unwrap();
+
+        assert!(result.config.is_some());
+        let config = result.config.unwrap();
+        assert_eq!(config.import_extensions, vec![".py", ".js", ".ts"]);
+
+        // Verify persisted
+        let loaded = PadzConfig::load(temp.path()).unwrap();
+        assert_eq!(loaded.import_extensions, vec![".py", ".js", ".ts"]);
+    }
+
+    #[test]
+    fn set_invalid_key_returns_error_message() {
+        let temp = tempdir().unwrap();
+        let paths = make_paths(temp.path());
+
+        let result = run(
+            &paths,
+            Scope::Project,
+            ConfigAction::Set("invalid-key".to_string(), "value".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("Unknown config key"));
+        assert!(result.messages[0].content.contains("invalid-key"));
+
+        // Config should not be attached on error
+        assert!(result.config.is_none());
+    }
+
+    #[test]
+    fn uses_global_scope_when_specified() {
+        let temp = tempdir().unwrap();
+        let global_dir = temp.path().join("global");
+        fs::create_dir_all(&global_dir).unwrap();
+
+        let paths = PadzPaths {
+            project: None,
+            global: global_dir.clone(),
+        };
+
+        // Set in global scope
+        let result = run(
+            &paths,
+            Scope::Global,
+            ConfigAction::Set("file-ext".to_string(), ".global".to_string()),
+        )
+        .unwrap();
+
+        assert!(result.config.is_some());
+        assert_eq!(result.config.unwrap().file_ext, ".global");
+
+        // Verify persisted in global dir
+        let loaded = PadzConfig::load(&global_dir).unwrap();
+        assert_eq!(loaded.file_ext, ".global");
+    }
+
+    #[test]
+    fn project_scope_fails_when_unavailable() {
+        let temp = tempdir().unwrap();
+
+        let paths = PadzPaths {
+            project: None,
+            global: temp.path().to_path_buf(),
+        };
+
+        let result = run(&paths, Scope::Project, ConfigAction::ShowAll);
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -83,4 +83,115 @@ mod tests {
 
         assert_eq!(child.metadata.parent_id, Some(parent.metadata.id));
     }
+
+    #[test]
+    fn parent_not_found_returns_error() {
+        let mut store = InMemoryStore::new();
+
+        // Try to create with non-existent parent index
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(99)])),
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn ambiguous_parent_selector_returns_error() {
+        let mut store = InMemoryStore::new();
+
+        // Create two pads with similar titles
+        run(
+            &mut store,
+            Scope::Project,
+            "Meeting Notes Monday".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        run(
+            &mut store,
+            Scope::Project,
+            "Meeting Notes Tuesday".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+
+        // Try to create with ambiguous title search as parent
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Title("Meeting".to_string())),
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("multiple"));
+    }
+
+    #[test]
+    fn create_returns_affected_pad_with_index_1() {
+        let mut store = InMemoryStore::new();
+
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "New Pad".into(),
+            "Content".into(),
+            None,
+        )
+        .unwrap();
+
+        // Should have one affected pad
+        assert_eq!(result.affected_pads.len(), 1);
+        assert_eq!(result.affected_pads[0].pad.metadata.title, "New Pad");
+        assert!(matches!(
+            result.affected_pads[0].index,
+            DisplayIndex::Regular(1)
+        ));
+
+        // Should have success message
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("Pad created"));
+        assert!(result.messages[0].content.contains("New Pad"));
+    }
+
+    #[test]
+    fn create_with_content_normalizes_title_in_content() {
+        let mut store = InMemoryStore::new();
+
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "My Title".into(),
+            "Body text".into(),
+            None,
+        )
+        .unwrap();
+
+        let pad = &result.affected_pads[0].pad;
+        // Title should be extracted and content should include title
+        assert_eq!(pad.metadata.title, "My Title");
+        assert!(pad.content.starts_with("My Title"));
+    }
+
+    #[test]
+    fn create_root_pad_has_no_parent() {
+        let mut store = InMemoryStore::new();
+
+        run(&mut store, Scope::Project, "Root".into(), "".into(), None).unwrap();
+
+        let pads = store.list_pads(Scope::Project).unwrap();
+        assert_eq!(pads.len(), 1);
+        assert!(pads[0].metadata.parent_id.is_none());
+    }
 }

--- a/crates/padzapp/src/commands/doctor.rs
+++ b/crates/padzapp/src/commands/doctor.rs
@@ -27,3 +27,132 @@ pub fn run<S: DataStore>(store: &mut S, scope: Scope) -> Result<CmdResult> {
 
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Metadata;
+    use crate::store::backend::StorageBackend;
+    use crate::store::mem_backend::MemBackend;
+    use crate::store::memory::InMemoryStore;
+    use crate::store::pad_store::PadStore;
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    #[test]
+    fn doctor_no_inconsistencies() {
+        let mut store = InMemoryStore::new();
+
+        let result = run(&mut store, Scope::Project).unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("No inconsistencies"));
+    }
+
+    #[test]
+    fn doctor_recovers_orphan_files() {
+        let backend = MemBackend::new();
+        let orphan_id = Uuid::new_v4();
+
+        // Create orphan: content exists but no index entry
+        backend
+            .write_content(&orphan_id, Scope::Project, "Orphan Title\n\nBody")
+            .unwrap();
+
+        let mut store = PadStore::with_backend(backend);
+        let result = run(&mut store, Scope::Project).unwrap();
+
+        // Should report inconsistencies found
+        assert!(result.messages.len() >= 2);
+        assert!(result.messages[0].content.contains("Inconsistencies found"));
+        // Should report recovered files
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Recovered") && m.content.contains("1")));
+    }
+
+    #[test]
+    fn doctor_removes_zombie_entries() {
+        let backend = MemBackend::new();
+        let zombie_id = Uuid::new_v4();
+
+        // Create zombie: index entry exists but no content
+        let mut index = HashMap::new();
+        index.insert(
+            zombie_id,
+            Metadata {
+                id: zombie_id,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                is_pinned: false,
+                pinned_at: None,
+                is_deleted: false,
+                deleted_at: None,
+                delete_protected: false,
+                parent_id: None,
+                title: "Zombie".to_string(),
+            },
+        );
+        backend.save_index(Scope::Project, &index).unwrap();
+
+        let mut store = PadStore::with_backend(backend);
+        let result = run(&mut store, Scope::Project).unwrap();
+
+        // Should report inconsistencies found
+        assert!(result.messages.len() >= 2);
+        assert!(result.messages[0].content.contains("Inconsistencies found"));
+        // Should report removed entries
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Removed") && m.content.contains("1")));
+    }
+
+    #[test]
+    fn doctor_reports_both_issues() {
+        let backend = MemBackend::new();
+
+        // Create orphan content
+        let orphan_id = Uuid::new_v4();
+        backend
+            .write_content(&orphan_id, Scope::Project, "Orphan\n\nContent")
+            .unwrap();
+
+        // Create zombie entry
+        let zombie_id = Uuid::new_v4();
+        let mut index = HashMap::new();
+        index.insert(
+            zombie_id,
+            Metadata {
+                id: zombie_id,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                is_pinned: false,
+                pinned_at: None,
+                is_deleted: false,
+                deleted_at: None,
+                delete_protected: false,
+                parent_id: None,
+                title: "Zombie".to_string(),
+            },
+        );
+        backend.save_index(Scope::Project, &index).unwrap();
+
+        let mut store = PadStore::with_backend(backend);
+        let result = run(&mut store, Scope::Project).unwrap();
+
+        // Should have warning + both issue types
+        assert!(result.messages.len() >= 3);
+        assert!(result.messages[0].content.contains("Inconsistencies found"));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Removed")));
+        assert!(result
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Recovered")));
+    }
+}

--- a/crates/padzapp/src/commands/export.rs
+++ b/crates/padzapp/src/commands/export.rs
@@ -413,6 +413,15 @@ mod tests {
     }
 
     #[test]
+    fn test_bump_markdown_headers_h3_h4() {
+        let input = "### H3 Header\n\nText\n\n#### H4 Header\n\nMore text";
+        let output = bump_markdown_headers(input);
+        // H3 -> H5, H4 -> H6
+        assert!(output.contains("##### H3 Header"), "H3 should become H5");
+        assert!(output.contains("###### H4 Header"), "H4 should become H6");
+    }
+
+    #[test]
     fn test_bump_markdown_headers_preserves_non_headers() {
         let input = "Regular paragraph\n\n- List item\n- Another item\n\n```rust\ncode\n```";
         let output = bump_markdown_headers(input);
@@ -505,6 +514,11 @@ mod tests {
         assert_eq!(
             sanitize_output_filename("my/notes", SingleFileFormat::Markdown),
             "my_notes.md"
+        );
+        // Test .markdown extension handling
+        assert_eq!(
+            sanitize_output_filename("notes.markdown", SingleFileFormat::Markdown),
+            "notes.md"
         );
     }
     #[test]

--- a/crates/padzapp/src/commands/helpers.rs
+++ b/crates/padzapp/src/commands/helpers.rs
@@ -458,4 +458,204 @@ mod tests {
         let pad = store.get_pad(&result[0].1, Scope::Project).unwrap();
         assert_eq!(pad.metadata.title, "Child");
     }
+
+    #[test]
+    fn test_title_search_no_match_returns_error() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Alpha".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Beta".into(), "".into(), None).unwrap();
+
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("Gamma".to_string())],
+            false,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("No pad found matching"));
+        assert!(err.to_string().contains("Gamma"));
+    }
+
+    #[test]
+    fn test_title_search_multiple_matches_returns_error() {
+        let mut store = InMemoryStore::new();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Meeting Monday".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Meeting Tuesday".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Meeting Wednesday".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("Meeting".to_string())],
+            false,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("multiple"));
+        assert!(err.to_string().contains("3")); // matched 3 pads
+    }
+
+    #[test]
+    fn test_title_search_single_match_succeeds() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Alpha".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Beta".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Gamma".into(), "".into(), None).unwrap();
+
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("Beta".to_string())],
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let pad = store.get_pad(&result[0].1, Scope::Project).unwrap();
+        assert_eq!(pad.metadata.title, "Beta");
+    }
+
+    #[test]
+    fn test_title_search_matches_content_not_just_title() {
+        let mut store = InMemoryStore::new();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Shopping List".into(),
+            "Buy apples and oranges".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Todo List".into(),
+            "Call dentist".into(),
+            None,
+        )
+        .unwrap();
+
+        // Search for content that's in body, not title
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("apples".to_string())],
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let pad = store.get_pad(&result[0].1, Scope::Project).unwrap();
+        assert_eq!(pad.metadata.title, "Shopping List");
+    }
+
+    #[test]
+    fn test_title_search_is_case_insensitive() {
+        let mut store = InMemoryStore::new();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "UPPERCASE TITLE".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("uppercase".to_string())],
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let pad = store.get_pad(&result[0].1, Scope::Project).unwrap();
+        assert_eq!(pad.metadata.title, "UPPERCASE TITLE");
+    }
+
+    #[test]
+    fn test_title_search_delete_protection_check() {
+        let mut store = InMemoryStore::new();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "ProtectedPad".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+
+        // Manually set delete_protected without pinning (to avoid dual-index)
+        let pads = store.list_pads(Scope::Project).unwrap();
+        let mut pad = pads[0].clone();
+        pad.metadata.delete_protected = true;
+        store.save_pad(&pad, Scope::Project).unwrap();
+
+        // Try to resolve with delete protection check enabled
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("ProtectedPad".to_string())],
+            true, // check_delete_protection = true
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("delete protected"));
+    }
+
+    #[test]
+    fn test_title_search_delete_protection_disabled() {
+        let mut store = InMemoryStore::new();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "ProtectedPad".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+
+        // Manually set delete_protected without pinning (to avoid dual-index)
+        let pads = store.list_pads(Scope::Project).unwrap();
+        let mut pad = pads[0].clone();
+        pad.metadata.delete_protected = true;
+        store.save_pad(&pad, Scope::Project).unwrap();
+
+        // Resolve with delete protection check disabled
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("ProtectedPad".to_string())],
+            false, // check_delete_protection = false
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+    }
 }


### PR DESCRIPTION
- **test(commands): Add export and import test coverage**
- **test(config): Add comprehensive tests for config command**
- **test(create): Add tests for parent resolution error paths**
- **test(helpers): Add tests for title search resolution**
- **test(fs_backend): Add tests for scope and extension edge cases**
- **test(helpers): Add tests for range selector edge cases**
- **test(doctor): Add comprehensive tests for doctor command**
- **test(import): Add tests for import edge cases**
- **test(update): Add tests for content normalization and edge cases**
- **test(api): Add comprehensive tests for API facade integration**
