### PR TITLE
Upgrade clapfig to 0.9.2 with multi-scope config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clapfig"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03991fbd0183597a3bfe1888ea48326b73909f1c0c7660d76cb40eefdaed395e"
+checksum = "494de2baa82679797a71471207275cdd98ccb8ae64be9031a3006fb6981f0858"
 dependencies = [
  "clap",
  "confique",

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 padzapp = { version = "0.19.0", path = "../padzapp" }
 chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.53", features = ["derive"] }
-clapfig = "0.8"
+clapfig = "0.9.2"
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 console = "0.15"
 directories = "6.0.0"

--- a/crates/padzapp/Cargo.toml
+++ b/crates/padzapp/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 chrono = { version = "0.4.42", features = ["serde"] }
-clapfig = { version = "0.8", default-features = false }
+clapfig = { version = "0.9.2", default-features = false }
 confique = { version = "0.4", features = ["toml"] }
 directories = "6.0.0"
 flate2 = "1.1.5"

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -180,10 +180,10 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
         Scope::Project
     };
 
-    // Build search paths based on scope:
-    // - Global scope: only Platform directory
-    // - Project scope: Platform (lower priority) then project dir (higher priority)
-    let search_paths = if use_global {
+    // Config search paths depend on scope:
+    // - Global: only global dir (project config must not affect global operations)
+    // - Project: both dirs merged (global provides defaults, project overrides)
+    let config_search_paths = if use_global {
         vec![SearchPath::Path(global_data_dir.clone())]
     } else {
         vec![
@@ -195,8 +195,8 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
     let config: PadzConfig = Clapfig::builder()
         .app_name("padz")
         .file_name("padz.toml")
-        .search_paths(search_paths)
-        .search_mode(SearchMode::FirstMatch)
+        .search_paths(config_search_paths)
+        .search_mode(SearchMode::Merge)
         .load()
         .unwrap_or_default();
     let file_ext = config.file_ext();

--- a/live-tests/tests/config-scopes.bats
+++ b/live-tests/tests/config-scopes.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# =============================================================================
+# CONFIG SCOPES TESTS (global + local layering)
+# =============================================================================
+# Tests the multi-scope config system:
+#   - Writing to local (project) vs global scope
+#   - Merged reads (global defaults + local overrides)
+#   - Scoped reads with -g
+#   - Config layering: local overrides global
+#   - Validation still works via clapfig
+# =============================================================================
+
+load '../lib/helpers.bash'
+load '../lib/assertions.bash'
+
+# -----------------------------------------------------------------------------
+# SETUP / TEARDOWN
+# -----------------------------------------------------------------------------
+
+setup() {
+    cd "${PROJECT_A}"
+    # Clean any leftover config files from previous tests
+    rm -f "${PROJECT_A}/.padz/padz.toml"
+    rm -f "${PADZ_GLOBAL_DATA}/padz.toml"
+}
+
+teardown() {
+    rm -f "${PROJECT_A}/.padz/padz.toml"
+    rm -f "${PADZ_GLOBAL_DATA}/padz.toml"
+}
+
+# -----------------------------------------------------------------------------
+# WRITE SCOPE: -g writes to global, default writes to local
+# -----------------------------------------------------------------------------
+
+@test "config: set without -g writes to project config" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Project config file should exist with the value
+    [[ -f "${PROJECT_A}/.padz/padz.toml" ]]
+    run cat "${PROJECT_A}/.padz/padz.toml"
+    [[ "$output" == *'mode = "todos"'* ]]
+
+    # Global config should NOT have been written
+    [[ ! -f "${PADZ_GLOBAL_DATA}/padz.toml" ]]
+}
+
+@test "config: set with -g writes to global config" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    # Global config file should exist with the value
+    [[ -f "${PADZ_GLOBAL_DATA}/padz.toml" ]]
+    run cat "${PADZ_GLOBAL_DATA}/padz.toml"
+    [[ "$output" == *'mode = "todos"'* ]]
+
+    # Project config should NOT have been written
+    [[ ! -f "${PROJECT_A}/.padz/padz.toml" ]]
+}
+
+# -----------------------------------------------------------------------------
+# READ SCOPE: merged view vs scoped view
+# -----------------------------------------------------------------------------
+
+@test "config: get without -g shows merged value (local overrides global)" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Merged read should show local override
+    run "${PADZ_BIN}" config get mode
+    assert_success
+    [[ "$output" == *"todos"* ]]
+}
+
+@test "config: get with -g shows only global value" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Scoped read should show global value
+    run "${PADZ_BIN}" -g config get mode
+    assert_success
+    [[ "$output" == *"notes"* ]]
+}
+
+@test "config: list without -g shows merged config" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set file_ext md >/dev/null
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Merged list should show both values
+    run "${PADZ_BIN}" config list
+    assert_success
+    [[ "$output" == *"todos"* ]]
+    [[ "$output" == *"md"* ]]
+}
+
+@test "config: list with -g shows only global entries" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set file_ext md >/dev/null
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Scoped list should only show global entries
+    run "${PADZ_BIN}" -g config list
+    assert_success
+    [[ "$output" == *"md"* ]]
+    [[ "$output" != *"todos"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# LAYERING: local overrides global, global provides defaults
+# -----------------------------------------------------------------------------
+
+@test "config: local value overrides global for same key" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Effective config should use local override
+    run "${PADZ_BIN}" config get mode
+    assert_success
+    [[ "$output" == *"todos"* ]]
+}
+
+@test "config: global value used when local has no override" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+    # No local config set
+
+    # Should fall back to global
+    run "${PADZ_BIN}" config get mode
+    assert_success
+    [[ "$output" == *"todos"* ]]
+}
+
+@test "config: different keys from each scope merge together" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" -g config set file_ext md >/dev/null
+    "${PADZ_BIN}" config set mode todos >/dev/null
+
+    # Both should be visible in merged view
+    run "${PADZ_BIN}" config list
+    assert_success
+    [[ "$output" == *"md"* ]]
+    [[ "$output" == *"todos"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# VALIDATION: clapfig validates on set
+# -----------------------------------------------------------------------------
+
+@test "config: invalid mode value is rejected" {
+    cd "${PROJECT_A}"
+    run "${PADZ_BIN}" config set mode garbage
+    assert_failure
+}
+
+@test "config: valid mode values are accepted" {
+    cd "${PROJECT_A}"
+    run "${PADZ_BIN}" config set mode todos
+    assert_success
+    run "${PADZ_BIN}" config set mode notes
+    assert_success
+}

--- a/live-tests/tests/mode.bats
+++ b/live-tests/tests/mode.bats
@@ -19,7 +19,10 @@ load '../lib/assertions.bash'
 # -----------------------------------------------------------------------------
 
 @test "mode: default mode is notes" {
-    run "${PADZ_BIN}" -g config get mode
+    # Use merged view from a clean project (no config files yet)
+    # Scoped -g reads only the raw global file which may not exist yet
+    cd "${PROJECT_A}"
+    run "${PADZ_BIN}" config get mode
     assert_success
     [[ "$output" == *"notes"* ]]
 }


### PR DESCRIPTION
## Summary

- Upgrade clapfig from 0.8 to 0.9.2, adopting multi-scope persist for global/local config
- Remove manual `validate_config_value` workaround — clapfig now validates enum fields on `config set` (clapfig#9)
- Register named "local" and "global" persist scopes, mapping the existing `-g` flag to clapfig's scope parameter
- Switch project-scope config from `FirstMatch` to `Merge` mode — global config now provides defaults that project config selectively overrides

## Test plan

- [x] `cargo test` — 417 unit tests pass
- [x] `live-tests/run-tests` — all 73 bats tests pass (11 new config-scope tests)
- [x] New `config-scopes.bats` covers: write isolation (local vs global), merged reads, scoped reads with `-g`, layering (local overrides global), and clapfig validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)