### PR TITLE
feat(ui): improve list view layout and status icons

### DIFF
--- a/crates/padz/src/cli/templates/list.tmp
+++ b/crates/padz/src/cli/templates/list.tmp
@@ -6,7 +6,7 @@
 {%- if pad.is_separator -%}
 {{- "" | nl -}}
 {%- else -%}
-{{- pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{{ pad.status_icon | style("time") }} {% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
+{{- pad.status_icon | style("time") }} {{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
 {%- for match in pad.matches -%}
 {{- "    " }}{{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}{{ "" | nl -}}
 {%- endfor -%}


### PR DESCRIPTION
## Summary
- Update status icons to `○` (planned), `⊙` (in progress), `●` (done)
- Move status icon to column 0 for consistent alignment regardless of nesting depth
- Change index display to space-padded local-only format (e.g., ` 1.` instead of `01.01.`) for cleaner visual hierarchy

## Before
```
  ⊙ 01.Todo Clear interface
    ○ 01.01.Second Child
    ● 01.02.Child
  ○ 02.A Second Child
```

## After
```
⊙    1.Todo Clear interface
○      1.Second Child
●      2.Child
○    2.A Second Child
```

## Test plan
- [x] All 270 tests pass
- [x] Manual verification of list output with nested pads

🤖 Generated with [Claude Code](https://claude.com/claude-code)