### PR TITLE
refactor: migrate remaining commands to declarative handlers

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -511,13 +511,6 @@ fn handle_config(ctx: &mut AppContext, key: Option<String>, value: Option<String
 fn handle_init(ctx: &AppContext) -> Result<()> {
     let result = ctx.api.init(ctx.scope)?;
     print_messages(&result.messages, ctx.output_mode);
-
-    // Show shell completion hint
-    println!();
-    println!("Tip: Enable shell completions for padz:");
-    println!("  eval \"$(padz completions bash)\"  # add to ~/.bashrc");
-    println!("  eval \"$(padz completions zsh)\"   # add to ~/.zshrc");
-
     Ok(())
 }
 

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -11,5 +11,18 @@ pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
         "Initialized padz store at {}",
         dir.display()
     )));
+
+    // Add shell completion hint
+    result.add_message(CmdMessage::info(String::new())); // blank line
+    result.add_message(CmdMessage::info(
+        "Tip: Enable shell completions for padz:".to_string(),
+    ));
+    result.add_message(CmdMessage::info(
+        "  eval \"$(padz completions bash)\"  # add to ~/.bashrc".to_string(),
+    ));
+    result.add_message(CmdMessage::info(
+        "  eval \"$(padz completions zsh)\"   # add to ~/.zshrc".to_string(),
+    ));
+
     Ok(result)
 }


### PR DESCRIPTION
## Summary

Continue the outstanding migration effort from PR #37. Migrate remaining commands that can now use the declarative handler pattern.

## Changes

### Commands Migrated

| Command | Change | Notes |
|---------|--------|-------|
| **purge** | No code change needed | Already declarative after PR #38 moved confirmation to API |
| **export** | No code change needed | Already follows the pattern (call API, print messages) |
| **import** | No code change needed | Already follows the pattern (call API, print messages) |
| **init** | Shell completion hint moved to API | Hint now appears in JSON output |

### init Migration Details

Before: CLI had extra `println!` statements for shell completion hint that bypassed the message system.

After: Hint is part of API messages, so:
- Terminal output unchanged
- `--output=json` now includes the hint in the messages array

## Commands Still NOT Using Declarative Handlers

| Command | Reason | Required Outstanding Feature |
|---------|--------|------------------------------|
| `create` | Opens editor, clipboard integration, stdin handling | Handler lifecycle hooks (pre/post) |
| `edit`/`open` | Opens external editor | External process invocation support |
| `completions` | Shell-specific script output | Non-template binary output |

These would require outstanding to support:
1. **Handler lifecycle hooks**: Pre/post handler callbacks for side effects
2. **External process invocation**: Opening editors
3. **Binary output**: Non-template output for shell completions

## Test plan

- [x] All 235 tests pass
- [x] Pre-commit hooks pass (fmt, clippy, check, test)
- [x] Verified init output includes shell hint in terminal mode
- [x] JSON output mode works for all migrated commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)