### PR TITLE
feat: add todo mode toggle (notes vs todos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **Todo mode toggle** - New `mode` config (`notes` | `todos`, default `notes`) that adapts padz for note-taking or task management:
+    - **Display**: Todos mode shows status icons (⚪︎ ☉︎︎ ⚫︎); notes mode hides them and gives more title width
+    - **Quick-create**: In todos mode, `padz create Buy Milk` skips the editor; supports `\n` for multi-line (`padz create 'Buy Groceries\nMilk\nEggs'`)
+    - **Quick-edit**: In todos mode, `padz edit 1 Updated Title` updates directly without opening the editor
+    - **Purge**: In todos mode, `padz purge` removes both Done and Deleted pads; in notes mode only Deleted
+
 - **Changed**
   - **Compact timestamps** - List timestamps now use compact format (` 3d ⏲`, `23h ⏲`) instead of verbose (`3 days ago`), reclaiming ~9 chars for title display. Removed `timeago` dependency.
   - **Unified pin marker position** - Pin marker `⚲` now appears in the left column (col 0) for both pinned and regular sections, instead of appearing on the right side in the regular list

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -182,10 +182,14 @@ fn handle_config(cli: &Cli, subcommand: &Option<ConfigSubcommand>) -> Result<()>
             output: file.clone(),
         },
         Some(ConfigSubcommand::Get { key }) => ConfigAction::Get { key: key.clone() },
-        Some(ConfigSubcommand::Set { key, value }) => ConfigAction::Set {
-            key: key.clone(),
-            value: value.clone(),
-        },
+        Some(ConfigSubcommand::Set { key, value }) => {
+            // Validate enum fields before writing (clapfig doesn't validate on set yet)
+            validate_config_value(key, value)?;
+            ConfigAction::Set {
+                key: key.clone(),
+                value: value.clone(),
+            }
+        }
     };
 
     Clapfig::builder::<PadzConfig>()
@@ -197,6 +201,21 @@ fn handle_config(cli: &Cli, subcommand: &Option<ConfigSubcommand>) -> Result<()>
         .handle_and_print(&action)
         .map_err(|e| padzapp::error::PadzError::Api(e.to_string()))?;
 
+    Ok(())
+}
+
+/// Validate config values for fields with restricted choices.
+/// Workaround until clapfig validates on set (https://github.com/arthur-debert/clapfig/issues/9).
+fn validate_config_value(key: &str, value: &str) -> Result<()> {
+    if key == "mode" {
+        let json = format!("\"{}\"", value);
+        if serde_json::from_str::<padzapp::config::PadzMode>(&json).is_err() {
+            return Err(padzapp::error::PadzError::Api(format!(
+                "invalid value \"{}\" for key \"mode\". Valid values: notes, todos",
+                value
+            )));
+        }
+    }
     Ok(())
 }
 

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -125,6 +125,7 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
         scope,
         padz_ctx.config.import_extensions(),
         output_mode,
