### PR TITLE
Fix pinned list layout and compact timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Changed**
+  - **Compact timestamps** - List timestamps now use compact format (` 3d ⏲`, `23h ⏲`) instead of verbose (`3 days ago`), reclaiming ~9 chars for title display. Removed `timeago` dependency.
+  - **Unified pin marker position** - Pin marker `⚲` now appears in the left column (col 0) for both pinned and regular sections, instead of appearing on the right side in the regular list
+  - **Fixed pinned section indentation** - Children of pinned pads now indent correctly, matching the regular list layout. Removed the `right_pin` column.
+
 ## [0.18.0] - 2026-02-10
 
 ## [0.18.0] - 2026-02-10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,6 @@ dependencies = [
  "standout-dispatch",
  "standout-input",
  "standout-macros",
- "timeago",
  "unicode-width",
 ]
 

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -28,7 +28,6 @@ standout-input = "6.0.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-timeago = "0.4"
 unicode-width = "0.2.2"
 anyhow = "1.0"
 

--- a/crates/padz/src/cli/templates/_pad_line.jinja
+++ b/crates/padz/src/cli/templates/_pad_line.jinja
@@ -29,7 +29,6 @@
     {"name": "status", "width": col_status, "style": "status-icon"},
     {"name": "index", "width": col_index, "style": index_style},
     {"name": "title", "width": pad.title_width, "overflow": "truncate", "style": title_style},
-    {"name": "right_pin", "width": col_right_pin, "style": "pinned"},
     {"name": "time", "width": col_time, "align": "right", "style": "time"}
 ]) -%}
 
@@ -41,7 +40,6 @@
     pad.status_icon,
     pad.index,
     pad.title ~ tags_str,
-    pad.right_pin,
     pad.time_ago
 ]) -}}
 {{ "" | nl -}}


### PR DESCRIPTION
## Summary
- **Fix pinned section indentation** — children of pinned pads now indent correctly, matching the regular list layout (was broken by `depth.saturating_sub(1)`)
- **Unify pin marker position** — `⚲` now appears in the left column for both pinned and regular sections (removes `right_pin` column)
- **Compact timestamps** — replaces verbose `3 days ago` with ` 3d ⏲`, reclaiming ~9 chars for title display and removing the `timeago` dependency

## Test plan
- [x] All 393 existing tests pass
- [x] Updated `test_format_time_ago_compact` covers all time units
- [x] Updated `test_build_list_pinned_in_regular_section_shows_left_pin`
- [ ] Visual check: `padz list` with pinned pads shows correct indentation and left-aligned pin markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)