### PR TITLE
feat: add ID arguments to list command

### DIFF
--- a/crates/padz/src/cli/complete.rs
+++ b/crates/padz/src/cli/complete.rs
@@ -36,7 +36,7 @@ fn get_pad_candidates(include_deleted: bool) -> Vec<CompletionCandidate> {
         tags: None,
     };
 
-    let Ok(result) = api.get_pads(ctx.scope, filter) else {
+    let Ok(result) = api.get_pads(ctx.scope, filter, &[] as &[String]) else {
         return vec![];
     };
 
@@ -94,7 +94,7 @@ pub fn deleted_pads_completer() -> ArgValueCandidates {
             tags: None,
         };
 
-        let Ok(result) = api.get_pads(ctx.scope, filter) else {
+        let Ok(result) = api.get_pads(ctx.scope, filter, &[] as &[String]) else {
             return vec![];
         };
 

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -157,7 +157,7 @@ impl<'a> ScopedApi<'a> {
             todo_status: Some(TodoStatus::Done),
             tags: None,
         };
-        let pads = self.call(|api, scope| api.get_pads(scope, filter))?;
+        let pads = self.call(|api, scope| api.get_pads(scope, filter, &[] as &[String]))?;
 
         if pads.listed_pads.is_empty() {
             return Ok(Output::Render(serde_json::json!({
@@ -309,8 +309,9 @@ impl<'a> ScopedApi<'a> {
         filter: PadFilter,
         peek: bool,
         show_deleted_help: bool,
+        ids: &[String],
     ) -> Result<Output<Value>, anyhow::Error> {
-        let result = self.call(|api, scope| api.get_pads(scope, filter))?;
+        let result = self.call(|api, scope| api.get_pads(scope, filter, ids))?;
         Ok(Output::Render(build_list_result_value(
             &result.listed_pads,
             peek,
@@ -462,6 +463,7 @@ pub fn create(
 #[handler]
 pub fn list(
     #[ctx] ctx: &CommandContext,
+    #[arg] ids: Vec<String>,
     #[arg] search: Option<String>,
     #[flag] deleted: bool,
     #[flag] peek: bool,
@@ -491,7 +493,7 @@ pub fn list(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, peek, deleted)
+    api(ctx).list_pads(filter, peek, deleted, &ids)
 }
 
 #[handler]
@@ -507,7 +509,7 @@ pub fn search(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, false, false)
+    api(ctx).list_pads(filter, false, false, &[])
 }
 
 // =============================================================================

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -182,6 +182,10 @@ pub enum Commands {
     #[command(alias = "ls", display_order = 2)]
     #[dispatch(pure)]
     List {
+        /// Pad IDs to show (e.g. 2, 3 5, 1-3)
+        #[arg(num_args = 0..)]
+        ids: Vec<String>,
+
         /// Search term
         #[arg(short, long)]
         search: Option<String>,

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -75,6 +75,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted.listed_pads.len(), 1);
@@ -97,7 +98,7 @@ mod tests {
         .unwrap();
 
         // Manually protect the pad (since pin command logic isn't coupled yet or might not be updated yet)
-        let pad_id = get::run(&store, Scope::Project, get::PadFilter::default())
+        let pad_id = get::run(&store, Scope::Project, get::PadFilter::default(), &[])
             .unwrap()
             .listed_pads[0]
             .pad
@@ -170,6 +171,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted.listed_pads.len(), 1);
@@ -209,7 +211,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Parent should still be active with no visible children
-        let active = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(active.listed_pads.len(), 1);
         assert_eq!(active.listed_pads[0].pad.metadata.title, "Parent");
         assert_eq!(active.listed_pads[0].children.len(), 0); // child is deleted

--- a/crates/padzapp/src/commands/pinning.rs
+++ b/crates/padzapp/src/commands/pinning.rs
@@ -98,7 +98,7 @@ mod tests {
         let sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
         pin(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        let result = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let result = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert!(result
             .listed_pads
             .iter()
@@ -113,7 +113,7 @@ mod tests {
         pin(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
         unpin(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        let result = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let result = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert!(result
             .listed_pads
             .iter()
@@ -134,7 +134,7 @@ mod tests {
         .unwrap();
 
         // Check if protected
-        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert!(pads.listed_pads[0].pad.metadata.delete_protected);
 
         // Try to delete (should fail)
@@ -155,7 +155,7 @@ mod tests {
         .unwrap();
 
         // Check is unprotected
-        let pads_after = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let pads_after = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert!(!pads_after.listed_pads[0].pad.metadata.delete_protected);
 
         // Try to delete (should succeed)
@@ -230,7 +230,7 @@ mod tests {
 
         pin(&mut store, Scope::Project, &selectors).unwrap();
 
-        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         // Both pads should be pinned.
         for dp in &pads.listed_pads {
             assert!(

--- a/crates/padzapp/src/commands/purge.rs
+++ b/crates/padzapp/src/commands/purge.rs
@@ -138,6 +138,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted.listed_pads.len(), 1);
@@ -167,6 +168,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted_after.listed_pads.len(), 0);
@@ -208,6 +210,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted.listed_pads.len(), 1);
@@ -234,7 +237,7 @@ mod tests {
             .any(|m| m.content.contains("Purged: 1 A")));
 
         // Verify gone
-        let listed = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(listed.listed_pads.len(), 0);
     }
 
@@ -250,7 +253,7 @@ mod tests {
         assert!(res.messages[0].content.contains("No pads to purge"));
 
         // A still exists
-        let listed = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(listed.listed_pads.len(), 1);
     }
 

--- a/crates/padzapp/src/commands/restore.rs
+++ b/crates/padzapp/src/commands/restore.rs
@@ -81,6 +81,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted.listed_pads.len(), 1);
@@ -109,7 +110,7 @@ mod tests {
         ));
 
         // Verify it's active again
-        let active = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(active.listed_pads.len(), 1);
         assert!(matches!(
             active.listed_pads[0].index,
@@ -124,6 +125,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted_after.listed_pads.len(), 0);
@@ -165,7 +167,7 @@ mod tests {
         assert_eq!(result.affected_pads.len(), 2);
 
         // Verify 2 active, 1 deleted
-        let active = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(active.listed_pads.len(), 2);
 
         let deleted = get::run(
@@ -175,6 +177,7 @@ mod tests {
                 status: get::PadStatusFilter::Deleted,
                 ..Default::default()
             },
+            &[],
         )
         .unwrap();
         assert_eq!(deleted.listed_pads.len(), 1);
@@ -189,7 +192,7 @@ mod tests {
         create::run(&mut store, Scope::Project, "Newer".into(), "".into(), None).unwrap();
 
         // Get original created_at of the older pad (which is now index 2 since newest first)
-        let original = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let original = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         let older_pad = original
             .listed_pads
             .iter()
@@ -213,7 +216,7 @@ mod tests {
         .unwrap();
 
         // Verify created_at is preserved
-        let after = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let after = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         let restored_pad = after
             .listed_pads
             .iter()
@@ -249,7 +252,7 @@ mod tests {
         .unwrap();
 
         // Verify parent and child are hidden from active view
-        let active = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(active.listed_pads.len(), 0);
 
         // Restore parent
@@ -261,7 +264,8 @@ mod tests {
         .unwrap();
 
         // Verify parent is active and child is visible again
-        let active_after = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let active_after =
+            get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(active_after.listed_pads.len(), 1);
         assert_eq!(active_after.listed_pads[0].pad.metadata.title, "Parent");
         assert_eq!(active_after.listed_pads[0].children.len(), 1);

--- a/crates/padzapp/src/commands/status.rs
+++ b/crates/padzapp/src/commands/status.rs
@@ -113,7 +113,7 @@ mod tests {
         // Should have affected pad
         assert_eq!(result.affected_pads.len(), 1);
 
-        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(pads.listed_pads[0].pad.metadata.status, TodoStatus::Done);
     }
 
@@ -134,7 +134,7 @@ mod tests {
         // Should have affected pad
         assert_eq!(result.affected_pads.len(), 1);
 
-        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(pads.listed_pads[0].pad.metadata.status, TodoStatus::Planned);
     }
 
@@ -191,7 +191,7 @@ mod tests {
         // Should have 2 affected pads
         assert_eq!(result.affected_pads.len(), 2);
 
-        let pads = get::run(&store, Scope::Project, get::PadFilter::default()).unwrap();
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert!(pads
             .listed_pads
             .iter()

--- a/crates/padzapp/src/commands/update.rs
+++ b/crates/padzapp/src/commands/update.rs
@@ -220,7 +220,7 @@ mod tests {
         assert!(res.messages.iter().any(|m| m.content.contains("B Updated")));
 
         // Check store state
-        let pads = get::run(&store, Scope::Project, get::PadFilter::default())
+        let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[])
             .unwrap()
             .listed_pads;
         let pad_a = pads


### PR DESCRIPTION
## Summary
- Adds optional positional ID arguments to `padz list` so users can filter which pads are displayed: `padz list 2`, `padz list 3 5`, `padz list 1-3`
- Selected pads are shown with their full subtree of children, making it easy to focus on a single pad and its nested items
- Uses the existing `parse_selectors` infrastructure (paths, ranges, title search) for ID resolution

## Details

The primary use case is inspecting nested pads:

```
padz list 3
```
Shows only pad 3 and its children, instead of the full list.

ID filtering composes with existing filters (`--planned`, `--tag`, `--search`, `--deleted`), applied after ID selection.

### Files changed
- **setup.rs**: Added `ids: Vec<String>` positional arg to `List` command
- **handlers.rs**: Threads IDs through handler → ScopedApi → API
- **api.rs**: Parses ID strings into `PadSelector`s via existing `parse_selectors`
- **get.rs**: Core `filter_by_selectors` logic that linearizes the tree, resolves selectors, and extracts matched pads with full subtrees
- **Other command test files**: Updated `get::run` call sites for new signature

## Test plan
- [x] 6 new unit tests: single pad, multiple pads, pads with children, ranges, not-found error, index preservation
- [x] All 27 get module tests pass
- [x] Full test suite passes (pre-commit hook: fmt, clippy, check, test)
- [ ] Manual: `padz list 2` shows pad 2 and its children
- [ ] Manual: `padz list 1-3` shows pads 1 through 3
- [ ] Manual: `padz list` (no args) still shows all pads

🤖 Generated with [Claude Code](https://claude.com/claude-code)