### PR TITLE
chore(deps): update outstanding-clap to v0.4.0 with --output flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "outstanding"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7112920e41e37858ce05ae827a6a703982d17fd4b1e19f1be2a337035f04713d"
+checksum = "2d239fd52f66dbba70270e8ae8095fe56b3716154a5f09d2ddcc1cd27fe31cf8"
 dependencies = [
  "console",
  "dark-light",
@@ -1167,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "outstanding-clap"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c728d5dbd6a0c3a4c35f03de171ff6dd2e93ad36353ce8283504f31c0d47dfe"
+checksum = "d6e710a5794af419cdae4f82b5012ead2975f5fc5286d382a320addd3b947b12"
 dependencies = [
  "clap",
  "console",

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -20,8 +20,8 @@ clap = { version = "4.5.53", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 console = "0.15"
 once_cell = "1.19"
-outstanding = "0.3.5"
-outstanding-clap = "0.3.5"
+outstanding = "0.4.0"
+outstanding-clap = "0.4.0"
 serde = { version = "1.0.228", features = ["derive"] }
 timeago = "0.4"
 unicode-width = "0.2.2"

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -1,16 +1,12 @@
 //! # Rendering Module
 //!
-//! This module provides styled terminal output using the `outstanding` crate.
-//! Templates are defined here and rendered with automatic terminal color detection.
+//! This module provides styled terminal output using the `outstanding` crate.   The core padzpp api
+//! will return regulat result adata objects, and the CLI layer will do the rendering.
 //!
-//! ## Design Philosophy
+//! Redenring is mostly template based with , using minijinja templates, and using stylesheet's for
+//! controling formatted term output.  See the syles (crate::cli::styles) and templates (crate::cli::templates)
+//! modules for the specifics and best practices of each.
 //!
-//! Layout calculations (width, truncation, padding) stay in Rust because they require
-//! Unicode-aware processing. Templates handle presentation concerns:
-//! - Style selection based on semantic flags (is_pinned, is_deleted, etc.)
-//! - Section separators and grouping
-//! - Conditional icon rendering
-
 use super::setup::get_grouped_help;
 use super::styles::{names, PADZ_THEME};
 use super::templates::{FULL_PAD_TEMPLATE, LIST_TEMPLATE, MESSAGES_TEMPLATE, TEXT_LIST_TEMPLATE};
@@ -28,9 +24,9 @@ pub const TIME_WIDTH: usize = 14;
 pub const PIN_MARKER: &str = "⚲";
 
 /// Status indicators for todo status
-pub const STATUS_PLANNED: &str = "○";
-pub const STATUS_IN_PROGRESS: &str = "⊙";
-pub const STATUS_DONE: &str = "●";
+pub const STATUS_PLANNED: &str = "⚪︎";
+pub const STATUS_IN_PROGRESS: &str = "☉︎︎";
+pub const STATUS_DONE: &str = "⚫︎";
 
 #[derive(Serialize)]
 struct MatchSegmentData {
@@ -551,8 +547,9 @@ mod tests {
         assert!(output.contains(STATUS_PLANNED)); // Default status is Planned
         assert!(output.contains(" 1."));
         assert!(output.contains("Test Note"));
-        // Should have base padding, status icon, space, then index
-        assert!(output.contains(&format!("{}  1.", STATUS_PLANNED)));
+        // Should have base padding, then status icon, then index
+        assert!(output.contains(&format!("{} ", STATUS_PLANNED)));
+        assert!(output.contains(&format!("{} {}.", STATUS_PLANNED, " 1")));
     }
 
     #[test]

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -551,8 +551,8 @@ mod tests {
         assert!(output.contains(STATUS_PLANNED)); // Default status is Planned
         assert!(output.contains(" 1."));
         assert!(output.contains("Test Note"));
-        // Should have status icon at start, then base padding, then index
-        assert!(output.contains(&format!("{}    1.", STATUS_PLANNED)));
+        // Should have base padding, status icon, space, then index
+        assert!(output.contains(&format!("{}  1.", STATUS_PLANNED)));
     }
 
     #[test]

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -11,7 +11,7 @@ use super::setup::get_grouped_help;
 use super::styles::{names, PADZ_THEME};
 use super::templates::{FULL_PAD_TEMPLATE, LIST_TEMPLATE, MESSAGES_TEMPLATE, TEXT_LIST_TEMPLATE};
 use chrono::{DateTime, Utc};
-use outstanding::{render, render_with_color, truncate_to_width, ThemeChoice};
+use outstanding::{render, render_with_output, truncate_to_width, OutputMode, ThemeChoice};
 use padzapp::api::{CmdMessage, MessageLevel, TodoStatus};
 use padzapp::index::{DisplayIndex, DisplayPad};
 use padzapp::peek::{format_as_peek, PeekResult};
@@ -111,18 +111,18 @@ struct MessagesData {
 }
 
 /// Renders a list of pads to a string.
-pub fn render_pad_list(pads: &[DisplayPad], peek: bool) -> String {
-    render_pad_list_internal(pads, None, false, peek)
+pub fn render_pad_list(pads: &[DisplayPad], peek: bool, output_mode: OutputMode) -> String {
+    render_pad_list_internal(pads, Some(output_mode), false, peek)
 }
 
 /// Renders a list of pads with optional deleted help text.
-pub fn render_pad_list_deleted(pads: &[DisplayPad], peek: bool) -> String {
-    render_pad_list_internal(pads, None, true, peek)
+pub fn render_pad_list_deleted(pads: &[DisplayPad], peek: bool, output_mode: OutputMode) -> String {
+    render_pad_list_internal(pads, Some(output_mode), true, peek)
 }
 
 fn render_pad_list_internal(
     pads: &[DisplayPad],
-    use_color: Option<bool>,
+    output_mode: Option<OutputMode>,
     show_deleted_help: bool,
     peek: bool,
 ) -> String {
@@ -136,12 +136,12 @@ fn render_pad_list_internal(
     };
 
     if pads.is_empty() {
-        return match use_color {
-            Some(c) => render_with_color(
+        return match output_mode {
+            Some(mode) => render_with_output(
                 LIST_TEMPLATE,
                 &empty_data,
                 ThemeChoice::from(&*PADZ_THEME),
-                c,
+                mode,
             ),
             None => render(LIST_TEMPLATE, &empty_data, ThemeChoice::from(&*PADZ_THEME)),
         }
@@ -340,8 +340,10 @@ fn render_pad_list_internal(
         peek,
     };
 
-    match use_color {
-        Some(c) => render_with_color(LIST_TEMPLATE, &data, ThemeChoice::from(&*PADZ_THEME), c),
+    match output_mode {
+        Some(mode) => {
+            render_with_output(LIST_TEMPLATE, &data, ThemeChoice::from(&*PADZ_THEME), mode)
+        }
         None => render(LIST_TEMPLATE, &data, ThemeChoice::from(&*PADZ_THEME)),
     }
     .unwrap_or_else(|e| format!("Render error: {}\n", e))
@@ -380,11 +382,11 @@ fn truncate_match_segments(
 }
 
 /// Renders full pad contents similar to the legacy `print_full_pads` output.
-pub fn render_full_pads(pads: &[DisplayPad]) -> String {
-    render_full_pads_internal(pads, None)
+pub fn render_full_pads(pads: &[DisplayPad], output_mode: OutputMode) -> String {
+    render_full_pads_internal(pads, Some(output_mode))
 }
 
-fn render_full_pads_internal(pads: &[DisplayPad], use_color: Option<bool>) -> String {
+fn render_full_pads_internal(pads: &[DisplayPad], output_mode: Option<OutputMode>) -> String {
     let entries = pads
         .iter()
         .map(|dp| {
@@ -403,33 +405,38 @@ fn render_full_pads_internal(pads: &[DisplayPad], use_color: Option<bool>) -> St
 
     let data = FullPadData { pads: entries };
 
-    match use_color {
-        Some(c) => render_with_color(FULL_PAD_TEMPLATE, &data, ThemeChoice::from(&*PADZ_THEME), c),
+    match output_mode {
+        Some(mode) => render_with_output(
+            FULL_PAD_TEMPLATE,
+            &data,
+            ThemeChoice::from(&*PADZ_THEME),
+            mode,
+        ),
         None => render(FULL_PAD_TEMPLATE, &data, ThemeChoice::from(&*PADZ_THEME)),
     }
     .unwrap_or_else(|e| format!("Render error: {}\n", e))
 }
 
-pub fn render_text_list(lines: &[String], empty_message: &str) -> String {
-    render_text_list_internal(lines, empty_message, None)
+pub fn render_text_list(lines: &[String], empty_message: &str, output_mode: OutputMode) -> String {
+    render_text_list_internal(lines, empty_message, Some(output_mode))
 }
 
 fn render_text_list_internal(
     lines: &[String],
     empty_message: &str,
-    use_color: Option<bool>,
+    output_mode: Option<OutputMode>,
 ) -> String {
     let data = TextListData {
         lines: lines.to_vec(),
         empty_message: empty_message.to_string(),
     };
 
-    match use_color {
-        Some(c) => render_with_color(
+    match output_mode {
+        Some(mode) => render_with_output(
             TEXT_LIST_TEMPLATE,
             &data,
             ThemeChoice::from(&*PADZ_THEME),
-            c,
+            mode,
         ),
         None => render(TEXT_LIST_TEMPLATE, &data, ThemeChoice::from(&*PADZ_THEME)),
     }
@@ -531,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_render_empty_list() {
-        let output = render_pad_list_internal(&[], Some(false), false, false);
+        let output = render_pad_list_internal(&[], Some(OutputMode::Text), false, false);
         // Should show the "no pads yet" message with help text
         assert!(output.contains("No pads yet, create one with `padz create`"));
     }
@@ -541,7 +548,7 @@ mod tests {
         let pad = make_pad("Test Note", false, false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
-        let output = render_pad_list_internal(&[dp], Some(false), false, false);
+        let output = render_pad_list_internal(&[dp], Some(OutputMode::Text), false, false);
 
         // Should contain status icon, space-padded index and title
         assert!(output.contains(STATUS_PLANNED)); // Default status is Planned
@@ -557,7 +564,7 @@ mod tests {
         let pad = make_pad("Pinned Note", true, false);
         let dp = make_display_pad(pad, DisplayIndex::Pinned(1));
 
-        let output = render_pad_list_internal(&[dp], Some(false), false, false);
+        let output = render_pad_list_internal(&[dp], Some(OutputMode::Text), false, false);
 
         // Should contain pinned index
         assert!(output.contains("p1."));
@@ -571,7 +578,7 @@ mod tests {
         let pad = make_pad("Deleted Note", false, true);
         let dp = make_display_pad(pad, DisplayIndex::Deleted(1));
 
-        let output = render_pad_list_internal(&[dp], Some(false), false, false);
+        let output = render_pad_list_internal(&[dp], Some(OutputMode::Text), false, false);
 
         // Should contain deleted index
         assert!(output.contains("d1."));
@@ -589,7 +596,7 @@ mod tests {
             make_display_pad(pinned, DisplayIndex::Regular(2)),
         ];
 
-        let output = render_pad_list_internal(&pads, Some(false), false, false);
+        let output = render_pad_list_internal(&pads, Some(OutputMode::Text), false, false);
 
         // Should have pinned section with marker
         assert!(output.contains("p1."));
@@ -608,7 +615,7 @@ mod tests {
 
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
-        let output = render_pad_list_internal(&[dp], Some(false), false, false);
+        let output = render_pad_list_internal(&[dp], Some(OutputMode::Text), false, false);
 
         // Should have pin marker on the right side
         assert!(output.contains(PIN_MARKER));
@@ -620,7 +627,7 @@ mod tests {
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
         // Force styling for test environment
-        let output = render_pad_list_internal(&[dp], Some(true), false, false);
+        let output = render_pad_list_internal(&[dp], Some(OutputMode::Term), false, false);
 
         // When use_color is true, should include ANSI codes (at least for time which is dimmed)
         // Note: console crate may not emit codes in test env, so we just verify it runs
@@ -643,7 +650,7 @@ mod tests {
             ],
         }]);
 
-        let output = render_pad_list_internal(&[dp], Some(false), false, false);
+        let output = render_pad_list_internal(&[dp], Some(OutputMode::Text), false, false);
 
         assert!(output.contains("1."));
         assert!(output.contains("Search Result"));
@@ -653,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_render_full_pads_empty() {
-        let output = render_full_pads_internal(&[], Some(false));
+        let output = render_full_pads_internal(&[], Some(OutputMode::Text));
         assert!(output.contains("No pads found."));
     }
 
@@ -662,7 +669,7 @@ mod tests {
         let pad = make_pad("Full Pad", false, false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(3));
 
-        let output = render_full_pads_internal(&[dp], Some(false));
+        let output = render_full_pads_internal(&[dp], Some(OutputMode::Text));
 
         assert!(output.contains("3 Full Pad"));
         assert!(output.contains("some content"));
@@ -689,14 +696,14 @@ mod tests {
 
     #[test]
     fn test_render_text_list_empty() {
-        let output = render_text_list_internal(&[], "Nothing here.", Some(false));
+        let output = render_text_list_internal(&[], "Nothing here.", Some(OutputMode::Text));
         assert!(output.contains("Nothing here."));
     }
 
     #[test]
     fn test_render_text_list_lines() {
         let lines = vec!["first".to_string(), "second".to_string()];
-        let output = render_text_list_internal(&lines, "", Some(false));
+        let output = render_text_list_internal(&lines, "", Some(OutputMode::Text));
         assert!(output.contains("first"));
         assert!(output.contains("second"));
     }

--- a/crates/padz/src/cli/styles.rs
+++ b/crates/padz/src/cli/styles.rs
@@ -67,6 +67,23 @@
 //! style. All of the styles are registered once through
 //! `once_cell::sync::Lazy`.
 //!
+//! ## Debugging Styled Output
+//!
+//! When developing or testing templates and styles, use the `--output=term-debug` flag
+//! to see style names as markup tags instead of ANSI escape codes:
+//!
+//! ```bash
+//! padz list --output=term-debug
+//! ```
+//!
+//! This renders output like:
+//! ```text
+//! [pinned]⚲[/pinned] [time]⚪︎[/time] [list-index]p1.[/list-index][list-title]My Pad[/list-title]
+//! ```
+//!
+//! This makes it easy to verify which styles are applied to each element, debug
+//! template issues, and write assertions in tests without dealing with ANSI codes.
+//!
 use console::Style;
 use once_cell::sync::Lazy;
 use outstanding::{rgb_to_ansi256, AdaptiveTheme, Theme};

--- a/crates/padz/src/cli/styles.rs
+++ b/crates/padz/src/cli/styles.rs
@@ -1,7 +1,52 @@
 //! Styles for the Padz CLI application.
 //!
-//! Padz uses the `outstanding` crate for theming and styling console output, so
-//! we keep every style definition in one place. The CLI needs to work equally
+//! Padz uses the `outstanding` crate for theming and styling console output, to separate the data
+//! and it's presentaiion layers.
+//!
+//! We use an adaptattive theme, that is, one that had presentition styles for both light and dark
+//! modes, and which the outstanding crate manages automatically.
+//!
+//! A theme is a collections of named styles, which is a set for formatting optins as in colors, font
+//! decoration, weight and so on.
+//!
+//! Styles : A Three Layer Approach.
+//!
+//! Keeping in mind that our goal is to keep presentation easy to change, iterate and consistent,
+//! styling gets done in three layers.
+//!
+//! 1. The Application: Semantics (i.e. CSS Classes)
+//!
+//! On the template, the application is to use semantic style names, that is, names that describe
+//! the  data / information being presented. For example a a timestamp with the 'time' style.
+//!
+//! The semantic style does not define the actual presentation values it self, but rather it refers to
+//! the presentation layer.
+//!
+//! 2. The Presentation Layer: Consistence (i.e. enabled, , focused).
+//!
+//! The presentation layer defines presentation styles that are consistent accross the application.  
+//! These often relates to the data semantics, but often are a cross with state. For example, say that
+//! certain elements are disabled. You don't want every disabled element througout the app to look different.
+//! Or that an element is highlighted, or focused, etc.
+//!
+//! And the presentation layer ins't the raw values just yet, but rather another set of named styles,
+//! the visual layer.
+//!
+//! 3. The Visual Layer: Actual Colors and Decorations
+//!
+//! Now we reach the final point, in which we define the actual colors and decoration values are for
+//! presentation styles. Say we define the highlighted has a background color of yellow and black text.
+//!
+//! This layer gives us flexibility to iterate the visual while keeping the semantics and the presentation
+//! consistent. For example light and dark modes only need to define the visual layers differntly,
+//! while the  application's code, templates and presentation styles remain the same.
+//!
+//! The combined result of the three layers is that:
+//!    * Templates/ Code work on the semantic level, freening the code from presentation details.
+//!    * The presentation layer keeps the application consistent.
+//!    * The visual layer allows us to iterate the look and feel easily.
+//!
+//! The CLI needs to work equally
 //! well in light and dark terminals, so `PADZ_THEME` exposes an adaptive theme
 //! that resolves to the appropriate palette at runtime.
 //!

--- a/crates/padz/src/cli/templates.rs
+++ b/crates/padz/src/cli/templates.rs
@@ -1,3 +1,43 @@
+//! # CLI Templates Module
+//!
+//! Out output pipleine, oustanding crate based, relies on templates for rendering term output.
+//!
+//! We have preference for stand-alone templates files, as seprateing them from code makes is easier
+//! and safer to edit, diff and so on.
+//!
+//! We then include the template files as string constants here, so that they can be used as a regular
+//! string literals elsewhere in the code.
+//!
+//! Templates are minijinja based. A few important best practices:
+//!
+//!     1. Blank Lines / Whitespace:
+//!         
+//!     While natural to keep templates organized as the output they produce, there are often times
+//!     where that forces the template to become unreadble (i.e. many nested conditionals, very long
+//!     lines). It can become quite tricky to iterate on blank lines and whitespaces, specilly when
+//!     dealing with loops and conditionals.
+//!     For this reason, we have templates requiring explicit line breaks, which make it clear where
+//!     they are coming from.
+//!     2. Reusability and Composition:
+//!     Templates can and should be nested when appropriate. This allows for reuse (i.e. a pad
+//!     listing title) that can be used in multiple places, and keeps templates smaller and more
+//!     readable. Else we descend into a "god output" where everything is defined.
+//!
+//!     3. Judicial Conditionals:
+//!     While conditionals are necessary, they can quickly make templates unreadable.
+//!     They are best used when branching what gets output, but not when they contronling styles.
+//!
+//!     For example, {% if pad.is_pinned %} <pinned-style> {% else %} <regular-style> {% endif %}
+//!     throughout various parts in the template.  In this case its best to set the style variable
+//!     that does the logic, and then use the style variable directly.
+//!
+//!     4. Harder Logic
+//!     While best avoided, for when more complex logic is needed, it is best to move that logic
+//!     into the rust code, and pass the results as functions for the template to use.
+//!
+//!
+//!     
+//!
 pub const LIST_TEMPLATE: &str = include_str!("templates/list.tmp");
 pub const FULL_PAD_TEMPLATE: &str = include_str!("templates/full_pad.tmp");
 pub const TEXT_LIST_TEMPLATE: &str = include_str!("templates/text_list.tmp");

--- a/crates/padz/src/cli/templates.rs
+++ b/crates/padz/src/cli/templates.rs
@@ -35,8 +35,25 @@
 //!     While best avoided, for when more complex logic is needed, it is best to move that logic
 //!     into the rust code, and pass the results as functions for the template to use.
 //!
+//! ## Debugging Template Output
 //!
-//!     
+//! When developing or testing templates, use the `--output=term-debug` flag to see
+//! style names as markup tags instead of ANSI escape codes:
+//!
+//! ```bash
+//! padz list --output=term-debug
+//! ```
+//!
+//! This renders output like:
+//! ```text
+//! [pinned]⚲[/pinned] [time]⚪︎[/time] [list-index]p1.[/list-index][list-title]My Pad[/list-title]
+//! ```
+//!
+//! This is invaluable for:
+//! - Verifying that the correct style is applied to each template element
+//! - Debugging layout issues by seeing exactly what styles are where
+//! - Writing test assertions that check for specific style applications
+//! - Comparing output between template changes without ANSI code noise
 //!
 pub const LIST_TEMPLATE: &str = include_str!("templates/list.tmp");
 pub const FULL_PAD_TEMPLATE: &str = include_str!("templates/full_pad.tmp");

--- a/crates/padz/src/cli/templates/list.tmp
+++ b/crates/padz/src/cli/templates/list.tmp
@@ -6,7 +6,7 @@
 {%- if pad.is_separator -%}
 {{- "" | nl -}}
 {%- else -%}
-{{- pad.status_icon | style("time") }} {{ pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
+{{- pad.left_pad }}{% if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif %}{{ pad.status_icon | style("time") }} {% if pad.is_pinned_section %}{{ pad.index | style("pinned") }}{% elif pad.is_deleted %}{{ pad.index | style("deleted-index") }}{% else %}{{ pad.index | style("list-index") }}{% endif %}{% if pad.is_deleted %}{{ pad.title | style("deleted-title") }}{% elif peek %}{{ pad.title | style("title") }}{% else %}{{ pad.title | style("list-title") }}{% endif %}{{ pad.padding }}{% if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif %}{{ pad.time_ago | style("time") | nl -}}
 {%- for match in pad.matches -%}
 {{- "    " }}{{ pad.left_pad }}    {{ match.line_number | style("muted") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}{{ "" | nl -}}
 {%- endfor -%}


### PR DESCRIPTION
## Summary

- Update `outstanding` and `outstanding-clap` crates from v0.3.5 to v0.4.0
- Integrate the new simplified API from outstanding-clap v0.4.0
- Add global `--output` flag for controlling terminal output mode
- Add documentation for the term-debug feature in styles and templates modules

## Changes

### Dependency Updates
- `outstanding`: 0.3.5 → 0.4.0
- `outstanding-clap`: 0.3.5 → 0.4.0

### API Integration
- Replace deprecated `TopicHelper` with `Outstanding::with_registry()`
- Replace `render_with_color` with `render_with_output` using `OutputMode` enum
- Propagate output mode from CLI through to all render functions

### New Feature: `--output` Flag
The CLI now has a global `--output` flag with these modes:
- `auto` (default) - automatically detect terminal capabilities
- `term` - force ANSI colors
- `text` - plain text, no formatting
- `term-debug` - shows style names as markup tags for debugging

Example with `--output=term-debug`:
```
[pinned]⚲[/pinned] [time]⚪︎[/time] [list-index]p1.[/list-index][list-title]My Pad[/list-title]
```

### Documentation
- Added module-level docs to `styles.rs` and `templates.rs` explaining how to use `--output=term-debug` for debugging styled output and writing test assertions

## Test plan
- [x] All 270 tests pass
- [x] Verified `padz list --output=term-debug` shows markup tags
- [x] Verified `padz list --output=text` strips formatting
- [x] Verified `padz --help` shows the new `--output` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)