### PR TITLE
feat: edit real pad files instead of temp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Changed**
+  - **Editor opens real pad files** - Create and edit now open the actual pad file in `.padz/` instead of a temporary file in `/tmp`. This means:
+    - **Crash resilience**: If the editor or system crashes, content is preserved on disk and recovered automatically by reconciliation
+    - **Path autocomplete**: Editor autocomplete suggests project-relative paths (e.g., `../README.md`) instead of `/tmp` files
+    - **No temp file dependency**: Removed `standout-input` dependency from the CLI crate
+  - **Fixed double-title bug in edit** - The edit handler no longer duplicates the title in the editor buffer (`Title\n\nTitle\n\nBody` → `Title\n\nBody`)
+
 ## [0.19.0] - 2026-02-13
 
 ## [0.19.0] - 2026-02-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,12 +704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,12 +729,6 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1287,7 +1275,6 @@ dependencies = [
  "serde_yaml",
  "standout",
  "standout-dispatch",
- "standout-input",
  "standout-macros",
  "unicode-width",
 ]
@@ -1792,12 +1779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,19 +1873,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "standout-input"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7afd58822a46c4e996ea30f6a0bfedddddf7b28e917aab16eeb115785899c5a2"
-dependencies = [
- "clap",
- "shell-words",
- "tempfile",
- "thiserror 2.0.17",
- "which",
 ]
 
 [[package]]