+        padz_ctx.config.mode,
     ))
 }
 

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -229,9 +229,17 @@ impl<S: DataStore> PadzApi<S> {
         indexes: &[I],
         recursive: bool,
         confirmed: bool,
+        include_done: bool,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        commands::purge::run(&mut self.store, scope, &selectors, recursive, confirmed)
+        commands::purge::run(
+            &mut self.store,
+            scope,
+            &selectors,
+            recursive,
+            confirmed,
+            include_done,
+        )
     }
 
     pub fn restore_pads<I: AsRef<str>>(
@@ -663,7 +671,7 @@ mod tests {
         api.delete_pads(Scope::Project, &["1"]).unwrap();
 
         // Purge with confirmed=true should succeed
-        let result = api.purge_pads(Scope::Project, &["d1"], false, true);
+        let result = api.purge_pads(Scope::Project, &["d1"], false, true, false);
         assert!(result.is_ok());
 
         // Verify it's gone from the store
@@ -690,7 +698,7 @@ mod tests {
         api.delete_pads(Scope::Project, &["1"]).unwrap();
 
         // Purge with confirmed=false should fail
-        let result = api.purge_pads(Scope::Project, &["d1"], false, false);
+        let result = api.purge_pads(Scope::Project, &["d1"], false, false, false);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("Aborted"));

--- a/crates/padzapp/src/config.rs
+++ b/crates/padzapp/src/config.rs
@@ -17,6 +17,7 @@
 //! |-----|---------|-------------|
 //! | `file_ext` | `txt` | Extension for new pad files (e.g., `md`, `txt`) |
 //! | `import_extensions` | `["md", "txt", "text", "lex"]` | Extensions for `padz import` |
+//! | `mode` | `notes` | UI mode: `notes` (clean) or `todos` (status icons, quick-create) |
 //!
 //! ## Extension Convention
 //!
@@ -42,6 +43,32 @@ fn strip_leading_dot<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error
     Ok(s.strip_prefix('.').unwrap_or(&s).to_string())
 }
 
+/// UI mode controlling display and editor behavior.
+///
+/// - **Notes**: Clean note-taking — status icons hidden, editor always opens.
+/// - **Todos**: Task management — status icons shown, quick-create/edit from CLI args.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PadzMode {
+    Notes,
+    Todos,
+}
+
+impl Default for PadzMode {
+    fn default() -> Self {
+        Self::Notes
+    }
+}
+
+impl std::fmt::Display for PadzMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PadzMode::Notes => write!(f, "notes"),
+            PadzMode::Todos => write!(f, "todos"),
+        }
+    }
+}
+
 fn default_import_ext() -> Vec<String> {
     vec![
         "md".to_string(),
@@ -64,6 +91,11 @@ pub struct PadzConfig {
     /// Stored without leading dots; use import_extensions() for the dotted form.
     /// When absent, defaults to ["md", "txt", "text", "lex"].
     pub import_extensions: Option<Vec<String>>,
+
+    /// UI mode: "notes" for clean note-taking, "todos" for task management.
+    #[config(default = "notes")]
+    #[serde(default)]
+    pub mode: PadzMode,
 }
 
 impl Default for PadzConfig {
@@ -71,6 +103,7 @@ impl Default for PadzConfig {
         Self {
             file_ext: "txt".to_string(),
             import_extensions: None,
+            mode: PadzMode::default(),
         }
     }
 }
@@ -173,5 +206,51 @@ mod tests {
         let toml_str = r#"file_ext = "md""#;
         let config: PadzConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.file_ext, "md");
+    }
+
+    #[test]
+    fn test_default_mode_is_notes() {
+        let config = PadzConfig::default();
+        assert_eq!(config.mode, PadzMode::Notes);
+    }
+
+    #[test]
+    fn test_mode_deserialize_notes() {
+        let toml_str = "file_ext = \"txt\"\nmode = \"notes\"";
+        let config: PadzConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mode, PadzMode::Notes);
+    }
+
+    #[test]
+    fn test_mode_deserialize_todos() {
+        let toml_str = "file_ext = \"txt\"\nmode = \"todos\"";
+        let config: PadzConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mode, PadzMode::Todos);
+    }
+
+    #[test]
+    fn test_mode_defaults_when_absent() {
+        let toml_str = r#"file_ext = "txt""#;
+        let config: PadzConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mode, PadzMode::Notes);
+    }
+
+    #[test]
+    fn test_mode_serialize_roundtrip() {
+        let config = PadzConfig {
+            mode: PadzMode::Todos,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&config).unwrap();
+        assert!(toml_str.contains(r#"mode = "todos""#));
+
+        let parsed: PadzConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.mode, PadzMode::Todos);
+    }
+
+    #[test]
+    fn test_mode_display() {
+        assert_eq!(PadzMode::Notes.to_string(), "notes");
+        assert_eq!(PadzMode::Todos.to_string(), "todos");
     }
 }

