### PR TITLE
feat(todo): Implement Notes as Todos

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -234,6 +234,7 @@ fn handle_list(
                 PadStatusFilter::Active
             },
             search_term: Some(term),
+            todo_status: None,
         }
     } else {
         PadFilter {
@@ -243,6 +244,7 @@ fn handle_list(
                 PadStatusFilter::Active
             },
             search_term: None,
+            todo_status: None,
         }
     };
 
@@ -334,6 +336,7 @@ fn handle_search(ctx: &mut AppContext, term: String) -> Result<()> {
     let filter = PadFilter {
         status: PadStatusFilter::Active,
         search_term: Some(term),
+        todo_status: None,
     };
     let result = ctx.api.get_pads(ctx.scope, filter)?;
     let output = render_pad_list(&result.listed_pads, false);

--- a/crates/padz/src/cli/complete.rs
+++ b/crates/padz/src/cli/complete.rs
@@ -32,6 +32,7 @@ fn get_pad_candidates(include_deleted: bool) -> Vec<CompletionCandidate> {
             PadStatusFilter::Active
         },
         search_term: None,
+        todo_status: None,
     };
 
     let Ok(result) = api.get_pads(ctx.scope, filter) else {
@@ -88,6 +89,7 @@ pub fn deleted_pads_completer() -> ArgValueCandidates {
         let filter = PadFilter {
             status: PadStatusFilter::Deleted,
             search_term: None,
+            todo_status: None,
         };
 
         let Ok(result) = api.get_pads(ctx.scope, filter) else {

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -30,7 +30,7 @@ pub const PIN_MARKER: &str = "⚲";
 /// Status indicators for todo status
 pub const STATUS_PLANNED: &str = "◯";
 pub const STATUS_IN_PROGRESS: &str = "◐";
-pub const STATUS_DONE: &str = "⬤";
+pub const STATUS_DONE: &str = "◉";
 
 #[derive(Serialize)]
 struct MatchSegmentData {

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -16,7 +16,7 @@ use super::styles::{names, PADZ_THEME};
 use super::templates::{FULL_PAD_TEMPLATE, LIST_TEMPLATE, MESSAGES_TEMPLATE, TEXT_LIST_TEMPLATE};
 use chrono::{DateTime, Utc};
 use outstanding::{render, render_with_color, truncate_to_width, ThemeChoice};
-use padzapp::api::{CmdMessage, MessageLevel};
+use padzapp::api::{CmdMessage, MessageLevel, TodoStatus};
 use padzapp::index::{DisplayIndex, DisplayPad};
 use padzapp::peek::{format_as_peek, PeekResult};
 use serde::Serialize;
@@ -26,6 +26,11 @@ use unicode_width::UnicodeWidthStr;
 pub const LINE_WIDTH: usize = 100;
 pub const TIME_WIDTH: usize = 14;
 pub const PIN_MARKER: &str = "⚲";
+
+/// Status indicators for todo status
+pub const STATUS_PLANNED: &str = "◯";
+pub const STATUS_IN_PROGRESS: &str = "◐";
+pub const STATUS_DONE: &str = "⬤";
 
 #[derive(Serialize)]
 struct MatchSegmentData {
@@ -48,6 +53,7 @@ struct MatchLineData {
 struct PadLineData {
     // Pre-computed layout components (Rust handles width calculations)
     left_pad: String,
+    status_icon: String, // Todo status indicator (◯, ◐, ⬤)
     index: String,
     title: String,
     padding: String,
@@ -197,6 +203,15 @@ fn render_pad_list_internal(
         let depth_pad = "  ".repeat(depth);
         let left_pad = format!("{}{}", base_pad, depth_pad);
 
+        // Get status icon based on pad's todo status
+        let status_icon = match dp.pad.metadata.status {
+            TodoStatus::Planned => STATUS_PLANNED,
+            TodoStatus::InProgress => STATUS_IN_PROGRESS,
+            TodoStatus::Done => STATUS_DONE,
+        }
+        .to_string();
+        let status_icon_width = status_icon.width() + 1; // icon + space
+
         // Calculate available width for title
         let pin_width = PIN_MARKER.width();
         let left_prefix_width = if is_pinned_section && depth == 0 {
@@ -208,7 +223,8 @@ fn render_pad_list_internal(
         let right_suffix_width = if show_right_pin { pin_width + 1 } else { 2 };
 
         let idx_width = full_idx_str.width();
-        let fixed_width = left_prefix_width + idx_width + right_suffix_width + TIME_WIDTH;
+        let fixed_width =
+            left_prefix_width + status_icon_width + idx_width + right_suffix_width + TIME_WIDTH;
         let available = LINE_WIDTH.saturating_sub(fixed_width);
 
         let title_display = truncate_to_width(dp.pad.metadata.title.as_str(), available);
@@ -265,6 +281,7 @@ fn render_pad_list_internal(
 
         pad_lines.push(PadLineData {
             left_pad,
+            status_icon,
             index: full_idx_str.clone(),
             title: title_display,
             padding,
@@ -302,6 +319,7 @@ fn render_pad_list_internal(
         if last_was_pinned && !is_pinned_section {
             pad_lines.push(PadLineData {
                 left_pad: String::new(),
+                status_icon: String::new(),
                 index: String::new(),
                 title: String::new(),
                 padding: String::new(),
@@ -541,11 +559,12 @@ mod tests {
 
         let output = render_pad_list_internal(&[dp], Some(false), false, false);
 
-        // Should contain zero-padded index and title
+        // Should contain status icon, zero-padded index and title
+        assert!(output.contains(STATUS_PLANNED)); // Default status is Planned
         assert!(output.contains("01."));
         assert!(output.contains("Test Note"));
-        // Should have 2-space left padding for regular entries (aligns with pinned "⚲ " prefix)
-        assert!(output.contains("  01."));
+        // Should have status icon before index
+        assert!(output.contains(&format!("{} 01.", STATUS_PLANNED)));
     }
 
     #[test]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -167,6 +167,18 @@ pub enum CoreCommands {
         /// Peek at pad content
         #[arg(long)]
         peek: bool,
+
+        /// Show only planned pads
+        #[arg(long, conflicts_with_all = ["done", "in_progress"])]
+        planned: bool,
+
+        /// Show only done pads
+        #[arg(long, conflicts_with_all = ["planned", "in_progress"])]
+        done: bool,
+
+        /// Show only in-progress pads
+        #[arg(long, conflicts_with_all = ["planned", "done"])]
+        in_progress: bool,
     },
 
     /// Search pads (dedicated command)
@@ -208,8 +220,12 @@ pub enum PadCommands {
     #[command(alias = "rm", display_order = 13)]
     Delete {
         /// Indexes of the pads (e.g. 1 3 5)
-        #[arg(required = true, num_args = 1.., add = active_pads_completer())]
+        #[arg(num_args = 1.., add = active_pads_completer(), required_unless_present = "done_status")]
         indexes: Vec<String>,
+
+        /// Delete all pads marked as done
+        #[arg(long = "done", conflicts_with = "indexes")]
+        done_status: bool,
     },
 
     /// Restore deleted pads
@@ -241,6 +257,22 @@ pub enum PadCommands {
     Path {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]
+        indexes: Vec<String>,
+    },
+
+    /// Mark pads as done (completed)
+    #[command(alias = "done", display_order = 18)]
+    Complete {
+        /// Indexes of the pads (e.g. 1 3 5 or 1-5)
+        #[arg(required = true, num_args = 1.., add = active_pads_completer())]
+        indexes: Vec<String>,
+    },
+
+    /// Reopen pads (set back to planned)
+    #[command(display_order = 19)]
+    Reopen {
+        /// Indexes of the pads (e.g. 1 3 5 or 1-5)
+        #[arg(required = true, num_args = 1.., add = active_pads_completer())]
         indexes: Vec<String>,
     },
 }

--- a/crates/padz/src/cli/templates/list.tmp
+++ b/crates/padz/src/cli/templates/list.tmp
@@ -6,7 +6,7 @@
 {%- if pad.is_separator -%}
 {{- "" | nl -}}
 {%- else -%}
-{{- pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
+{{- pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{{ pad.status_icon | style("time") }} {% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
 {%- for match in pad.matches -%}
 {{- "    " }}{{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}{{ "" | nl -}}
 {%- endfor -%}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -148,6 +148,26 @@ impl<S: DataStore> PadzApi<S> {
         commands::pinning::unpin(&mut self.store, scope, &selectors)
     }
 
+    /// Marks pads as Done (completed).
+    pub fn complete_pads<I: AsRef<str>>(
+        &mut self,
+        scope: Scope,
+        indexes: &[I],
+    ) -> Result<commands::CmdResult> {
+        let selectors = parse_selectors(indexes)?;
+        commands::status::complete(&mut self.store, scope, &selectors)
+    }
+
+    /// Reopens pads (sets them back to Planned).
+    pub fn reopen_pads<I: AsRef<str>>(
+        &mut self,
+        scope: Scope,
+        indexes: &[I],
+    ) -> Result<commands::CmdResult> {
+        let selectors = parse_selectors(indexes)?;
+        commands::status::reopen(&mut self.store, scope, &selectors)
+    }
+
     pub fn update_pads(
         &mut self,
         scope: Scope,
@@ -339,6 +359,7 @@ fn normalize_single_to_deleted(s: &str) -> String {
 // parse_index_or_range and parse_path removed (imported from index.rs)
 
 pub use crate::commands::config::ConfigAction;
+pub use crate::model::TodoStatus;
 pub use commands::get::{PadFilter, PadStatusFilter};
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
 

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -571,6 +571,7 @@ mod tests {
                 PadFilter {
                     status: PadStatusFilter::All,
                     search_term: None,
+                    todo_status: None,
                 },
             )
             .unwrap();

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -37,6 +37,9 @@ pub fn run<S: DataStore>(
 
     store.save_pad(&pad, scope)?;
 
+    // Propagate status change to parent (e.g. adding a "Planned" child might revert parent from "Done")
+    crate::todos::propagate_status_change(store, scope, pad.metadata.parent_id)?;
+
     let mut result = CmdResult::default();
     // New pad is always the newest, so it gets index 1
     let display_pad = DisplayPad {

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -23,6 +23,10 @@ pub fn run<S: DataStore>(
         pad.metadata.is_deleted = true;
         pad.metadata.deleted_at = Some(Utc::now());
         store.save_pad(&pad, scope)?;
+
+        // Propagate status change to parent (deleted child no longer affects status)
+        crate::todos::propagate_status_change(store, scope, pad.metadata.parent_id)?;
+
         result.add_message(CmdMessage::success(format!(
             "Pad deleted ({}): {}",
             super::helpers::fmt_path(&display_index),

--- a/crates/padzapp/src/commands/doctor.rs
+++ b/crates/padzapp/src/commands/doctor.rs
@@ -93,6 +93,7 @@ mod tests {
                 delete_protected: false,
                 parent_id: None,
                 title: "Zombie".to_string(),
+                status: crate::model::TodoStatus::Planned,
             },
         );
         backend.save_index(Scope::Project, &index).unwrap();
@@ -136,6 +137,7 @@ mod tests {
                 delete_protected: false,
                 parent_id: None,
                 title: "Zombie".to_string(),
+                status: crate::model::TodoStatus::Planned,
             },
         );
         backend.save_index(Scope::Project, &index).unwrap();

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -82,6 +82,7 @@ pub mod paths;
 pub mod pinning;
 pub mod purge;
 pub mod restore;
+pub mod status;
 
 pub mod update;
 pub mod view;

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -188,6 +188,8 @@ pub struct PadUpdate {
     pub index: crate::index::DisplayIndex,
     pub title: String,
     pub content: String,
+    pub status: Option<crate::model::TodoStatus>,
+    pub path: Option<Vec<crate::index::DisplayIndex>>,
 }
 
 impl PadUpdate {
@@ -196,6 +198,18 @@ impl PadUpdate {
             index,
             title,
             content,
+            status: None,
+            path: None,
         }
+    }
+
+    pub fn with_status(mut self, status: crate::model::TodoStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    pub fn with_path(mut self, path: Vec<crate::index::DisplayIndex>) -> Self {
+        self.path = Some(path);
+        self
     }
 }

--- a/crates/padzapp/src/commands/restore.rs
+++ b/crates/padzapp/src/commands/restore.rs
@@ -23,6 +23,9 @@ pub fn run<S: DataStore>(
         pad.metadata.deleted_at = None;
         // Keep original created_at so the pad appears in its original position
         store.save_pad(&pad, scope)?;
+
+        // Propagate status change to parent (restored child affects status again)
+        crate::todos::propagate_status_change(store, scope, pad.metadata.parent_id)?;
         result.add_message(CmdMessage::success(format!(
             "Pad restored ({}): {}",
             super::helpers::fmt_path(&display_index),

--- a/crates/padzapp/src/commands/status.rs
+++ b/crates/padzapp/src/commands/status.rs
@@ -1,0 +1,272 @@
+//! # Todo Status Commands
+//!
+//! This module provides commands for managing the todo status of pads:
+//! - [`complete`]: Marks pads as Done
+//! - [`reopen`]: Reopens pads (sets them back to Planned)
+
+use crate::commands::{CmdMessage, CmdResult};
+use crate::error::Result;
+use crate::index::{DisplayIndex, DisplayPad, PadSelector};
+use crate::model::{Scope, TodoStatus};
+use crate::store::DataStore;
+use uuid::Uuid;
+
+use super::helpers::{indexed_pads, resolve_selectors};
+
+/// Marks pads as Done.
+pub fn complete<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    selectors: &[PadSelector],
+) -> Result<CmdResult> {
+    set_status(store, scope, selectors, TodoStatus::Done)
+}
+
+/// Reopens pads (sets them back to Planned).
+pub fn reopen<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    selectors: &[PadSelector],
+) -> Result<CmdResult> {
+    set_status(store, scope, selectors, TodoStatus::Planned)
+}
+
+fn set_status<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    selectors: &[PadSelector],
+    new_status: TodoStatus,
+) -> Result<CmdResult> {
+    let resolved = resolve_selectors(store, scope, selectors, false)?;
+    let mut result = CmdResult::default();
+
+    let mut affected_uuids: Vec<Uuid> = Vec::new();
+    for (display_index, uuid) in resolved {
+        let mut pad = store.get_pad(&uuid, scope)?;
+        let old_status = pad.metadata.status;
+
+        if old_status == new_status {
+            // Already in desired state
+            let status_name = match new_status {
+                TodoStatus::Done => "done",
+                TodoStatus::Planned => "planned",
+                TodoStatus::InProgress => "in progress",
+            };
+            result.add_message(CmdMessage::info(format!(
+                "Pad {} is already {}",
+                super::helpers::fmt_path(&display_index),
+                status_name
+            )));
+        } else {
+            pad.metadata.status = new_status;
+            pad.metadata.updated_at = chrono::Utc::now();
+
+            let parent_id = pad.metadata.parent_id;
+            store.save_pad(&pad, scope)?;
+
+            // Propagate status change to parent
+            crate::todos::propagate_status_change(store, scope, parent_id)?;
+
+            let action = match new_status {
+                TodoStatus::Done => "Completed",
+                TodoStatus::Planned => "Reopened",
+                TodoStatus::InProgress => "Set to in-progress",
+            };
+            result.add_message(CmdMessage::success(format!(
+                "{} pad {}: {}",
+                action,
+                super::helpers::fmt_path(&display_index),
+                pad.metadata.title
+            )));
+        }
+        affected_uuids.push(uuid);
+    }
+
+    // Re-index to get the current indexes
+    let indexed = indexed_pads(store, scope)?;
+    for uuid in affected_uuids {
+        // Prefer Regular index for active pads
+        let index_filter =
+            |idx: &DisplayIndex| matches!(idx, DisplayIndex::Regular(_) | DisplayIndex::Pinned(_));
+        if let Some(dp) = super::helpers::find_pad_by_uuid(&indexed, uuid, index_filter) {
+            result.affected_pads.push(DisplayPad {
+                pad: dp.pad.clone(),
+                index: dp.index.clone(),
+                matches: None,
+                children: Vec::new(),
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{create, get};
+    use crate::index::DisplayIndex;
+    use crate::model::Scope;
+    use crate::store::memory::InMemoryStore;
+    use std::slice;
+
+    #[test]
+    fn complete_marks_pad_as_done() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Task".into(), "".into(), None).unwrap();
+
+        let sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        let result = complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("Completed"));
+
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        assert_eq!(pads.listed_pads[0].pad.metadata.status, TodoStatus::Done);
+    }
+
+    #[test]
+    fn reopen_sets_pad_to_planned() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Task".into(), "".into(), None).unwrap();
+
+        // First complete it
+        let sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        // Then reopen it
+        let result = reopen(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("Reopened"));
+
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        assert_eq!(pads.listed_pads[0].pad.metadata.status, TodoStatus::Planned);
+    }
+
+    #[test]
+    fn complete_already_done_is_idempotent() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Task".into(), "".into(), None).unwrap();
+
+        let sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        // Complete again
+        let result = complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        assert!(matches!(
+            result.messages[0].level,
+            crate::commands::MessageLevel::Info
+        ));
+        assert!(result.messages[0].content.contains("already done"));
+    }
+
+    #[test]
+    fn reopen_already_planned_is_idempotent() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "Task".into(), "".into(), None).unwrap();
+
+        let sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+
+        // Reopen an already planned pad
+        let result = reopen(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        assert!(matches!(
+            result.messages[0].level,
+            crate::commands::MessageLevel::Info
+        ));
+        assert!(result.messages[0].content.contains("already planned"));
+    }
+
+    #[test]
+    fn complete_batch() {
+        let mut store = InMemoryStore::new();
+        create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "B".into(), "".into(), None).unwrap();
+
+        let selectors = vec![
+            PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+            PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+        ];
+
+        let result = complete(&mut store, Scope::Project, &selectors).unwrap();
+
+        assert_eq!(result.messages.len(), 2);
+        assert!(result
+            .messages
+            .iter()
+            .all(|m| m.content.contains("Completed")));
+
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        assert!(pads
+            .listed_pads
+            .iter()
+            .all(|dp| dp.pad.metadata.status == TodoStatus::Done));
+    }
+
+    #[test]
+    fn complete_propagates_to_parent() {
+        let mut store = InMemoryStore::new();
+
+        // Create parent
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+
+        // Create child
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Complete the child (1.1)
+        let sel = PadSelector::Path(vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)]);
+        complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        // Parent should now be Done (all children are Done)
+        let pads = store.list_pads(Scope::Project).unwrap();
+        let parent = pads.iter().find(|p| p.metadata.title == "Parent").unwrap();
+        assert_eq!(parent.metadata.status, TodoStatus::Done);
+    }
+
+    #[test]
+    fn reopen_propagates_to_parent() {
+        let mut store = InMemoryStore::new();
+
+        // Create parent
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+
+        // Create child
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Complete the child
+        let sel = PadSelector::Path(vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)]);
+        complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        // Verify parent is Done
+        let pads = store.list_pads(Scope::Project).unwrap();
+        let parent = pads.iter().find(|p| p.metadata.title == "Parent").unwrap();
+        assert_eq!(parent.metadata.status, TodoStatus::Done);
+
+        // Reopen the child
+        reopen(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
+
+        // Parent should now be Planned (all children are Planned)
+        let pads_after = store.list_pads(Scope::Project).unwrap();
+        let parent_after = pads_after
+            .iter()
+            .find(|p| p.metadata.title == "Parent")
+            .unwrap();
+        assert_eq!(parent_after.metadata.status, TodoStatus::Planned);
+    }
+}

--- a/crates/padzapp/src/lib.rs
+++ b/crates/padzapp/src/lib.rs
@@ -114,6 +114,7 @@ pub mod init;
 pub mod model;
 pub mod peek;
 pub mod store;
+pub mod todos;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/crates/padzapp/src/model.rs
+++ b/crates/padzapp/src/model.rs
@@ -59,6 +59,19 @@ pub enum Scope {
     Global,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TodoStatus {
+    Planned,
+    InProgress,
+    Done,
+}
+
+impl Default for TodoStatus {
+    fn default() -> Self {
+        Self::Planned
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Metadata {
     pub id: Uuid,
@@ -72,6 +85,8 @@ pub struct Metadata {
     pub parent_id: Option<Uuid>,
     // We store the title in metadata to list without reading content files
     pub title: String,
+    #[serde(default)]
+    pub status: TodoStatus,
 }
 
 // Custom deserializer to handle legacy data where `delete_protected` is missing.
@@ -96,6 +111,7 @@ impl<'de> Deserialize<'de> for Metadata {
             delete_protected: helper.delete_protected.unwrap_or(helper.is_pinned),
             parent_id: helper.parent_id,
             title: helper.title,
+            status: helper.status.unwrap_or(TodoStatus::Planned),
         })
     }
 }
@@ -114,6 +130,8 @@ struct MetadataHelper {
     #[serde(default)]
     parent_id: Option<Uuid>,
     title: String,
+    #[serde(default)]
+    status: Option<TodoStatus>,
 }
 
 impl Metadata {
@@ -130,6 +148,7 @@ impl Metadata {
             delete_protected: false,
             parent_id: None,
             title,
+            status: TodoStatus::Planned,
         }
     }
 }

--- a/crates/padzapp/src/store/pad_store.rs
+++ b/crates/padzapp/src/store/pad_store.rs
@@ -93,6 +93,7 @@ impl<B: StorageBackend> PadStore<B> {
                             delete_protected: false,
                             parent_id: None,
                             title,
+                            status: crate::model::TodoStatus::Planned,
                         };
                         meta_map.insert(*id, new_meta);
                         report.recovered_files += 1;
@@ -281,6 +282,7 @@ mod tests {
                 delete_protected: false,
                 parent_id: None,
                 title: "Zombie".to_string(),
+                status: crate::model::TodoStatus::Planned,
             },
         );
         backend.save_index(Scope::Project, &index).unwrap();

--- a/crates/padzapp/src/todos.rs
+++ b/crates/padzapp/src/todos.rs
@@ -1,0 +1,277 @@
+//! # Notes as Todos: Design and Implementation
+//!
+//! This module implements the "Notes as Todos" feature, allowing pads to have a status
+//! (Planned, In Progress, Done) and defining how these statuses propagate in a hierarchy.
+//!
+//! ## Statuses
+//!
+//! A pad can have one of three statuses:
+//! - [`TodoStatus::Planned`][]: Tests/tasks to be done.
+//! - [`TodoStatus::InProgress`][]: Currently being worked on.
+//! - [`TodoStatus::Done`][]: Completed.
+//!
+//! Statuses are stored in the [`crate::model::Metadata`] struct.
+//!
+//! ## Nested Status Propagation
+//!
+//! For nested pads, the parent status is generally a function of its children's statuses.
+//! This relationship ensures that the parent reflects the aggregate state of its sub-tasks.
+//!
+//! ### Propagation Rules
+//!
+//! 1. **All Done -> Done**: If all children are [`TodoStatus::Done`], the parent becomes [`TodoStatus::Done`].
+//! 2. **All Planned -> Planned**: If all children are [`TodoStatus::Planned`], the parent becomes [`TodoStatus::Planned`].
+//! 3. **Mixed -> In Progress**: If children are in mixed states (e.g., some Done, some Planned, or any InProgress),
+//!    the parent becomes [`TodoStatus::InProgress`].
+//!    - Specifically: If not all are Done, but at least one is Done (or InProgress), the parent is InProgress.
+//!
+//! ### Manual Override vs. Automatic Updates
+//!
+//! Users can manually set the status of a parent pad.
+//! - **Manual Override**: If a user explicitly sets a parent to "Done", it becomes "Done" immediately.
+//!   This creates a potential inconsistency (Parent=Done, Children=Planned), which is *allowed* by design.
+//!   Downward propagation (changing children to match parent) is **NOT** performed.
+//! - **Automatic Reaction**: However, subsequent changes to children *will* trigger a re-calculation of the parent status.
+//!   The "Manual Override" is ephemeral; it holds until the next event that triggers a recalculation.
+//!
+//! ### Implementation Logic
+//!
+//! The propagation logic is "Bottom-Up":
+//! - When a pad is created, deleted, or its status changes:
+//!   1. Identify its parent.
+//!   2. If no parent, stop.
+//!   3. Fetch all siblings of the pad (children of the parent).
+//!   4. Calculate the derived status based on siblings.
+//!   5. If derived status != parent's current status:
+//!      - Update parent status.
+//!      - Recurse (treat parent as the changed child).
+//!
+//! ## Design Decisions
+//!
+//! - **No Downward Propagation**: Setting a parent to "Done" acts as a milestone check, not a batch operation.
+//!   We preserves the individual states of children.
+//! - **Eventual Consistency**: While manual overrides allow temporary inconsistency, the system trends towards
+//!   consistency as children are updated.
+//! - **Storage**: Status is a persistent field in `Metadata`, not just a runtime calculation. This allows
+//!   for the manual overrides to persist until challenged.
+//!
+
+use crate::error::Result;
+use crate::model::{Scope, TodoStatus};
+use crate::store::DataStore;
+use uuid::Uuid;
+
+/// Propagates status changes upwards from a specific child pad.
+///
+/// This function should be called whenever a pad is:
+/// - Created (if it has a parent)
+/// - Deleted (if it had a parent)
+/// - Updated (if its status, delete state, or parent changed)
+///
+/// It recursively updates parents until the root or until no change occurs.
+pub fn propagate_status_change<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    child_parent_id: Option<Uuid>,
+) -> Result<()> {
+    let mut current_parent_id = child_parent_id;
+
+    while let Some(parent_id) = current_parent_id {
+        // 1. Get the parent
+        let mut parent_pad = match store.get_pad(&parent_id, scope) {
+            Ok(p) => p,
+            Err(_) => {
+                // Parent might be deleted or missing, stop propagation
+                break;
+            }
+        };
+
+        // 2. Get all children (siblings of the original child)
+        // We need efficient lookups. Store lists all pads?
+        // Optimally, store would support `get_children(parent_id)`.
+        // For now, we iterate (inefficient but safe for "basic level").
+        // TODO: Optimize store query for children.
+        let all_pads = store.list_pads(scope)?;
+        let children: Vec<&crate::model::Pad> = all_pads
+            .iter()
+            .filter(|p| p.metadata.parent_id == Some(parent_id) && !p.metadata.is_deleted)
+            .collect();
+
+        if children.is_empty() {
+            // No active children? Status is not derived. Stop.
+            // Or should it revert to Planned? Spec doesn't say.
+            break;
+        }
+
+        // 3. Calculate derived status
+        let derived = calculate_status(&children);
+
+        // 4. Update if needed
+        if parent_pad.metadata.status != derived {
+            // println!("Updating parent {} status from {:?} to {:?}", parent_pad.metadata.title, parent_pad.metadata.status, derived);
+            parent_pad.metadata.status = derived;
+            parent_pad.metadata.updated_at = chrono::Utc::now();
+            store.save_pad(&parent_pad, scope)?;
+
+            // Recurse up
+            current_parent_id = parent_pad.metadata.parent_id;
+        } else {
+            // No change, stop propagation
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Calculates the status of a parent based on its children.
+fn calculate_status(children: &[&crate::model::Pad]) -> TodoStatus {
+    let all_done = children
+        .iter()
+        .all(|p| p.metadata.status == TodoStatus::Done);
+    let all_planned = children
+        .iter()
+        .all(|p| p.metadata.status == TodoStatus::Planned);
+
+    if all_done {
+        TodoStatus::Done
+    } else if all_planned {
+        TodoStatus::Planned
+    } else {
+        // Mixed state (some Done, some Planned, or any InProgress)
+        TodoStatus::InProgress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Pad, TodoStatus};
+    use crate::store::memory::InMemoryStore;
+    use crate::store::DataStore;
+
+    fn make_pad(title: &str, status: TodoStatus) -> Pad {
+        let mut p = Pad::new(title.to_string(), "".to_string());
+        p.metadata.status = status;
+        p
+    }
+
+    #[test]
+    fn test_propagate_all_planned() {
+        let mut store = InMemoryStore::new();
+        let parent = make_pad("Parent", TodoStatus::Done); // Wrong status initially
+        let mut child1 = make_pad("Child1", TodoStatus::Planned);
+        let mut child2 = make_pad("Child2", TodoStatus::Planned);
+
+        // Setup hierarchy
+        let parent_id = parent.metadata.id;
+        child1.metadata.parent_id = Some(parent_id);
+        child2.metadata.parent_id = Some(parent_id);
+
+        store.save_pad(&parent, Scope::Project).unwrap();
+        store.save_pad(&child1, Scope::Project).unwrap();
+        store.save_pad(&child2, Scope::Project).unwrap();
+
+        // Propagate from child1
+        propagate_status_change(&mut store, Scope::Project, Some(parent_id)).unwrap();
+
+        // Parent should become Planned
+        let updated_parent = store.get_pad(&parent_id, Scope::Project).unwrap();
+        assert_eq!(updated_parent.metadata.status, TodoStatus::Planned);
+    }
+
+    #[test]
+    fn test_propagate_all_done() {
+        let mut store = InMemoryStore::new();
+        let parent = make_pad("Parent", TodoStatus::Planned);
+        let mut child1 = make_pad("Child1", TodoStatus::Done);
+        let mut child2 = make_pad("Child2", TodoStatus::Done);
+
+        let parent_id = parent.metadata.id;
+        child1.metadata.parent_id = Some(parent_id);
+        child2.metadata.parent_id = Some(parent_id);
+
+        store.save_pad(&parent, Scope::Project).unwrap();
+        store.save_pad(&child1, Scope::Project).unwrap();
+        store.save_pad(&child2, Scope::Project).unwrap();
+
+        propagate_status_change(&mut store, Scope::Project, Some(parent_id)).unwrap();
+
+        let updated_parent = store.get_pad(&parent_id, Scope::Project).unwrap();
+        assert_eq!(updated_parent.metadata.status, TodoStatus::Done);
+    }
+
+    #[test]
+    fn test_propagate_mixed_done_planned() {
+        let mut store = InMemoryStore::new();
+        let parent = make_pad("Parent", TodoStatus::Planned);
+        let mut child1 = make_pad("Child1", TodoStatus::Done);
+        let mut child2 = make_pad("Child2", TodoStatus::Planned);
+
+        let parent_id = parent.metadata.id;
+        child1.metadata.parent_id = Some(parent_id);
+        child2.metadata.parent_id = Some(parent_id);
+
+        store.save_pad(&parent, Scope::Project).unwrap();
+        store.save_pad(&child1, Scope::Project).unwrap();
+        store.save_pad(&child2, Scope::Project).unwrap();
+
+        propagate_status_change(&mut store, Scope::Project, Some(parent_id)).unwrap();
+
+        let updated_parent = store.get_pad(&parent_id, Scope::Project).unwrap();
+        assert_eq!(updated_parent.metadata.status, TodoStatus::InProgress);
+    }
+
+    #[test]
+    fn test_propagate_ignores_deleted_children() {
+        let mut store = InMemoryStore::new();
+        let parent = make_pad("Parent", TodoStatus::Planned);
+        let mut child1 = make_pad("Child1", TodoStatus::Done);
+        let mut child2 = make_pad("Child2", TodoStatus::Planned);
+        child2.metadata.is_deleted = true; // This child should be ignored
+
+        let parent_id = parent.metadata.id;
+        child1.metadata.parent_id = Some(parent_id);
+        child2.metadata.parent_id = Some(parent_id);
+
+        store.save_pad(&parent, Scope::Project).unwrap();
+        store.save_pad(&child1, Scope::Project).unwrap();
+        store.save_pad(&child2, Scope::Project).unwrap();
+
+        propagate_status_change(&mut store, Scope::Project, Some(parent_id)).unwrap();
+
+        // Only child1 (Done) counts -> Parent should be Done!
+        let updated_parent = store.get_pad(&parent_id, Scope::Project).unwrap();
+        assert_eq!(updated_parent.metadata.status, TodoStatus::Done);
+    }
+
+    #[test]
+    fn test_propagate_recursive() {
+        let mut store = InMemoryStore::new();
+        let mut grandparent = make_pad("GP", TodoStatus::Planned);
+        let mut parent = make_pad("Parent", TodoStatus::Planned);
+        let mut child = make_pad("Child", TodoStatus::Done);
+
+        let gp_id = grandparent.metadata.id;
+        let p_id = parent.metadata.id;
+
+        grandparent.metadata.parent_id = None;
+        parent.metadata.parent_id = Some(gp_id);
+        child.metadata.parent_id = Some(p_id);
+
+        store.save_pad(&grandparent, Scope::Project).unwrap();
+        store.save_pad(&parent, Scope::Project).unwrap();
+        store.save_pad(&child, Scope::Project).unwrap();
+
+        // Trigger on child's parent
+        propagate_status_change(&mut store, Scope::Project, Some(p_id)).unwrap();
+
+        // Check parent (should be Done)
+        let updated_p = store.get_pad(&p_id, Scope::Project).unwrap();
+        assert_eq!(updated_p.metadata.status, TodoStatus::Done);
+
+        // Check grandparent (should be Done)
+        let updated_gp = store.get_pad(&gp_id, Scope::Project).unwrap();
+        assert_eq!(updated_gp.metadata.status, TodoStatus::Done);
+    }
+}


### PR DESCRIPTION
## Description
This PR implements the 'Notes as Todos' feature, enabling pads to have a status (Planned, InProgress, Done) that propagates recursively through the pad hierarchy.

## Key Changes
- Introduced `TodoStatus` enum (Planned, InProgress, Done).
- Added `status` field to `Metadata` struct with backward compatibility.
- Implemented `todos.rs` with bottom-up status propagation logic:
    - All Done -> Done
    - All Planned -> Planned
    - Mixed -> InProgress
- Updated `create`, `update`, `delete`, and `restore` commands to trigger automatic status propagation using the new logic.
- Refactored `PadUpdate` to support nested paths, enabling better testing of tree structures.
- Added comprehensive unit tests for propagation logic and integration tests for command wiring.

## Verification
- Added `tests/todos.rs` unit tests covering all propagation rules.
- Added integration test in `commands/update.rs` verifying end-to-end status updates.
- Verified all tests pass with `cargo test`.