@@ -2356,18 +2324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
-dependencies = [
- "either",
- "env_home",
- "rustix 1.1.2",
- "winsafe",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,12 +2652,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -26,7 +26,6 @@ once_cell = "1.19"
 standout = "6.1.0"
 standout-macros = "6.1.0"
 standout-dispatch = "6.1.0"
-standout-input = "6.1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/live-tests/tests/editor-flow.bats
+++ b/live-tests/tests/editor-flow.bats
@@ -1,0 +1,201 @@
+#!/usr/bin/env bats
+# =============================================================================
+# EDITOR FLOW / DATA DIR TESTS
+# =============================================================================
+# Tests that pad files live in the .padz/ data dir (not /tmp), and that
+# reconciliation correctly handles external file modifications.
+#
+# NOTE: Interactive editor tests cannot run in bats because stdin is not a
+# terminal. The editor path is tested by creating pads and then modifying
+# their files directly to simulate what an editor would do, then verifying
+# reconciliation picks up the changes.
+#
+# TEST GUIDELINES
+# ---------------
+# 1. Each test should verify ONE specific behavior
+# 2. Use helpers (get_pad_title, etc.) instead of grep
+# 3. Use assertions for clear failure messages
+# =============================================================================
+
+load '../lib/helpers.bash'
+load '../lib/assertions.bash'
+load '../lib/backdoors.bash'
+
+# Setup: Create fresh isolated environment for each test
+setup() {
+    TEST_TEMP_DIR=$(mktemp -d)
+    export PADZ_GLOBAL_DATA="${TEST_TEMP_DIR}/global-data"
+    mkdir -p "${PADZ_GLOBAL_DATA}"
+}
+
+# Teardown: Clean up after each test
+teardown() {
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+# -----------------------------------------------------------------------------
+# PAD FILES LIVE IN DATA DIR
+# -----------------------------------------------------------------------------
+
+@test "pad files are stored in data dir" {
+    "${PADZ_BIN}" -g create --no-editor "Data Dir Test" >/dev/null
+
+    # Verify there's a pad-*.txt file in the data dir
+    local pad_count
+    pad_count=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | wc -l | tr -d ' ')
+    [[ "${pad_count}" -gt 0 ]]
+}
+
+@test "pad file uses pad-uuid.txt naming" {
+    "${PADZ_BIN}" -g create --no-editor "Naming Test" >/dev/null
+
+    local pad_file
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    local filename
+    filename=$(basename "${pad_file}")
+
+    # Should match pad-{uuid}.txt pattern
+    [[ "${filename}" =~ ^pad-[0-9a-f-]+\.txt$ ]]
+}
+
+@test "pad file content matches pad content" {
+    "${PADZ_BIN}" -g create --no-editor "Content Match" >/dev/null
+
+    local pad_file
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    local file_content
+    file_content=$(cat "${pad_file}")
+
+    # File should contain the title
+    [[ "${file_content}" == *"Content Match"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# RECONCILIATION: EXTERNAL FILE EDITS
+# (simulates what happens after editor modifies a file)
+# -----------------------------------------------------------------------------
+
+@test "reconciliation picks up title change in file" {
+    "${PADZ_BIN}" -g create --no-editor "Original Title" >/dev/null
+
+    # Find the pad file and change its content (simulating editor)
+    local pad_file
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+
+    # Write new content with different title
+    printf 'Changed Title\n\nNew body content' > "${pad_file}"
+
+    # Touch the file to ensure mtime is newer (triggers staleness detection)
+    touch -t "$(date -v+1H '+%Y%m%d%H%M.%S')" "${pad_file}" 2>/dev/null || \
+    touch -d '+1 hour' "${pad_file}" 2>/dev/null || \
+    sleep 1  # fallback: just wait
+
+    # List triggers reconciliation which picks up file changes
+    assert_pad_exists "Changed Title" global
+}
+
+@test "reconciliation removes empty files" {
+    "${PADZ_BIN}" -g create --no-editor "Will Be Empty" >/dev/null
+    assert_pad_exists "Will Be Empty" global
+
+    # Empty the pad file (simulating editor clearing content)
+    local pad_file
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    truncate -s 0 "${pad_file}"
+
+    # Touch to ensure mtime is newer
+    touch -t "$(date -v+1H '+%Y%m%d%H%M.%S')" "${pad_file}" 2>/dev/null || \
+    touch -d '+1 hour' "${pad_file}" 2>/dev/null || \
+    sleep 1
+
+    # Doctor or list triggers reconciliation - pad should be cleaned up
+    run "${PADZ_BIN}" -g doctor
+    assert_success
+
+    local count
+    count=$(count_pads global)
+    [[ "${count}" -eq 0 ]]
+}
+
+@test "refresh_pad updates metadata after file edit" {
+    # Create pad via pipe
+    run bash -c "printf 'Original Title\n\nOriginal body' | \"${PADZ_BIN}\" -g create"
+    assert_success
+    assert_pad_exists "Original Title" global
+
+    # Find and modify the file
+    local pad_file
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    printf 'Updated Title\n\nUpdated body via file edit' > "${pad_file}"
+
+    # Touch to trigger staleness
+    touch -t "$(date -v+1H '+%Y%m%d%H%M.%S')" "${pad_file}" 2>/dev/null || \
+    touch -d '+1 hour' "${pad_file}" 2>/dev/null || \
+    sleep 1
+
+    # List triggers reconciliation
+    assert_pad_exists "Updated Title" global
+    assert_pad_not_exists "Original Title" global
+}
+
+# -----------------------------------------------------------------------------
+# PIPED CONTENT (still works as before)
+# -----------------------------------------------------------------------------
+
+@test "piped create works" {
+    run bash -c "printf 'Piped Title\n\nPiped body' | \"${PADZ_BIN}\" -g create"
+    assert_success
+    assert_output_contains "Created"
+
+    assert_pad_exists "Piped Title" global
+}
+
+@test "piped edit works" {
+    bash -c "printf 'Original\n\nOriginal body' | \"${PADZ_BIN}\" -g create" >/dev/null
+
+    local index
+    index=$(find_pad_by_title "Original" global)
+
+    run bash -c "printf 'Updated Via Pipe\n\nNew body' | \"${PADZ_BIN}\" -g open ${index}"
+    assert_success
+
+    assert_pad_exists "Updated Via Pipe" global
+}
+
+@test "empty piped create aborts" {
+    run bash -c "printf '' | \"${PADZ_BIN}\" -g create"
+    assert_success
+    assert_output_contains "Aborted"
+
+    local count
+    count=$(count_pads global)
+    [[ "${count}" -eq 0 ]]
+}
+
+@test "empty piped edit fails" {
+    bash -c "printf 'Test Pad\n\nBody' | \"${PADZ_BIN}\" -g create" >/dev/null
+
+    local index
+    index=$(find_pad_by_title "Test Pad" global)
+
+    run bash -c "printf '   ' | \"${PADZ_BIN}\" -g open ${index}"
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# NO TMP FILES CREATED
+# -----------------------------------------------------------------------------
+
+@test "no pad files created in system tmp dir" {
+    # Record tmp dir state before
+    local tmp_before
+    tmp_before=$(ls /tmp/pad-* 2>/dev/null | wc -l | tr -d ' ')
+
+    bash -c "printf 'Tmp Test\n\nBody' | \"${PADZ_BIN}\" -g create" >/dev/null
+
+    # Check no new pad files in /tmp
+    local tmp_after
+    tmp_after=$(ls /tmp/pad-* 2>/dev/null | wc -l | tr -d ' ')
+
+    [[ "${tmp_before}" == "${tmp_after}" ]]
+}


### PR DESCRIPTION
## Summary

- **Editor opens real pad files in `.padz/` data directory** instead of creating temporary files in `/tmp`. This provides crash resilience (reconciliation recovers content if the editor or system crashes) and useful path autocomplete (relative paths like `../README.md` work from `.padz/`).
- **Removed `standout-input` dependency** from the CLI crate — stdin is read directly and `open_in_editor` is called on the real pad file.
- **Fixed latent double-title bug** in the edit handler where `EditorContent::new(title, pad.content)` duplicated the title in the temp file since `pad.content` already includes it.

## Test plan

- [x] All 421 cargo tests pass (365 padzapp + 25 padz + 21 fs_backend + 1 fs_wrapper + 8 title_referencing + 1 doc)
- [x] All 84 bats live-tests pass (73 existing + 11 new in `editor-flow.bats`)
- [x] New `editor-flow.bats` tests verify: pad files in data dir, `pad-uuid.txt` naming, content matches, reconciliation picks up title changes, reconciliation removes empty files, refresh after file edit, piped create/edit, empty piped abort, no tmp files created
- [x] Pre-commit hooks pass (fmt, clippy, check, test, bats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)