### PR TITLE
feat: migrate from outstanding to standout rendering library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +648,21 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1178,54 +1216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "outstanding"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6473b70557d9fc910a58de81cb5999611f9a5c5cd2e5fe464f6cc335041803a"
-dependencies = [
- "console",
- "csv",
- "dark-light",
- "deunicode",
- "minijinja",
- "once_cell",
- "outstanding-macros",
- "quick-xml",
- "serde",
- "serde_json",
- "serde_yaml",
- "unicode-width",
-]
-
-[[package]]
-name = "outstanding-clap"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e4b33debb3d9b8729bf341cf45f370384ccf9dd44d3386cfe078daa030abbf"
-dependencies = [
- "anyhow",
- "clap",
- "console",
- "minijinja",
- "outstanding",
- "serde",
- "serde_json",
- "terminal_size",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "outstanding-macros"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dad596ae2e484247ef5c627fa1f9142d192c78317c8227cfde2895fde269dc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "padz"
 version = "0.14.0"
 dependencies = [
@@ -1236,11 +1226,12 @@ dependencies = [
  "console",
  "dark-light",
  "once_cell",
- "outstanding",
- "outstanding-clap",
  "padzapp",
  "predicates",
  "serde",
+ "serde_json",
+ "serde_yaml",
+ "standout",
  "timeago",
  "unicode-width",
 ]
@@ -1277,7 +1268,31 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1723,6 +1738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1751,49 @@ checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "standout"
+version = "1.0.0"
+source = "git+https://github.com/arthur-debert/standout.git?rev=b1644edc139dab254e95d722e4e52702cab49dcb#b1644edc139dab254e95d722e4e52702cab49dcb"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console",
+ "cssparser",
+ "csv",
+ "dark-light",
+ "deunicode",
+ "minijinja",
+ "once_cell",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "standout-bbparser",
+ "standout-macros",
+ "terminal_size",
+ "thiserror 2.0.17",
+ "unicode-width",
+]
+
+[[package]]
+name = "standout-bbparser"
+version = "1.0.0"
+source = "git+https://github.com/arthur-debert/standout.git?rev=b1644edc139dab254e95d722e4e52702cab49dcb#b1644edc139dab254e95d722e4e52702cab49dcb"
+dependencies = [
+ "console",
+]
+
+[[package]]
+name = "standout-macros"
+version = "1.0.0"
+source = "git+https://github.com/arthur-debert/standout.git?rev=b1644edc139dab254e95d722e4e52702cab49dcb#b1644edc139dab254e95d722e4e52702cab49dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -21,9 +21,10 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 console = "0.15"
 dark-light = "0.2"
 once_cell = "1.19"
-outstanding = { version = "0.14.0", features = ["macros"] }
-outstanding-clap = "0.14.0"
+standout = { git = "https://github.com/arthur-debert/standout.git", rev = "b1644edc139dab254e95d722e4e52702cab49dcb", features = ["clap", "macros"] }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
 timeago = "0.4"
 unicode-width = "0.2.2"
 

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -47,7 +47,6 @@ use super::setup::{
     parse_cli, Cli, Commands, CompletionShell, CoreCommands, DataCommands, MiscCommands,
     PadCommands, TagsCommands,
 };
-use outstanding::OutputMode;
 use padzapp::api::{ConfigAction, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
 use padzapp::clipboard::{copy_to_clipboard, format_for_clipboard, get_from_clipboard};
 use padzapp::editor::open_in_editor;
@@ -56,6 +55,7 @@ use padzapp::init::initialize;
 use padzapp::model::Scope;
 use padzapp::model::{extract_title_and_body, parse_pad_content};
 use padzapp::store::fs::FileStore;
+use standout::OutputMode;
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
@@ -78,7 +78,7 @@ struct AppContext {
 }
 
 pub fn run() -> Result<()> {
-    // parse_cli() uses outstanding-clap's Outstanding which handles
+    // parse_cli() uses standout's App which handles
     // help display (including topics) and errors automatically.
     // It also extracts the output mode from the --output flag.
     let (cli, output_mode) = parse_cli();
@@ -304,7 +304,7 @@ fn handle_list(
 
     let result = ctx.api.get_pads(ctx.scope, filter)?;
 
-    // Use outstanding-based rendering
+    // Use standout-based rendering
     let output = if deleted {
         render_pad_list_deleted(&result.listed_pads, peek, ctx.output_mode)
     } else {

--- a/crates/padz/src/cli/mod.rs
+++ b/crates/padz/src/cli/mod.rs
@@ -54,7 +54,7 @@
 //! ## Module Structure
 //!
 //! - `commands`: Per-command handlers that call API and format output
-//! - `render`: Output formatting using outstanding's `OutstandingApp` (styles and templates embedded at compile time)
+//! - `render`: Output formatting using standout's `App` (styles and templates embedded at compile time)
 //! - `setup`: Argument parsing via clap, help text
 
 mod commands;

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -1,9 +1,9 @@
 use super::complete::{active_pads_completer, all_pads_completer, deleted_pads_completer};
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use once_cell::sync::Lazy;
-use outstanding::topics::TopicRegistry;
-use outstanding::OutputMode;
-use outstanding_clap::{render_help_with_topics, Outstanding};
+use standout::cli::{render_help_with_topics, App};
+use standout::topics::TopicRegistry;
+use standout::OutputMode;
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 pub enum CompletionShell {
@@ -84,7 +84,7 @@ static HELP_TOPICS: Lazy<TopicRegistry> = Lazy::new(|| {
 });
 
 /// Parse a topic file content into a Topic struct
-fn parse_topic_file(name: &str, content: &str) -> Option<outstanding::topics::Topic> {
+fn parse_topic_file(name: &str, content: &str) -> Option<standout::topics::Topic> {
     let lines: Vec<&str> = content.lines().collect();
     if lines.len() < 2 {
         return None;
@@ -106,10 +106,10 @@ fn parse_topic_file(name: &str, content: &str) -> Option<outstanding::topics::To
         return None;
     }
 
-    Some(outstanding::topics::Topic::new(
+    Some(standout::topics::Topic::new(
         title,
         body,
-        outstanding::topics::TopicType::Text,
+        standout::topics::TopicType::Text,
         Some(name.to_string()),
     ))
 }
@@ -120,15 +120,15 @@ pub fn build_command() -> clap::Command {
     Cli::command()
 }
 
-/// Parses command-line arguments using outstanding-clap's Outstanding.
+/// Parses command-line arguments using standout's App.
 /// This handles help display (including topics) and errors automatically.
 /// It also adds the --output flag for output mode control (auto, term, text, term-debug).
 /// Returns the parsed CLI and the output mode extracted from the matches.
 pub fn parse_cli() -> (Cli, OutputMode) {
-    let outstanding = Outstanding::with_registry(HELP_TOPICS.clone());
-    let matches = outstanding.run_with(Cli::command());
+    let app = App::with_registry(HELP_TOPICS.clone());
+    let matches = app.parse_with(Cli::command());
 
-    // Extract output mode from the matches (outstanding-clap adds this as _output_mode)
+    // Extract output mode from the matches (standout adds this as _output_mode)
     let output_mode = match matches
         .get_one::<String>("_output_mode")
         .map(|s| s.as_str())

--- a/crates/padz/src/cli/templates/_deleted_help.jinja
+++ b/crates/padz/src/cli/templates/_deleted_help.jinja
@@ -1,9 +1,9 @@
-{{- "Deleted Pads" | style("section-header") | nl -}}
-{{- "" | nl -}}
-{{- "These pads are marked for deletion and will be permanently deleted after a month." | style("help-text") | nl -}}
-{{- "To restore a pad:" | style("help-text") | nl -}}
-{{- "    padz restore <index>      - Restore specific pads" | style("help-text") | nl -}}
-{{- "    padz restore              - Restore all deleted pads" | style("help-text") | nl -}}
-{{- "To permanently delete:" | style("help-text") | nl -}}
-{{- "    padz purge <index>        - Permanently delete specific pads" | style("help-text") | nl -}}
-{{- "    padz purge                - Permanently delete all deleted pads" | style("help-text") | nl -}}
+[section-header]Deleted Pads[/section-header]{{ "" | nl }}
+{{ "" | nl }}
+[help-text]These pads are marked for deletion and will be permanently deleted after a month.[/help-text]{{ "" | nl }}
+[help-text]To restore a pad:[/help-text]{{ "" | nl }}
+[help-text]    padz restore <index>      - Restore specific pads[/help-text]{{ "" | nl }}
+[help-text]    padz restore              - Restore all deleted pads[/help-text]{{ "" | nl }}
+[help-text]To permanently delete:[/help-text]{{ "" | nl }}
+[help-text]    padz purge <index>        - Permanently delete specific pads[/help-text]{{ "" | nl }}
+[help-text]    padz purge                - Permanently delete all deleted pads[/help-text]{{ "" | nl }}

--- a/crates/padz/src/cli/templates/_match_lines.jinja
+++ b/crates/padz/src/cli/templates/_match_lines.jinja
@@ -1,8 +1,8 @@
 {#- Search match lines for a pad -#}
 {#- Expects: pad.left_pad, pad.matches (list of {line_number, segments}), pad.more_matches_count -#}
 {%- for match in pad.matches -%}
-{{- "    " }}{{ pad.left_pad }}    {{ match.line_number | style("line-number") }} {% for seg in match.segments %}{{ seg.text | style(seg.style) }}{% endfor %}{{ "" | nl -}}
+    {{ pad.left_pad }}    [line-number]{{ match.line_number }}[/line-number] {% for seg in match.segments %}{{ seg.text | style_as(seg.style) }}{% endfor %}{{ "" | nl }}
 {%- endfor -%}
 {%- if pad.more_matches_count > 0 -%}
-{{- "    " }}{{ pad.left_pad }}    {{ ("And " ~ pad.more_matches_count ~ " more results") | style("truncation") }}{{ "" | nl -}}
+    {{ pad.left_pad }}    [truncation]And {{ pad.more_matches_count }} more results[/truncation]{{ "" | nl }}
 {%- endif -%}

--- a/crates/padz/src/cli/templates/_pad_line.jinja
+++ b/crates/padz/src/cli/templates/_pad_line.jinja
@@ -1,5 +1,5 @@
-{#- Single pad line rendering -#}
-{#- Expects: pad (PadLineData), pin_marker, peek (bool), col_* (column widths) -#}
+{#- Single pad line rendering using Tabular -#}
+{#- Expects: pad (PadLineData), peek (bool), col_* (column widths) -#}
 
 {#- Determine index style based on section type -#}
 {%- set index_style = "list-index" -%}
@@ -17,13 +17,31 @@
   {%- set title_style = "title" -%}
 {%- endif -%}
 
-{#- Render the pad line using col() filter for layout -#}
-{#- Layout: indent | left_pin(2) | status(2) | index(4) | title(fill) | tags | right_pin(2) | time(14) -#}
+{#- Build tags string -#}
+{%- set tags_str = "" -%}
+{%- for tag in pad.tags -%}
+  {%- set tags_str = tags_str ~ " [tag]" ~ tag ~ "[/tag]" -%}
+{%- endfor -%}
+
+{#- Define tabular layout with styles at column level -#}
+{%- set t = tabular([
+    {"name": "left_pin", "width": col_left_pin, "style": "pinned"},
+    {"name": "status", "width": col_status, "style": "status-icon"},
+    {"name": "index", "width": col_index, "style": index_style},
+    {"name": "title", "width": pad.title_width, "overflow": "truncate", "style": title_style},
+    {"name": "right_pin", "width": col_right_pin, "style": "pinned"},
+    {"name": "time", "width": col_time, "align": "right", "style": "time"}
+]) -%}
+
+{#- Render the row with indent prefix -#}
+{#- Note: tags are appended after title column since they have variable count -#}
 {{- pad.indent -}}
-{{- pad.left_pin | col(col_left_pin) | style("pinned") -}}
-{{- pad.status_icon | col(col_status) | style("status-icon") -}}
-{{- pad.index | col(col_index) | style(index_style) -}}
-{{- pad.title | col(pad.title_width) | style(title_style) -}}
-{% if pad.tags %} {% endif %}{%- for tag in pad.tags -%}{{ tag | style("tag") }}{% if not loop.last %} {% endif %}{%- endfor -%}
-{{- pad.right_pin | col(col_right_pin) | style("pinned") -}}
-{{- pad.time_ago | col(col_time, align='right') | style("time") | nl -}}
+{{- t.row([
+    pad.left_pin,
+    pad.status_icon,
+    pad.index,
+    pad.title ~ tags_str,
+    pad.right_pin,
+    pad.time_ago
+]) -}}
+{{ "" | nl -}}

--- a/crates/padz/src/cli/templates/_peek_content.jinja
+++ b/crates/padz/src/cli/templates/_peek_content.jinja
@@ -1,13 +1,13 @@
 {#- Peek content preview for a pad -#}
 {#- Expects: pad.left_pad, pad.peek (PeekResult with opening_lines, truncated_count, closing_lines) -#}
-{{- "" | nl -}}
-{{- "    " }}{{ pad.left_pad }}    {{ pad.peek.opening_lines | style("preview") | indent(8) | nl -}}
+{{ "" | nl }}
+    {{ pad.left_pad }}    [preview]{{ pad.peek.opening_lines | indent(8) }}[/preview]{{ "" | nl }}
 {%- if pad.peek.truncated_count -%}
-{{- "" | nl -}}
-{{- "    " }}{{ pad.left_pad }}                      {{ ("... " ~ pad.peek.truncated_count ~ " lines not shown ...") | style("truncation") | nl -}}
-{{- "" | nl -}}
+{{ "" | nl }}
+    {{ pad.left_pad }}                      [truncation]... {{ pad.peek.truncated_count }} lines not shown ...[/truncation]{{ "" | nl }}
+{{ "" | nl }}
 {%- endif -%}
 {%- if pad.peek.closing_lines -%}
-{{- "    " }}{{ pad.left_pad }}    {{ pad.peek.closing_lines | style("preview") | indent(8) | nl -}}
+    {{ pad.left_pad }}    [preview]{{ pad.peek.closing_lines | indent(8) }}[/preview]{{ "" | nl }}
 {%- endif -%}
-{{- "" | nl -}}
+{{ "" | nl }}

--- a/crates/padz/src/cli/templates/full_pad.jinja
+++ b/crates/padz/src/cli/templates/full_pad.jinja
@@ -2,32 +2,30 @@
 {#- Shows complete pad content with index, title, and body -#}
 
 {% if pads | length == 0 -%}
-{{- "No pads found." | style("empty-message") }}
+[empty-message]No pads found.[/empty-message]
 {% else -%}
 {% for pad in pads -%}
 
 {#- Separator between pads (not before first) -#}
 {%- if not loop.first %}
 
-{{ " " | style("separator") }}
+[separator] [/separator]
 
 {% endif -%}
 
-{#- Determine styles based on pad state -#}
-{%- set index_style = "list-index" -%}
-{%- set title_style = "title" -%}
-{%- set content_style = "list-title" -%}
-{%- if pad.is_pinned -%}
-  {%- set index_style = "pinned" -%}
-{%- elif pad.is_deleted -%}
-  {%- set index_style = "deleted-index" -%}
-  {%- set title_style = "deleted-title" -%}
-  {%- set content_style = "deleted-title" -%}
-{%- endif -%}
-
 {#- Render header: index + title -#}
-{{- pad.index | style(index_style) }} {{ pad.title | style(title_style) }}
-{{ " " | style("separator") }}
-{{ pad.content | style(content_style) -}}
+{%- if pad.is_pinned -%}
+[pinned]{{ pad.index }}[/pinned] [title]{{ pad.title }}[/title]
+{%- elif pad.is_deleted -%}
+[deleted-index]{{ pad.index }}[/deleted-index] [deleted-title]{{ pad.title }}[/deleted-title]
+{%- else -%}
+[list-index]{{ pad.index }}[/list-index] [title]{{ pad.title }}[/title]
+{%- endif %}
+
+{%- if pad.is_deleted -%}
+[deleted-title]{{ pad.content }}[/deleted-title]
+{%- else -%}
+[list-title]{{ pad.content }}[/list-title]
+{%- endif -%}
 {%- endfor %}
 {% endif %}

--- a/crates/padz/src/cli/templates/list.jinja
+++ b/crates/padz/src/cli/templates/list.jinja
@@ -1,19 +1,19 @@
 {%- if empty -%}
-{{- "No pads yet, create one with `padz create`" | style("empty-message") | nl -}}
+[empty-message]No pads yet, create one with `padz create`[/empty-message]{{ "" | nl -}}
 {{ help_text }}
 {%- else -%}
 {%- for pad in pads -%}
 {%- if pad.is_separator -%}
 {{- "" | nl -}}
 {%- else -%}
-{%- include "_pad_line" -%}
-{%- include "_match_lines" -%}
+{%- include "_pad_line.jinja" -%}
+{%- include "_match_lines.jinja" -%}
 {%- if pad.peek -%}
-{%- include "_peek_content" -%}
+{%- include "_peek_content.jinja" -%}
 {%- endif -%}
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}
 {%- if deleted_help -%}
-{%- include "_deleted_help" -%}
+{%- include "_deleted_help.jinja" -%}
 {%- endif -%}

--- a/crates/padz/src/cli/templates/messages.jinja
+++ b/crates/padz/src/cli/templates/messages.jinja
@@ -1,3 +1,3 @@
 {% for msg in messages -%}
-{{ msg.content | style(msg.style) }}
+{{ msg.content | style_as(msg.style) }}
 {% endfor %}

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -3,15 +3,15 @@
 
 {#- Start message -#}
 {%- if start_message -%}
-{{ start_message | style("info") | nl }}
+[info]{{ start_message }}[/info]{{ "" | nl }}
 {%- endif -%}
 
 {#- Affected pads list -#}
 {%- for pad in pads -%}
-{%- include "_pad_line" -%}
+{%- include "_pad_line.jinja" -%}
 {%- endfor -%}
 
 {#- Trailing messages (info, warnings, errors) -#}
 {%- for msg in trailing_messages -%}
-{{ msg.content | style(msg.style) | nl }}
+{{ msg.content | style_as(msg.style) }}{{ "" | nl }}
 {%- endfor -%}

--- a/crates/padz/src/cli/templates/text_list.jinja
+++ b/crates/padz/src/cli/templates/text_list.jinja
@@ -1,7 +1,7 @@
 {% if lines | length == 0 %}
-{{ empty_message | style("empty-message") }}
+[empty-message]{{ empty_message }}[/empty-message]
 {% else -%}
 {% for line in lines -%}
-{{ line | style("list-title") }}
+[list-title]{{ line }}[/list-title]
 {% endfor -%}
 {% endif %}

--- a/crates/padz/src/main.rs
+++ b/crates/padz/src/main.rs
@@ -20,7 +20,7 @@
 //! │  CLI Layer (crates/padz-cli/src/cli/)                       │
 //! │  - clap argument parsing (setup.rs)                         │
 //! │  - Command selection + context wiring (commands.rs)         │
-//! │  - Terminal rendering via Outstanding templates (render.rs) │
+//! │  - Terminal rendering via Standout templates (render.rs)    │
 //! │  - Shell completion scripts + helpers                       │
 //! └─────────────────────────────────────────────────────────────┘
 //!                              │
@@ -45,9 +45,9 @@
 //! is therefore responsible for **all** user-facing concerns: argument parsing,
 //! context initialization, dispatch, error handling, and rendering.
 //!
-//! ## Rendering with Outstanding
+//! ## Rendering with Standout
 //!
-//! Terminal output is produced through the `outstanding` crate. Templates live in
+//! Terminal output is produced through the `standout` crate. Templates live in
 //! `src/cli/templates/` (e.g., `list.tmp`, `full_pad.tmp`) and are embedded at
 //! compile time via `include_str!()`. `render.rs` feeds data structures into those
 //! templates and the CLI commands simply print the rendered strings. This keeps CLI

--- a/docs/standout-upgrading-feedback.md
+++ b/docs/standout-upgrading-feedback.md
@@ -1,0 +1,110 @@
+# Standout Upgrade Feedback
+
+Feedback from migrating padz from `outstanding` (v0.14) to `standout` (v1.0 @ b1644ed).
+
+## What Went Well
+
+1. **The guides are excellent** - `intro-to-standout.md` and `intro-to-tabular.md` are well-written and comprehensive for new users.
+
+2. **BBCode tag syntax is intuitive** - Once understood, `[style]content[/style]` is cleaner than `{{ x | style("name") }}`.
+
+3. **The `style_as` filter** for dynamic styles works well.
+
+4. **StylesheetRegistry API** - Loading themes from embedded styles via `embed_styles!` → `StylesheetRegistry` → `.get("default")` worked smoothly.
+
+## Pain Points & Documentation Gaps
+
+### 1. No Migration Guide from `outstanding`
+
+**Problem:** There's no documentation explaining what changed from `outstanding` to `standout`. I had to discover changes through trial and error.
+
+**Suggestion:** Add a `migrating-from-outstanding.md` guide covering:
+
+- Package rename: `outstanding` → `standout`, `outstanding-clap` → `standout` with `clap` feature
+- Import path changes
+- API renames (`OutstandingApp` → `App`, `RenderSetup` → `App::builder()`)
+- Template syntax changes (`style()` filter → BBCode tags)
+
+### 2. `App.render()` vs `Renderer.render()` - Critical Difference Undocumented
+
+**Problem:** `App.render()` does NOT apply styles - it only does template rendering. Styles are only applied by:
+
+- `Renderer.render()`
+- `render_auto()`
+- `App.run_command()` (which calls `render_auto` internally)
+
+I spent significant time debugging why BBCode tags were appearing literally in output when using `App.render()`.
+
+**Suggestion:** Add prominent documentation explaining:
+
+- `App` is primarily for CLI integration with clap (help, topics, command dispatch)
+- For pure rendering with styles, use `Renderer` or standalone `render`/`render_auto` functions
+- `App.render()` is a low-level method that skips style application
+
+### 3. Template Includes Require Explicit Extensions
+
+**Problem:** `{% include "_pad_line" %}` failed silently. Had to change to `{% include "_pad_line.jinja" %}`.
+
+The `embed_templates!` docs mention extensionless lookup works, but this doesn't apply to Jinja `{% include %}` statements.
+
+**Suggestion:** Document that `{% include %}` requires the full filename with extension.
+
+### 4. `Renderer` Has Fixed OutputMode
+
+**Problem:** `Renderer` takes `OutputMode` at construction time and has no setter. Our code needed per-render output mode control, which forced us to create a new `Renderer` for each render call (inefficient).
+
+**Suggestion:** Either:
+
+- Add `renderer.set_output_mode(mode)` method
+- Or document this limitation clearly and recommend `render_auto()` for per-call mode control
+
+### 5. `render_auto()` Doesn't Support Includes
+
+**Problem:** The standalone `render_auto(template_content, data, theme, mode)` takes template content as a string, which means `{% include %}` won't work (no template registry).
+
+**Suggestion:** Document which render functions support includes and which don't:
+
+- `Renderer.render()` ✓ supports includes (has template registry)
+- `render_auto()` ✗ no includes (takes raw template string)
+- `render()` ✗ no includes
+
+### 6. `render-only.md` Topic Was Helpful But Incomplete
+
+**Problem:** The `render-only.md` topic showed the basic pattern but didn't cover:
+
+- How to handle structured output modes (JSON/YAML)
+- How to use embedded templates with `Renderer`
+- The relationship between `Theme`, `StylesheetRegistry`, and `embed_styles!`
+
+**Suggestion:** Expand with a more complete example showing:
+
+```rust
+// Load theme from embedded styles
+let styles = embed_styles!("src/styles");
+let mut registry: StylesheetRegistry = styles.into();
+let theme = registry.get("default")?;
+
+// Create renderer with templates
+let mut renderer = Renderer::with_output(theme, mode)?;
+renderer.add_template("list", include_str!("templates/list.jinja"))?;
+renderer.add_template("_partial.jinja", include_str!("templates/_partial.jinja"))?;
+
+// Render
+let output = renderer.render("list", &data)?;
+```
+
+## Minor Issues
+
+1. **`EmbeddedTemplates` type confusion** - `embed_templates!` returns `EmbeddedSource<TemplateResource>` but `Renderer.with_embedded()` takes `HashMap<String, String>`. The conversion isn't obvious.
+
+2. **Error messages could be better** - "unknown filter: filter style is unknown" doesn't hint that `style()` was replaced with BBCode tags.
+
+## Summary
+
+The library is well-designed and the new BBCode tag syntax is cleaner. The main gaps are:
+
+1. **Migration documentation** for users coming from `outstanding`
+2. **Clearer separation** between `App` (CLI integration) and `Renderer` (pure rendering)
+3. **Documentation of which render functions support what features** (includes, per-call modes, etc.)
+
+Happy to discuss any of these points further!


### PR DESCRIPTION
## Summary

- Migrate from `outstanding`/`outstanding-clap` to `standout` rendering library
- Update template syntax from `style()` filter to BBCode tags (`[style]...[/style]`)
- Implement `Tabular` for proper column alignment in list views
- Add upgrade feedback document for the standout team

## Changes

### Dependencies
- Replace `outstanding = "0.14.0"` and `outstanding-clap = "0.14.0"` with `standout` (git dependency)
- Add `serde_json` and `serde_yaml` for structured output handling

### Rendering Architecture
- Switch from `App.render()` to `Renderer` for proper style application
- Create per-render `Renderer` instances with appropriate output mode
- Handle structured formats (JSON/YAML) via direct serialization

### Template Syntax
- Convert `{{ x | style("name") }}` → `[name]{{ x }}[/name]`
- Use `{{ x | style_as(dynamic) }}` for dynamic style names
- Update includes to use explicit `.jinja` extensions
- Implement `tabular()` function for column layout in `_pad_line.jinja`

### Documentation
- Update all doc comments from "outstanding" to "standout"
- Add `docs/standout-upgrading-feedback.md` with migration pain points

## Test plan

- [x] All 24 render tests pass
- [x] All 356 padzapp tests pass
- [x] CLI `padz list` displays properly aligned columns
- [x] CLI `padz list --output=json` returns valid JSON
- [x] Pre-commit hooks pass (fmt, clippy, check, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)