### PR TITLE
feat: add peek command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **Peek command** - `padz peek` / `padz peek 2 3` shows pad listing with content previews. Shortcut for `padz list --peek`, supports ID filtering and tag filtering.
+
 ## [0.17.0] - 2026-02-10
 
 ## [0.17.0] - 2026-02-10

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -497,6 +497,21 @@ pub fn list(
 }
 
 #[handler]
+pub fn peek(
+    #[ctx] ctx: &CommandContext,
+    #[arg] ids: Vec<String>,
+    #[arg] tags: Vec<String>,
+) -> Result<Output<Value>, anyhow::Error> {
+    let filter = PadFilter {
+        status: PadStatusFilter::Active,
+        search_term: None,
+        todo_status: None,
+        tags: if tags.is_empty() { None } else { Some(tags) },
+    };
+    api(ctx).list_pads(filter, true, false, &ids)
+}
+
+#[handler]
 pub fn search(
     #[ctx] ctx: &CommandContext,
     #[arg] term: String,

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -227,6 +227,19 @@ pub enum Commands {
         tags: Vec<String>,
     },
 
+    /// Peek at pad content previews
+    #[command(alias = "pk", display_order = 4)]
+    #[dispatch(pure, template = "list")]
+    Peek {
+        /// Pad IDs to show (e.g. 2, 3 5, 1-3)
+        #[arg(num_args = 0..)]
+        ids: Vec<String>,
+
+        /// Filter by tag(s) (can be specified multiple times, uses AND logic)
+        #[arg(long = "tag", short = 't', num_args = 1..)]
+        tags: Vec<String>,
+    },
+
     // --- Pad operations ---
     /// View one or more pads
     #[command(alias = "v", display_order = 10)]


### PR DESCRIPTION
## Summary
- Add `padz peek` command as a shortcut for `padz list --peek`
- Supports ID filtering (`padz peek 2 3`, `padz peek 1-3`) and tag filtering (`padz peek -t mytag`)
- Thin handler that delegates to existing `list_pads` with `peek=true` — no new rendering or API code

## Test plan
- [x] `cargo build` compiles
- [x] All 410 tests pass
- [ ] Manual: `padz peek` shows all pads with content preview
- [ ] Manual: `padz peek 2 3` shows specific pads with preview
- [ ] Manual: `padz pk` alias works

🤖 Generated with [Claude Code](https://claude.com/claude-code)