### PR TITLE
refactor: migrate create/edit to declarative handler pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "outstanding"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973671899ecc1aab51afcbe2c3dbd5bcb04ebcf5052ca68fb8eced143e123f09"
+checksum = "9c4b82a59cdb2179a410cbaea83126bdc32f933c8f8dba548dc165e44b00401d"
 dependencies = [
  "console",
  "dark-light",
@@ -1174,15 +1174,17 @@ dependencies = [
 
 [[package]]
 name = "outstanding-clap"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fe01e6db78603a29229777f7b833933cbda463603e30af96dad3b6c32947d8"
+checksum = "413970cdb3262cf9eabcd9be4ccc3c179ac3c283ac43be8ddd9b10a57be5e39a"
 dependencies = [
  "anyhow",
  "clap",
  "console",
  "outstanding",
  "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -21,8 +21,8 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 console = "0.15"
 dark-light = "0.2"
 once_cell = "1.19"
-outstanding = "0.6.0"
-outstanding-clap = "0.6.0"
+outstanding = "0.7.2"
+outstanding-clap = "0.7.2"
 serde = { version = "1.0.228", features = ["derive"] }
 timeago = "0.4"
 unicode-width = "0.2.2"

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -40,6 +40,9 @@ pub fn run<S: DataStore>(
     // Propagate status change to parent (e.g. adding a "Planned" child might revert parent from "Done")
     crate::todos::propagate_status_change(store, scope, pad.metadata.parent_id)?;
 
+    // Get the path for the created pad (for editor integration)
+    let pad_path = store.get_pad_path(&pad.metadata.id, scope)?;
+
     let mut result = CmdResult::default();
     // New pad is always the newest, so it gets index 1
     let display_pad = DisplayPad {
@@ -49,6 +52,7 @@ pub fn run<S: DataStore>(
         children: Vec::new(),
     };
     result.affected_pads.push(display_pad);
+    result.pad_paths.push(pad_path);
     result.add_message(CmdMessage::success(format!(
         "Pad created: {}",
         pad.metadata.title

--- a/crates/padzapp/src/commands/view.rs
+++ b/crates/padzapp/src/commands/view.rs
@@ -8,5 +8,14 @@ use super::helpers::pads_by_selectors;
 
 pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
     let pads = pads_by_selectors(store, scope, selectors, false)?;
-    Ok(CmdResult::default().with_listed_pads(pads))
+
+    // Collect paths for each pad (for editor integration)
+    let paths: Vec<_> = pads
+        .iter()
+        .filter_map(|dp| store.get_pad_path(&dp.pad.metadata.id, scope).ok())
+        .collect();
+
+    let mut result = CmdResult::default().with_listed_pads(pads);
+    result.pad_paths = paths;
+    Ok(result)
 }


### PR DESCRIPTION
## Summary

Continue the outstanding migration effort. Migrate create and edit commands to follow the declarative handler pattern with clear separation of concerns.

## Changes

### Dependencies
- Update `outstanding` to v0.7.2
- Update `outstanding-clap` to v0.7.2 (includes post-dispatch hooks support)

### API Layer (`padzapp`)
- `create` command now returns `pad_paths` in `CmdResult`
- `view` command now returns `pad_paths` in `CmdResult`

### CLI Layer (`padz`)
- Refactor `handle_create` into phases:
  - **Pre-dispatch**: `resolve_create_input()` handles stdin/clipboard
  - **Dispatch**: API call
  - **Output**: Render messages
  - **Post-dispatch**: Editor and clipboard side effects
- Simplify `handle_edit` to use `result.pad_paths` directly

## Pattern

```
┌─────────────────────────────────────────────────────────────┐
│ Pre-dispatch: Resolve inputs (stdin, clipboard, args)       │
├─────────────────────────────────────────────────────────────┤
│ Dispatch: Call API                                          │
├─────────────────────────────────────────────────────────────┤
│ Output: Render messages/data                                │
├─────────────────────────────────────────────────────────────┤
│ Post-dispatch: Side effects (editor, clipboard)             │
└─────────────────────────────────────────────────────────────┘
```

## Commands Still NOT Using Declarative Handlers

| Command | Reason |
|---------|--------|
| `completions` | Shell-specific binary output (no value in migrating) |

All other commands now follow the declarative pattern.

## Test plan

- [x] All 235 tests pass
- [x] Pre-commit hooks pass (fmt, clippy, check, test)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)