### PR TITLE
refactor: unify create/open editor + clipboard flow

### DIFF
--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -196,4 +196,27 @@ mod tests {
         assert_eq!(pads.len(), 1);
         assert!(pads[0].metadata.parent_id.is_none());
     }
+
+    #[test]
+    fn create_returns_pad_path() {
+        let mut store = InMemoryStore::new();
+
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "Path Test".into(),
+            "Body".into(),
+            None,
+        )
+        .unwrap();
+
+        // pad_paths should be populated for editor/clipboard integration
+        assert_eq!(result.pad_paths.len(), 1);
+        // Path should contain the pad's UUID
+        let pad_id = result.affected_pads[0].pad.metadata.id.to_string();
+        assert!(
+            result.pad_paths[0].to_string_lossy().contains(&pad_id),
+            "pad_path should contain the pad's UUID"
+        );
+    }
 }

--- a/live-tests/tests/crud.bats
+++ b/live-tests/tests/crud.bats
@@ -139,6 +139,52 @@ load '../lib/assertions.bash'
 }
 
 # -----------------------------------------------------------------------------
+# CREATE (interactive editor)
+# -----------------------------------------------------------------------------
+
+@test "create: interactive mode creates pad (EDITOR=true)" {
+    # With EDITOR=true, the editor exits immediately, keeping the initial content
+    run "${PADZ_BIN}" -g create "Interactive Create Test"
+    assert_success
+
+    assert_pad_exists "Interactive Create Test" global
+}
+
+@test "create: interactive mode copies to clipboard" {
+    # Only test clipboard on macOS where pbpaste is available
+    command -v pbpaste >/dev/null || skip "pbpaste not available"
+
+    "${PADZ_BIN}" -g create "Clipboard Create Test" >/dev/null
+
+    local clipboard
+    clipboard=$(pbpaste)
+    [[ "${clipboard}" == *"Clipboard Create Test"* ]]
+}
+
+@test "create: --no-editor copies to clipboard" {
+    command -v pbpaste >/dev/null || skip "pbpaste not available"
+
+    "${PADZ_BIN}" -g create --no-editor "No Editor Clipboard Test" >/dev/null
+
+    local clipboard
+    clipboard=$(pbpaste)
+    [[ "${clipboard}" == *"No Editor Clipboard Test"* ]]
+}
+
+@test "create: piped content copies to clipboard" {
+    command -v pbpaste >/dev/null || skip "pbpaste not available"
+
+    echo "Piped Clipboard Title
+
+Body of piped pad." | "${PADZ_BIN}" -g create >/dev/null
+
+    local clipboard
+    clipboard=$(pbpaste)
+    [[ "${clipboard}" == *"Piped Clipboard Title"* ]]
+    [[ "${clipboard}" == *"Body of piped pad."* ]]
+}
+
+# -----------------------------------------------------------------------------
 # RESTORE
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Extract shared `edit_and_copy_pads` helper used by both `create` and `open` commands
- Refactor `create` to create the pad first, then open the **real file** in the editor (eliminating temp file pattern), matching `open`'s flow
- All three `create` paths (piped, `--no-editor`, interactive) now copy to clipboard
- Add unit test for `pad_paths` in create result; add 4 live tests for clipboard behavior across all create modes

## What changed
The `create` and `open` commands shared the same "open in editor, copy to clipboard" pattern but implemented it independently — `create` wrote to a temp file then created the pad from the result, while `open` edited pad files in-place. This divergence was the root cause of clipboard copy only working in `open` but not `create`.

Now `create` (interactive mode) does: `create_pad → edit_and_copy_pads → re-read file for metadata update`. The abort-on-empty behavior is preserved: if the user saves empty content, the pad file is removed (store self-heals via reconciliation).

## Test plan
- [x] All 357 padzapp unit tests pass (including new `create_returns_pad_path` test)
- [x] All 20 padz CLI tests pass
- [x] All 14 crud.bats live tests pass (including 4 new clipboard tests)
- [x] All 5 smoke.bats live tests pass
- [x] Pre-commit hooks pass (fmt, clippy, cargo check, cargo test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)