### PR TITLE
refactor(cli): use outstanding's col() filter for declarative table layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "outstanding"
-version = "0.7.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4b82a59cdb2179a410cbaea83126bdc32f933c8f8dba548dc165e44b00401d"
+checksum = "e07c8f77812baa5e21043562a9a6c3e38e927dbc9c4871a976e9e53062c32341"
 dependencies = [
  "console",
  "dark-light",
@@ -1174,16 +1174,18 @@ dependencies = [
 
 [[package]]
 name = "outstanding-clap"
-version = "0.7.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413970cdb3262cf9eabcd9be4ccc3c179ac3c283ac43be8ddd9b10a57be5e39a"
+checksum = "52107047c0b034890d0328af042021a0d707df5b498d7818aa71697f2e89aeb2"
 dependencies = [
  "anyhow",
  "clap",
  "console",
+ "minijinja",
  "outstanding",
  "serde",
  "serde_json",
+ "terminal_size",
  "thiserror 2.0.17",
 ]
 
@@ -1727,6 +1729,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -21,8 +21,8 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 console = "0.15"
 dark-light = "0.2"
 once_cell = "1.19"
-outstanding = "0.7.2"
-outstanding-clap = "0.7.2"
+outstanding = "0.9.0"
+outstanding-clap = "0.9.0"
 serde = { version = "1.0.228", features = ["derive"] }
 timeago = "0.4"
 unicode-width = "0.2.2"

--- a/crates/padz/src/cli/templates/_pad_line.tmp
+++ b/crates/padz/src/cli/templates/_pad_line.tmp
@@ -1,5 +1,5 @@
 {#- Single pad line rendering -#}
-{#- Expects: pad (PadLineData), pin_marker, peek (bool) -#}
+{#- Expects: pad (PadLineData), pin_marker, peek (bool), col_* (column widths) -#}
 
 {#- Determine index style based on section type -#}
 {%- set index_style = "list-index" -%}
@@ -17,10 +17,12 @@
   {%- set title_style = "title" -%}
 {%- endif -%}
 
-{#- Render the pad line -#}
-{{- pad.left_pad -}}
-{%- if pad.show_left_pin %}{{ pin_marker | style("pinned") }} {% endif -%}
-{{- pad.status_icon | style("status-icon") }} {{ pad.index | style(index_style) -}}
-{{- pad.title | style(title_style) }}{{ pad.padding -}}
-{%- if pad.show_right_pin %}{{ pin_marker | style("pinned") }} {% else %}  {% endif -%}
-{{- pad.time_ago | style("time") | nl -}}
+{#- Render the pad line using col() filter for layout -#}
+{#- Layout: indent | left_pin(2) | status(2) | index(4) | title(fill) | right_pin(2) | time(14) -#}
+{{- pad.indent -}}
+{{- pad.left_pin | col(col_left_pin) | style("pinned") -}}
+{{- pad.status_icon | col(col_status) | style("status-icon") -}}
+{{- pad.index | col(col_index) | style(index_style) -}}
+{{- pad.title | col(pad.title_width) | style(title_style) -}}
+{{- pad.right_pin | col(col_right_pin) | style("pinned") -}}
+{{- pad.time_ago | col(col_time, align='right') | style("time") | nl -}}


### PR DESCRIPTION
## Summary

- Update outstanding to v0.9.0 and use its `col()` template filter for declarative column layout
- Refactor list rendering to eliminate manual padding/truncation in Rust
- Define column width constants and let templates handle layout via `col(width, align='right')`

## Changes

### render.rs
- Added column width constants: `COL_LEFT_PIN`, `COL_STATUS`, `COL_INDEX`, `COL_RIGHT_PIN`, `COL_TIME`
- Simplified `PadLineData`: added `indent`/`title_width`, removed manual `padding`/`show_*` flags
- Removed manual title truncation and padding calculation
- Templates now handle all layout via outstanding's `col()` filter

### _pad_line.tmp
- Uses `col()` filter for each column: truncation, padding, and alignment
- Example: `{{ pad.title | col(pad.title_width) | style(title_style) }}`

## Benefits
- Declarative layout in templates
- ANSI-aware truncation/padding handled by outstanding
- Cleaner separation: Rust calculates widths, templates handle layout
- Removed ~40 lines of manual layout code

## Test plan
- [x] All existing tests pass (17 render tests + 235 library tests)
- [x] Visual verification of list output with pinned/regular/nested/deleted items
- [x] Verified title truncation, time alignment, pin markers work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)