### PR TITLE
feat: add --data option to override datastore directory path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **Data path override** - `--data <PATH>` option to explicitly specify the `.padz` data directory, useful for git worktrees or working from temp directories
+
 ## [0.10.2] - 2026-01-12
 
 ## [0.10.2] - 2026-01-12

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -156,7 +156,8 @@ pub fn run() -> Result<()> {
 fn init_context(cli: &Cli, output_mode: OutputMode) -> Result<AppContext> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-    let ctx = initialize(&cwd, cli.global);
+    let data_override = cli.data.as_ref().map(PathBuf::from);
+    let ctx = initialize(&cwd, cli.global, data_override);
 
     Ok(AppContext {
         api: ctx.api,

--- a/crates/padz/src/cli/complete.rs
+++ b/crates/padz/src/cli/complete.rs
@@ -19,9 +19,9 @@ fn get_pad_candidates(include_deleted: bool) -> Vec<CompletionCandidate> {
     let args: Vec<String> = std::env::args().collect();
     let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
-    // Initialize context
+    // Initialize context (completions don't support --data override)
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let ctx = initialize(&cwd, is_global);
+    let ctx = initialize(&cwd, is_global, None);
     let api: PadzApi<FileStore> = ctx.api;
 
     // Query pads
@@ -83,7 +83,7 @@ pub fn deleted_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let ctx = initialize(&cwd, is_global);
+        let ctx = initialize(&cwd, is_global, None);
         let api: PadzApi<FileStore> = ctx.api;
 
         let filter = PadFilter {

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -47,7 +47,13 @@ pub struct Cli {
     pub command: Option<Commands>,
 
     /// Operate on global pads
-    #[arg(short, long, global = true, help_heading = "Options")]
+    #[arg(
+        short,
+        long,
+        global = true,
+        help_heading = "Options",
+        conflicts_with = "data"
+    )]
     pub global: bool,
 
     /// Verbose output
@@ -55,7 +61,13 @@ pub struct Cli {
     pub verbose: bool,
 
     /// Override data directory path (e.g., for git worktrees)
-    #[arg(long, global = true, value_name = "PATH", help_heading = "Options")]
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        help_heading = "Options",
+        conflicts_with = "global"
+    )]
     pub data: Option<String>,
 }
 
@@ -415,10 +427,12 @@ mod tests {
     }
 
     #[test]
-    fn test_data_and_global_options_together() {
-        let cli = Cli::try_parse_from(["padz", "--data", "/tmp/.padz", "-g", "list"]).unwrap();
-        assert_eq!(cli.data, Some("/tmp/.padz".to_string()));
-        assert!(cli.global);
+    fn test_data_and_global_options_conflict() {
+        // --data and -g are mutually exclusive
+        let result = Cli::try_parse_from(["padz", "--data", "/tmp/.padz", "-g", "list"]);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("--data") || err.contains("--global"));
     }
 
     #[test]

--- a/docs/scopes.txt
+++ b/docs/scopes.txt
@@ -37,9 +37,32 @@ The result is that you must explicitly `padz init` in a repo to opt-in to projec
 
 The scope is resolved during `padz::init::initialize`:
 1.  If `-g` flag is present → Force `Scope::Global`.
-2.  Otherwise → Run `find_project_root(cwd)`.
+2.  If `--data <PATH>` is provided → Use that path directly as project data directory.
+3.  Otherwise → Run `find_project_root(cwd)`.
     -   Found → `Scope::Project`.
     -   Not Found → `Scope::Project` with `cwd/.padz` as path (may need `init`).
+
+### 3.1 Data Path Override (--data option)
+
+The `--data <PATH>` option allows explicitly specifying the `.padz` data directory,
+bypassing automatic scope detection. This is useful when:
+-   Working in a git worktree that should share data with the main repo
+-   Working in a temp directory for a project located elsewhere
+-   Explicitly pointing to a specific data store location
+
+Example usage:
+```bash
+# Working in a worktree, use main repo's pads
+padz --data ~/projects/myproject/.padz list
+
+# Create a pad from temp directory, saved to project
+padz --data /home/user/myproject/.padz create "temp notes"
+```
+
+When `--data` is provided:
+-   The path is used directly as the project data directory
+-   Scope detection via `find_project_root` is skipped
+-   The scope defaults to `Scope::Project` (unless `-g` forces global)
 
 ### 4. Nested Repositories
 


### PR DESCRIPTION
## Summary

- Adds `--data <PATH>` CLI option to explicitly specify the `.padz` data directory
- Bypasses automatic scope detection when provided
- `--data` and `-g` are mutually exclusive (both control data path)

## Use Cases

- Working in a git worktree that should share data with the main repo
- Working in a temp directory for a project located elsewhere
- Explicitly pointing to a specific data store location

## Usage

```bash
# Use pads from main project while in a worktree
padz --data ~/projects/myproject/.padz list

# Create pad in project store from any directory
padz --data /path/to/project/.padz create "my note"
```

## Changes

**Library (padzapp)**
- Add `data_override: Option<PathBuf>` parameter to `initialize()`
- Update module-level cargo docs
- Add 4 unit tests for data override functionality

**CLI (padz)**
- Add `--data <PATH>` global option with `conflicts_with = "global"`
- Pass data option through `init_context()` to `initialize()`
- Add 7 CLI parsing tests including conflict test

**Documentation**
- Update `docs/scopes.txt` with new Section 3.1 documenting the feature

## Test plan

- [x] All 290 existing tests pass
- [x] New unit tests for `initialize()` with data override
- [x] New CLI parsing tests for `--data` option
- [x] Conflict test verifies `--data` and `-g` cannot be used together

🤖 Generated with [Claude Code](https://claude.ai/code)