### PR TITLE
fix(api): require confirmation parameter for purge command

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -440,40 +440,9 @@ fn handle_purge(
     yes: bool,
     recursive: bool,
 ) -> Result<()> {
-    use std::io::{self, Write};
-
-    // Get preview of what would be purged
-    let preview = ctx.api.preview_purge(ctx.scope, &indexes, recursive)?;
-
-    if preview.targets.is_empty() {
-        println!("No pads to purge.");
-        return Ok(());
-    }
-
-    // Show confirmation unless --yes is provided
-    if !yes {
-        println!("This will permanently remove the following pads:");
-        for dp in &preview.targets {
-            println!("  {} {}", dp.index, dp.pad.metadata.title);
-        }
-        if preview.descendant_count > 0 {
-            println!("  ... and {} descendant(s)", preview.descendant_count);
-        }
-
-        print!("[Y] To delete: ");
-        io::stdout().flush()?;
-
-        let mut input = String::new();
-        io::stdin().read_line(&mut input)?;
-
-        if input.trim() != "Y" {
-            println!("Operation cancelled.");
-            return Ok(());
-        }
-    }
-
-    // Execute the purge
-    let result = ctx.api.purge_pads(ctx.scope, &indexes, recursive)?;
+    // Pass confirmation flag directly to API
+    // If not confirmed, API returns an error with a message about using --yes/-y
+    let result = ctx.api.purge_pads(ctx.scope, &indexes, recursive, yes)?;
     print_messages(&result.messages, ctx.output_mode);
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Move confirmation logic from CLI layer to API layer for the `purge` command
- The `purge_pads()` API now requires a `confirmed: bool` parameter
- When `confirmed=false`, returns an error with the pad count and instructions to use `--yes`/`-y`
- When `confirmed=true`, proceeds with purge and outputs "Purging N pad(s)..."

## Changes

- **`commands/purge.rs`**: Removed `PurgePreview` struct and `preview()` function. Added `confirmed` parameter to `run()`. Added new tests.
- **`api.rs`**: Removed `preview_purge()` method. Updated `purge_pads()` signature.
- **`cli/commands.rs`**: Simplified `handle_purge` - just passes `--yes` flag directly to API.

## Behavior

```bash
# Without -y: shows error with count
$ padz purge
Error: Purging 3 pad(s). Aborted, confirm with --yes or -y for hard deletion.

# With -y: proceeds
$ padz purge -y
Purging 3 pad(s)...
Purged: d1 Title1
Purged: d2 Title2
Purged: d3 Title3
```

## Test plan

- [x] All existing tests pass (235 tests)
- [x] New tests for confirmed/not-confirmed behavior
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)