### PR TITLE
feat: unify modifying commands output with affected pads list

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -40,7 +40,8 @@
 //! - `print_*()`: Output formatting functions
 
 use super::render::{
-    print_messages, render_full_pads, render_pad_list, render_pad_list_deleted, render_text_list,
+    print_messages, render_full_pads, render_modification_result, render_pad_list,
+    render_pad_list_deleted, render_text_list,
 };
 use super::setup::{
     parse_cli, Cli, Commands, CompletionShell, CoreCommands, DataCommands, MiscCommands,
@@ -181,8 +182,14 @@ fn handle_create(
         .api
         .create_pad(ctx.scope, title_to_use, initial_content, parent)?;
 
-    // === Output: Render messages ===
-    print_messages(&result.messages, ctx.output_mode);
+    // === Output: Render unified modification result ===
+    let output = render_modification_result(
+        "Created",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
 
     // === Post-dispatch: Editor and clipboard side effects ===
     if should_open_editor && !result.pad_paths.is_empty() {
@@ -342,35 +349,71 @@ fn handle_delete(ctx: &mut AppContext, indexes: Vec<String>, done_status: bool) 
             .collect();
 
         let result = ctx.api.delete_pads(ctx.scope, &done_indexes)?;
-        print_messages(&result.messages, ctx.output_mode);
+        let output = render_modification_result(
+            "Deleted",
+            &result.affected_pads,
+            &result.messages,
+            ctx.output_mode,
+        );
+        print!("{}", output);
     } else {
         let result = ctx.api.delete_pads(ctx.scope, &indexes)?;
-        print_messages(&result.messages, ctx.output_mode);
+        let output = render_modification_result(
+            "Deleted",
+            &result.affected_pads,
+            &result.messages,
+            ctx.output_mode,
+        );
+        print!("{}", output);
     }
     Ok(())
 }
 
 fn handle_restore(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     let result = ctx.api.restore_pads(ctx.scope, &indexes)?;
-    print_messages(&result.messages, ctx.output_mode);
+    let output = render_modification_result(
+        "Restored",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
     Ok(())
 }
 
 fn handle_pin(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     let result = ctx.api.pin_pads(ctx.scope, &indexes)?;
-    print_messages(&result.messages, ctx.output_mode);
+    let output = render_modification_result(
+        "Pinned",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
     Ok(())
 }
 
 fn handle_unpin(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     let result = ctx.api.unpin_pads(ctx.scope, &indexes)?;
-    print_messages(&result.messages, ctx.output_mode);
+    let output = render_modification_result(
+        "Unpinned",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
     Ok(())
 }
 
 fn handle_complete(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     let result = ctx.api.complete_pads(ctx.scope, &indexes)?;
-    print_messages(&result.messages, ctx.output_mode);
+    let output = render_modification_result(
+        "Completed",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
     Ok(())
 }
 
@@ -394,13 +437,25 @@ fn handle_move(ctx: &mut AppContext, mut indexes: Vec<String>, root: bool) -> Re
     let result = ctx
         .api
         .move_pads(ctx.scope, &indexes, destination.as_deref())?;
-    print_messages(&result.messages, ctx.output_mode);
+    let output = render_modification_result(
+        "Moved",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
     Ok(())
 }
 
 fn handle_reopen(ctx: &mut AppContext, indexes: Vec<String>) -> Result<()> {
     let result = ctx.api.reopen_pads(ctx.scope, &indexes)?;
-    print_messages(&result.messages, ctx.output_mode);
+    let output = render_modification_result(
+        "Reopened",
+        &result.affected_pads,
+        &result.messages,
+        ctx.output_mode,
+    );
+    print!("{}", output);
     Ok(())
 }
 

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -589,6 +589,154 @@ pub fn print_messages(messages: &[CmdMessage], output_mode: OutputMode) {
     }
 }
 
+/// Data structure for the modification result template.
+#[derive(Serialize)]
+struct ModificationResultData {
+    start_message: String,
+    pads: Vec<PadLineData>,
+    trailing_messages: Vec<MessageData>,
+    peek: bool,
+    pin_marker: String,
+    // Column widths for outstanding's `col()` filter
+    col_left_pin: usize,
+    col_status: usize,
+    col_index: usize,
+    col_right_pin: usize,
+    col_time: usize,
+}
+
+/// Renders a modification result (affected pads with start message).
+///
+/// Used by commands like complete, delete, pin, etc. to show a unified output:
+/// - Start message: "{action_verb} {count} pad..."
+/// - Affected pads rendered as a list
+/// - Trailing messages (info, warnings)
+pub fn render_modification_result(
+    action_verb: &str,
+    pads: &[DisplayPad],
+    trailing_messages: &[CmdMessage],
+    output_mode: OutputMode,
+) -> String {
+    // For structured modes, serialize the data directly
+    if output_mode.is_structured() {
+        #[derive(Serialize)]
+        struct JsonModificationResult<'a> {
+            action: &'a str,
+            pads: &'a [DisplayPad],
+            messages: &'a [CmdMessage],
+        }
+        let json_data = JsonModificationResult {
+            action: action_verb,
+            pads,
+            messages: trailing_messages,
+        };
+        return APP
+            .render("modification_result", &json_data, output_mode)
+            .unwrap_or_else(|_| "{}".to_string());
+    }
+
+    // Generate start message
+    let count = pads.len();
+    let start_message = if count == 0 {
+        String::new()
+    } else {
+        let pad_word = if count == 1 { "pad" } else { "pads" };
+        format!("{} {} {}...", action_verb, count, pad_word)
+    };
+
+    // Convert pads to PadLineData (similar to render_pad_list_internal)
+    let pad_lines: Vec<PadLineData> = pads
+        .iter()
+        .map(|dp| {
+            let is_pinned_section = matches!(dp.index, DisplayIndex::Pinned(_));
+            let is_deleted = matches!(dp.index, DisplayIndex::Deleted(_));
+            let show_right_pin = dp.pad.metadata.is_pinned && !is_pinned_section;
+
+            // Format index string
+            let local_idx_str = match &dp.index {
+                DisplayIndex::Pinned(n) => format!("p{}", n),
+                DisplayIndex::Regular(n) => format!("{:2}", n),
+                DisplayIndex::Deleted(n) => format!("d{}", n),
+            };
+            let full_idx_str = format!("{}.", local_idx_str);
+
+            // Get status icon
+            let status_icon = match dp.pad.metadata.status {
+                padzapp::api::TodoStatus::Planned => STATUS_PLANNED,
+                padzapp::api::TodoStatus::InProgress => STATUS_IN_PROGRESS,
+                padzapp::api::TodoStatus::Done => STATUS_DONE,
+            }
+            .to_string();
+
+            // Pin markers
+            let left_pin = if is_pinned_section {
+                PIN_MARKER.to_string()
+            } else {
+                String::new()
+            };
+            let right_pin = if show_right_pin {
+                PIN_MARKER.to_string()
+            } else {
+                String::new()
+            };
+
+            // Calculate title width
+            let fixed_columns = COL_LEFT_PIN + COL_STATUS + COL_INDEX + COL_RIGHT_PIN + COL_TIME;
+            let title_width = LINE_WIDTH.saturating_sub(fixed_columns + COL_LEFT_PIN);
+
+            PadLineData {
+                indent: String::new(),
+                left_pin,
+                status_icon,
+                index: full_idx_str,
+                title: dp.pad.metadata.title.clone(),
+                title_width,
+                right_pin,
+                time_ago: format_time_ago(dp.pad.metadata.created_at),
+                is_pinned_section,
+                is_deleted,
+                is_separator: false,
+                matches: vec![],
+                more_matches_count: 0,
+                peek: None,
+            }
+        })
+        .collect();
+
+    // Convert trailing messages
+    let trailing_data: Vec<MessageData> = trailing_messages
+        .iter()
+        .map(|msg| {
+            let style = match msg.level {
+                MessageLevel::Info => "info",
+                MessageLevel::Success => "success",
+                MessageLevel::Warning => "warning",
+                MessageLevel::Error => "error",
+            };
+            MessageData {
+                content: msg.content.clone(),
+                style: style.to_string(),
+            }
+        })
+        .collect();
+
+    let data = ModificationResultData {
+        start_message,
+        pads: pad_lines,
+        trailing_messages: trailing_data,
+        peek: false,
+        pin_marker: PIN_MARKER.to_string(),
+        col_left_pin: COL_LEFT_PIN,
+        col_status: COL_STATUS,
+        col_index: COL_INDEX,
+        col_right_pin: COL_RIGHT_PIN,
+        col_time: COL_TIME,
+    };
+
+    APP.render("modification_result", &data, output_mode)
+        .unwrap_or_else(|e| format!("Render error: {}\n", e))
+}
+
 fn format_time_ago(timestamp: DateTime<Utc>) -> String {
     let now = Utc::now();
     let duration = now.signed_duration_since(timestamp);

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -1,0 +1,17 @@
+{#- Unified rendering for modification commands -#}
+{#- Expects: start_message, pads (list of PadLineData), trailing_messages, peek (bool), col_* -#}
+
+{#- Start message -#}
+{%- if start_message -%}
+{{ start_message | style("info") | nl }}
+{%- endif -%}
+
+{#- Affected pads list -#}
+{%- for pad in pads -%}
+{%- include "_pad_line" -%}
+{%- endfor -%}
+
+{#- Trailing messages (info, warnings, errors) -#}
+{%- for msg in trailing_messages -%}
+{{ msg.content | style(msg.style) | nl }}
+{%- endfor -%}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -790,8 +790,11 @@ mod tests {
         // Move B (1) to A (2)
         let result = api.move_pads(Scope::Project, &["1"], Some("2")).unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("Moved 'B' to A"));
+        // No messages - CLI handles unified rendering
+        assert!(result.messages.is_empty());
+        // Should have 1 affected pad
+        assert_eq!(result.affected_pads.len(), 1);
+        assert_eq!(result.affected_pads[0].pad.metadata.title, "B");
 
         // Verify hierarchy
         let pads = api
@@ -815,7 +818,10 @@ mod tests {
 
         // Move Child (1.1) to Root
         let result = api.move_pads(Scope::Project, &["1.1"], None).unwrap();
-        assert_eq!(result.messages.len(), 1);
+        // No messages - CLI handles unified rendering
+        assert!(result.messages.is_empty());
+        // Should have 1 affected pad
+        assert_eq!(result.affected_pads.len(), 1);
 
         // Verify Child is now root
         let pads = api

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -1,4 +1,4 @@
-use crate::commands::{CmdMessage, CmdResult};
+use crate::commands::CmdResult;
 use crate::error::Result;
 use crate::index::{DisplayIndex, DisplayPad};
 use crate::model::{Pad, Scope};
@@ -53,10 +53,7 @@ pub fn run<S: DataStore>(
     };
     result.affected_pads.push(display_pad);
     result.pad_paths.push(pad_path);
-    result.add_message(CmdMessage::success(format!(
-        "Pad created: {}",
-        pad.metadata.title
-    )));
+    // Note: No success message - CLI layer handles unified rendering
     Ok(result)
 }
 
@@ -166,10 +163,8 @@ mod tests {
             DisplayIndex::Regular(1)
         ));
 
-        // Should have success message
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("Pad created"));
-        assert!(result.messages[0].content.contains("New Pad"));
+        // No messages - CLI handles unified rendering
+        assert!(result.messages.is_empty());
     }
 
     #[test]

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -1,4 +1,4 @@
-use crate::commands::{CmdMessage, CmdResult};
+use crate::commands::CmdResult;
 use crate::error::Result;
 use crate::index::{DisplayPad, PadSelector};
 use crate::model::Scope;
@@ -18,7 +18,7 @@ pub fn run<S: DataStore>(
 
     // Collect UUIDs and perform deletions
     let mut deleted_uuids: Vec<Uuid> = Vec::new();
-    for (display_index, uuid) in resolved {
+    for (_display_index, uuid) in resolved {
         let mut pad = store.get_pad(&uuid, scope)?;
         pad.metadata.is_deleted = true;
         pad.metadata.deleted_at = Some(Utc::now());
@@ -27,11 +27,7 @@ pub fn run<S: DataStore>(
         // Propagate status change to parent (deleted child no longer affects status)
         crate::todos::propagate_status_change(store, scope, pad.metadata.parent_id)?;
 
-        result.add_message(CmdMessage::success(format!(
-            "Pad deleted ({}): {}",
-            super::helpers::fmt_path(&display_index),
-            pad.metadata.title
-        )));
+        // Note: No per-pad message - CLI handles unified rendering
         deleted_uuids.push(uuid);
     }
 

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -187,6 +187,46 @@ impl CmdResult {
     }
 }
 
+/// Result from commands that modify pads.
+///
+/// Provides structured output for unified CLI rendering:
+/// - `affected_pads`: The pads that were modified (rendered as a list)
+/// - `trailing_messages`: Info/warning messages shown after the pad list
+///
+/// The CLI layer generates the start message (e.g., "Completing 2 pads...")
+/// based on the action and affected_pads count.
+#[derive(Debug, Default)]
+pub struct ModificationResult {
+    /// Pads that were modified by the operation
+    pub affected_pads: Vec<DisplayPad>,
+    /// Messages shown after the pad list (info, warnings, errors)
+    pub trailing_messages: Vec<CmdMessage>,
+}
+
+impl ModificationResult {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_pads(mut self, pads: Vec<DisplayPad>) -> Self {
+        self.affected_pads = pads;
+        self
+    }
+
+    pub fn add_info(&mut self, content: impl Into<String>) {
+        self.trailing_messages.push(CmdMessage::info(content));
+    }
+
+    /// Convert to CmdResult for backward compatibility
+    pub fn into_cmd_result(self) -> CmdResult {
+        CmdResult {
+            affected_pads: self.affected_pads,
+            messages: self.trailing_messages,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PadUpdate {
     pub index: crate::index::DisplayIndex,

--- a/crates/padzapp/src/commands/move_pads.rs
+++ b/crates/padzapp/src/commands/move_pads.rs
@@ -45,10 +45,7 @@ pub fn run<S: DataStore>(
         None
     };
 
-    let (dest_uuid, dest_title) = match destination_data {
-        Some((uuid, title)) => (Some(uuid), title),
-        None => (None, "Root".to_string()),
-    };
+    let dest_uuid = destination_data.map(|(uuid, _)| uuid);
 
     let mut result = CmdResult::default();
 
@@ -97,10 +94,7 @@ pub fn run<S: DataStore>(
 
         store.save_pad(&pad, scope)?;
 
-        result.add_message(CmdMessage::success(format!(
-            "Moved '{}' to {}",
-            pad.metadata.title, dest_title
-        )));
+        // Note: No success message - CLI handles unified rendering
 
         // Note: The index in result will be the *old* index because we haven't re-indexed the world.
         // But for the purpose of "affected pads", we return the pad state.

--- a/crates/padzapp/src/commands/pinning.rs
+++ b/crates/padzapp/src/commands/pinning.rs
@@ -44,22 +44,13 @@ fn pin_state<S: DataStore>(
         pad.metadata.delete_protected = is_pinned;
         store.save_pad(&pad, scope)?;
 
-        if is_pinned && !was_already_pinned {
-            result.add_message(CmdMessage::success(format!(
-                "Pinned pad {}",
-                super::helpers::fmt_path(&display_index)
-            )));
-        } else if !is_pinned && was_already_pinned {
-            result.add_message(CmdMessage::success(format!(
-                "Unpinned pad {}",
-                super::helpers::fmt_path(&display_index)
-            )));
-        } else if is_pinned && was_already_pinned {
+        // Only add info messages for no-op cases; success cases are shown via pad list
+        if is_pinned && was_already_pinned {
             result.add_message(CmdMessage::info(format!(
                 "Pad {} is already pinned",
                 super::helpers::fmt_path(&display_index)
             )));
-        } else {
+        } else if !is_pinned && !was_already_pinned {
             result.add_message(CmdMessage::info(format!(
                 "Pad {} is already unpinned",
                 super::helpers::fmt_path(&display_index)


### PR DESCRIPTION
## Summary

- Standardize output for pad-modifying commands to show unified format:
  ```
  Completed 2 pads...
  ⚫︎  1. Task A                              2 hours ago
  ⚫︎  2. Task B                              3 days ago
  ```
- Add `ModificationResult` type for structured command results
- Add `modification_result.jinja` template and `render_modification_result()` function
- Update all modifying commands: create, delete, pin, unpin, complete, reopen, restore, move

## Changes

**API Layer (padzapp):**
- Remove per-pad success messages from command implementations
- Keep info messages for no-op cases (e.g., "already pinned", "already done")

**CLI Layer (padz):**
- New unified rendering for all modification commands
- Affected pads displayed using existing `_pad_line.jinja` template

**Commands unchanged:**
- import, export, purge remain message-only

## Test plan

- [x] All 235 unit tests pass
- [ ] Manual test: `padz create "Test"` → shows "Created 1 pad..."
- [ ] Manual test: `padz complete 1 2` → shows "Completed 2 pads..." with pad list
- [ ] Manual test: `padz pin 1` → shows "Pinned 1 pad..." with pad list
- [ ] Verify JSON output mode: `padz complete 1 --output json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)