### PR TITLE
fix: restrict pad name matching to title only

### DIFF
--- a/crates/padzapp/src/commands/helpers.rs
+++ b/crates/padzapp/src/commands/helpers.rs
@@ -78,12 +78,7 @@ pub fn resolve_selectors<S: DataStore>(
                 let term_lower = term.to_lowercase();
                 let matches: Vec<&(Vec<DisplayIndex>, &DisplayPad)> = linearized
                     .iter()
-                    .filter(|(_, dp)| {
-                        if dp.pad.metadata.title.to_lowercase().contains(&term_lower) {
-                            return true;
-                        }
-                        dp.pad.content.to_lowercase().contains(&term_lower)
-                    })
+                    .filter(|(_, dp)| dp.pad.metadata.title.to_lowercase().contains(&term_lower))
                     .collect();
 
                 match matches.len() {
@@ -540,7 +535,7 @@ mod tests {
     }
 
     #[test]
-    fn test_title_search_matches_content_not_just_title() {
+    fn test_title_search_matches_title_only_not_content() {
         let mut store = InMemoryStore::new();
         create::run(
             &mut store,
@@ -559,11 +554,22 @@ mod tests {
         )
         .unwrap();
 
-        // Search for content that's in body, not title
+        // Search for content that's in body, not title - should NOT match
         let result = resolve_selectors(
             &store,
             Scope::Project,
             &[PadSelector::Title("apples".to_string())],
+            false,
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No pad found"));
+
+        // Search for title should work
+        let result = resolve_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Title("Shopping".to_string())],
             false,
         )
         .unwrap();


### PR DESCRIPTION
## Summary

- Pad name matching (e.g., `padz view About`) now only searches titles, not content
- Previously, `PadSelector::Title` matched against both title AND content, leading to unexpected matches
- Content search remains available via `padz list --search term`

## Test plan

- [x] Unit test updated to verify title-only matching behavior
- [x] Existing title matching tests pass
- [x] Full test suite passes (264 tests)
- [x] Manual verification: `padz view yaml` returns "No pad found" (yaml is in content only)
- [x] Manual verification: `padz list --search yaml` still finds content matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)