### PR TITLE
ci: add bats live-tests to pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,14 @@ jobs:
 
       - name: Run tests
         run: cargo test --all --locked
+
+      - name: Install bats
+        uses: bats-core/bats-action@4.0.0
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+
+      - name: Run live integration tests
+        run: live-tests/run-tests

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -48,4 +48,12 @@ cargo check --all-targets
 echo "🧪 Running cargo test..."
 cargo test --all
 
+# Run live integration tests (bats)
+if command -v bats &>/dev/null; then
+    echo "🧪 Running bats live-tests..."
+    "$(git rev-parse --show-toplevel)/live-tests/run-tests"
+else
+    echo "⚠️  bats not found, skipping live-tests (install with: brew install bats-core)"
+fi
+
 echo "✅ All pre-commit checks passed!"


### PR DESCRIPTION
## Summary
- Adds the 46-test bats integration suite (`live-tests/run-tests`) to the CI workflow, using `bats-core/bats-action@4.0.0`
- Adds the same suite to `scripts/pre-commit`, with a graceful skip if bats is not installed
- Clipboard tests correctly skip on Linux CI (guarded by `pbpaste` availability)

## Test plan
- [x] All 46 bats tests pass locally (macOS)
- [x] All 46 bats tests pass on CI (Ubuntu) — clipboard tests skipped as expected
- [x] Pre-commit hook runs bats suite end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)