--- a/live-tests/tests/mode.bats
+++ b/live-tests/tests/mode.bats
@@ -1,0 +1,283 @@
+#!/usr/bin/env bats
+# =============================================================================
+# MODE TOGGLE TESTS (notes vs todos)
+# =============================================================================
+# Tests the mode configuration and its effects on:
+#   - Display: status icons shown/hidden
+#   - Create: quick-create in todos mode (skip editor)
+#   - Edit: quick-edit in todos mode (skip editor)
+#   - Purge: includes Done pads in todos mode
+#
+# Each test sets mode explicitly to avoid depending on fixture state.
+# =============================================================================
+
+load '../lib/helpers.bash'
+load '../lib/assertions.bash'
+
+# -----------------------------------------------------------------------------
+# CONFIG: mode round-trip
+# -----------------------------------------------------------------------------
+
+@test "mode: default mode is notes" {
+    run "${PADZ_BIN}" -g config get mode
+    assert_success
+    [[ "$output" == *"notes"* ]]
+}
+
+@test "mode: can set mode to todos" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    run "${PADZ_BIN}" -g config get mode
+    assert_success
+    [[ "$output" == *"todos"* ]]
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: can set mode back to notes" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    run "${PADZ_BIN}" -g config get mode
+    assert_success
+    [[ "$output" == *"notes"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# DISPLAY: status icons
+# -----------------------------------------------------------------------------
+
+@test "mode: notes mode hides status icons in list" {
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    "${PADZ_BIN}" -g create --no-editor "Notes Display Test" >/dev/null
+
+    run "${PADZ_BIN}" -g list
+    assert_success
+
+    # Status icons should NOT appear in notes mode
+    [[ "$output" != *"⚪︎"* ]]
+    [[ "$output" != *"☉︎︎"* ]]
+    [[ "$output" != *"⚫︎"* ]]
+}
+
+@test "mode: todos mode shows status icons in list" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    "${PADZ_BIN}" -g create --no-editor "Todos Display Test" >/dev/null
+
+    run "${PADZ_BIN}" -g list
+    assert_success
+
+    # Status icons should appear in todos mode (at least one Planned icon)
+    [[ "$output" == *"⚪︎"* ]]
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# CREATE: quick-create in todos mode
+# -----------------------------------------------------------------------------
+
+@test "mode: todos quick-create with quoted args" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    # In todos mode, title args skip editor
+    run "${PADZ_BIN}" -g create "Quick Create Test"
+    assert_success
+
+    assert_pad_exists "Quick Create Test" global
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: todos quick-create with unquoted args" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    # Multiple unquoted words joined as title
+    run "${PADZ_BIN}" -g create Call Mom Tomorrow
+    assert_success
+
+    assert_pad_exists "Call Mom Tomorrow" global
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: todos quick-create with newline escape" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    # Literal \n should be converted to newline (title becomes first line)
+    run "${PADZ_BIN}" -g create 'Buy Groceries\nMilk\nEggs'
+    assert_success
+
+    assert_pad_exists "Buy Groceries" global
+
+    # Content should include the body (look up by title to avoid index collisions with pinned pads)
+    local content
+    content=$("${PADZ_BIN}" -g list --output json 2>/dev/null | jq -r --arg t "Buy Groceries" 'first(.pads[] | select(.pad.metadata.title == $t)) | .pad.content')
+    [[ "$content" == *"Milk"* ]]
+    [[ "$content" == *"Eggs"* ]]
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: todos create with no args still opens editor (EDITOR=true returns empty)" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    # No args → should open editor. EDITOR=true exits immediately with empty.
+    # This should abort with empty content warning.
+    run "${PADZ_BIN}" -g create
+    # Either success with warning or failure is acceptable
+    # The key point: it should NOT create an "Untitled" pad silently
+    # (that's the --no-editor behavior, not the no-args behavior)
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: notes create with args still opens editor (EDITOR=true returns empty)" {
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+
+    # In notes mode, providing a title should still try to open editor
+    # EDITOR=true exits immediately → empty → aborts
+    run "${PADZ_BIN}" -g create "Should Open Editor"
+
+    # The pad should NOT exist (editor was opened and returned empty)
+    # because notes mode always opens editor, and EDITOR=true produces empty
+    if pad_exists "Should Open Editor" global; then
+        echo "FAIL: In notes mode, create with args should open editor, not quick-create" >&2
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# EDIT: quick-edit in todos mode
+# -----------------------------------------------------------------------------
+
+@test "mode: todos quick-edit with content args" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    "${PADZ_BIN}" -g create "Original Todo Title" >/dev/null
+
+    local index
+    index=$(find_pad_by_title "Original Todo Title" global)
+
+    # In todos mode, content after index updates directly
+    run "${PADZ_BIN}" -g edit "${index}" "Updated Todo Title"
+    assert_success
+
+    assert_pad_exists "Updated Todo Title" global
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: todos quick-edit with multiple word args" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    "${PADZ_BIN}" -g create "Edit Multi Word Test" >/dev/null
+
+    local index
+    index=$(find_pad_by_title "Edit Multi Word Test" global)
+
+    # Multiple words after index become the new content
+    run "${PADZ_BIN}" -g edit "${index}" Call Mom Before Dinner
+    assert_success
+
+    assert_pad_exists "Call Mom Before Dinner" global
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# PURGE: todos mode includes Done pads
+# -----------------------------------------------------------------------------
+
+@test "mode: todos purge removes done pads" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    "${PADZ_BIN}" -g create "Purge Done Test" >/dev/null
+    local index
+    index=$(find_pad_by_title "Purge Done Test" global)
+    "${PADZ_BIN}" -g complete "${index}" >/dev/null
+
+    # Verify it's done (look up by title to avoid index collisions with pinned pads)
+    local status
+    status=$("${PADZ_BIN}" -g list --output json 2>/dev/null | jq -r --arg t "Purge Done Test" 'first(.pads[] | select(.pad.metadata.title == $t)) | .pad.metadata.status')
+    [[ "$status" == "Done" ]]
+
+    # Purge should target Done pads in todos mode
+    run "${PADZ_BIN}" -g purge --yes
+    assert_success
+
+    # The Done pad should be gone
+    assert_pad_not_exists "Purge Done Test" global
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: notes purge does NOT remove done pads" {
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+
+    "${PADZ_BIN}" -g create --no-editor "Notes Purge Done Test" >/dev/null
+    local index
+    index=$(find_pad_by_title "Notes Purge Done Test" global)
+    "${PADZ_BIN}" -g complete "${index}" >/dev/null
+
+    # Purge in notes mode should only target deleted pads, not done ones
+    run "${PADZ_BIN}" -g purge --yes
+    assert_success
+
+    # The Done pad should STILL exist
+    assert_pad_exists "Notes Purge Done Test" global
+}
+
+@test "mode: todos purge removes both done and deleted" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    "${PADZ_BIN}" -g create "Purge Both Done" >/dev/null
+    "${PADZ_BIN}" -g create "Purge Both Deleted" >/dev/null
+    "${PADZ_BIN}" -g create "Purge Both Keep" >/dev/null
+
+    # Complete "Purge Both Done"
+    local done_idx
+    done_idx=$(find_pad_by_title "Purge Both Done" global)
+    "${PADZ_BIN}" -g complete "${done_idx}" >/dev/null
+
+    # Delete "Purge Both Deleted"
+    local del_idx
+    del_idx=$(find_pad_by_title "Purge Both Deleted" global)
+    "${PADZ_BIN}" -g delete "${del_idx}" >/dev/null
+
+    # Purge should remove both Done and Deleted
+    run "${PADZ_BIN}" -g purge --yes
+    assert_success
+
+    # Only "Purge Both Keep" should remain
+    assert_pad_exists "Purge Both Keep" global
+    assert_pad_not_exists "Purge Both Done" global
+    assert_pad_not_exists "Purge Both Deleted" global
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# MODE SWITCHING: data preservation
+# -----------------------------------------------------------------------------
+
+@test "mode: switching modes preserves existing pads" {
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    "${PADZ_BIN}" -g create --no-editor "Mode Switch Test Pad" >/dev/null
+
+    assert_pad_exists "Mode Switch Test Pad" global
+
+    # Switch to todos
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    assert_pad_exists "Mode Switch Test Pad" global
+
+    # Switch back to notes
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    assert_pad_exists "Mode Switch Test Pad" global
+}


### PR DESCRIPTION
## Summary

- Adds a `mode` config (`notes` | `todos`, default `notes`) that controls display, create/edit, and purge behavior
- **Display**: todos mode shows status icons (⚪︎ ☉︎︎ ⚫︎); notes mode hides them and gives more title width
- **Create/Edit**: todos mode enables quick-create/edit from CLI args (skip editor); notes mode always opens editor
- **Purge**: todos mode removes both Done and Deleted pads; notes mode only removes Deleted

## Changes

- `PadzMode` enum + config field in `padzapp/config.rs`
- Mode threaded through `AppState` → handlers → render
- `split_indexes_and_content()` helper for quick-edit arg parsing
- `include_done` parameter added to purge command pipeline
- 16 new e2e bats tests in `live-tests/tests/mode.bats`
- Unit tests for config, display, and purge mode behavior

## Test plan

- [x] All 418 unit tests pass (`cargo test --workspace`)
- [x] All 62 e2e bats tests pass (`live-tests/run-tests`)
- [x] Pre-commit hooks pass (fmt, clippy, check, test)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)