### PR TITLE
feat: bucketed storage architecture with archive/unarchive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **Bucketed storage architecture** - Replaced flat store with three lifecycle buckets (`active/`, `archived/`, `deleted/`). Pad location IS lifecycle state — no more `is_deleted` metadata flag. Each bucket has its own `data.json` and content files.
+  - **Archive/unarchive commands** - `padz archive` moves pads to cold storage; `padz unarchive` brings them back. Children always move with their parent.
+  - **`--archived` flag for list** - `padz list --archived` shows archived pads (indexed as `ar1`, `ar2`, etc.)
+  - **Automatic migration** - Legacy flat-layout stores are auto-migrated to bucketed layout on first run. Pads with `is_deleted` move to `deleted/` bucket.
+
 - **Changed**
+  - **Delete/restore use bucket moves** - Delete moves pads from `active/` to `deleted/`; restore moves them back. No more metadata flag toggling.
+  - **Removed `is_deleted` from metadata** - Bucket membership determines lifecycle state. The `deleted` attribute is gone.
   - **Editor opens real pad files** - Create and edit now open the actual pad file in `.padz/` instead of a temporary file in `/tmp`. This means:
     - **Crash resilience**: If the editor or system crashes, content is preserved on disk and recovered automatically by reconciliation
     - **Path autocomplete**: Editor autocomplete suggests project-relative paths (e.g., `../README.md`) instead of `/tmp` files

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -184,6 +184,16 @@ impl<'a> ScopedApi<'a> {
         self.modification("Restored", result)
     }
 
+    pub fn archive_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+        let result = self.call(|api, scope| api.archive_pads(scope, indexes))?;
+        self.modification("Archived", result)
+    }
+
+    pub fn unarchive_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+        let result = self.call(|api, scope| api.unarchive_pads(scope, indexes))?;
+        self.modification("Unarchived", result)
+    }
+
     pub fn complete_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.complete_pads(scope, indexes))?;
         self.modification("Completed", result)
@@ -535,6 +545,7 @@ pub fn list(
     #[arg] ids: Vec<String>,
     #[arg] search: Option<String>,
     #[flag] deleted: bool,
+    #[flag] archived: bool,
     #[flag] peek: bool,
     #[flag] planned: bool,
     #[flag] done: bool,
@@ -554,6 +565,8 @@ pub fn list(
     let filter = PadFilter {
         status: if deleted {
             PadStatusFilter::Deleted
+        } else if archived {
+            PadStatusFilter::Archived
         } else {
             PadStatusFilter::Active
         },
@@ -562,7 +575,7 @@ pub fn list(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, peek, deleted, &ids)
+    api(ctx).list_pads(filter, peek, deleted || archived, &ids)
 }
 
 #[handler]
@@ -751,6 +764,22 @@ pub fn restore(
     #[arg] indexes: Vec<String>,
 ) -> Result<Output<Value>, anyhow::Error> {
     api(ctx).restore_pads(&indexes)
+}
+
+#[handler]
+pub fn archive(
+    #[ctx] ctx: &CommandContext,
+    #[arg] indexes: Vec<String>,
+) -> Result<Output<Value>, anyhow::Error> {
+    api(ctx).archive_pads(&indexes)
+}
+
+#[handler]
+pub fn unarchive(
+    #[ctx] ctx: &CommandContext,
+    #[arg] indexes: Vec<String>,
+) -> Result<Output<Value>, anyhow::Error> {
+    api(ctx).unarchive_pads(&indexes)
 }
 
 /// Pin pads to the top of the list.

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -93,6 +93,7 @@ pub fn build_modification_result_value(
             let local_idx_str = match &dp.index {
                 DisplayIndex::Pinned(n) => format!("p{}", n),
                 DisplayIndex::Regular(n) => format!("{:2}", n),
+                DisplayIndex::Archived(n) => format!("ar{}", n),
                 DisplayIndex::Deleted(n) => format!("d{}", n),
             };
             let full_idx_str = format!("{}.", local_idx_str);
@@ -228,6 +229,7 @@ pub fn build_list_result_value(
         let local_idx_str = match &dp.index {
             DisplayIndex::Pinned(n) => format!("p{}", n),
             DisplayIndex::Regular(n) => format!("{:2}", n),
+            DisplayIndex::Archived(n) => format!("ar{}", n),
             DisplayIndex::Deleted(n) => format!("d{}", n),
         };
         let full_idx_str = format!("{}.", local_idx_str);
@@ -475,10 +477,9 @@ mod tests {
     use padzapp::model::Pad;
     use standout::OutputMode;
 
-    fn make_pad(title: &str, pinned: bool, deleted: bool) -> Pad {
+    fn make_pad(title: &str, pinned: bool) -> Pad {
         let mut p = Pad::new(title.to_string(), "some content".to_string());
         p.metadata.is_pinned = pinned;
-        p.metadata.is_deleted = deleted;
         p
     }
 
@@ -505,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_build_list_single_regular_pad() {
-        let pad = make_pad("Test Note", false, false);
+        let pad = make_pad("Test Note", false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
         let data =
@@ -528,7 +529,7 @@ mod tests {
 
     #[test]
     fn test_build_list_pinned_pad() {
-        let pad = make_pad("Pinned Note", true, false);
+        let pad = make_pad("Pinned Note", true);
         let dp = make_display_pad(pad, DisplayIndex::Pinned(1));
 
         let data =
@@ -550,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_build_list_deleted_pad() {
-        let pad = make_pad("Deleted Note", false, true);
+        let pad = make_pad("Deleted Note", false);
         let dp = make_display_pad(pad, DisplayIndex::Deleted(1));
 
         let data =
@@ -572,8 +573,8 @@ mod tests {
 
     #[test]
     fn test_build_list_mixed_pinned_and_regular() {
-        let pinned = make_pad("Pinned", true, false);
-        let regular = make_pad("Regular", false, false);
+        let pinned = make_pad("Pinned", true);
+        let regular = make_pad("Regular", false);
 
         let pads = vec![
             make_display_pad(pinned.clone(), DisplayIndex::Pinned(1)),
@@ -597,7 +598,7 @@ mod tests {
     #[test]
     fn test_build_list_pinned_in_regular_section_shows_left_pin() {
         // A pinned pad displayed in regular section should show left_pin
-        let mut pad = make_pad("Pinned Note", true, false);
+        let mut pad = make_pad("Pinned Note", true);
         pad.metadata.is_pinned = true;
 
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
@@ -616,7 +617,7 @@ mod tests {
 
     #[test]
     fn test_build_list_with_messages() {
-        let pad = make_pad("Test", false, false);
+        let pad = make_pad("Test", false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
         let messages = vec![CmdMessage::success("Operation completed")];
 
@@ -646,7 +647,7 @@ mod tests {
 
     #[test]
     fn test_build_list_json_mode_returns_raw_pads() {
-        let pad = make_pad("Test", false, false);
+        let pad = make_pad("Test", false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
         let data =
@@ -661,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_build_modification_result() {
-        let pad = make_pad("Test", false, false);
+        let pad = make_pad("Test", false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
         let data = build_modification_result_value(
@@ -711,7 +712,7 @@ mod tests {
 
     #[test]
     fn test_notes_mode_hides_status_icon() {
-        let pad = make_pad("Test Note", false, false);
+        let pad = make_pad("Test Note", false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
         let data =
@@ -727,7 +728,7 @@ mod tests {
 
     #[test]
     fn test_todos_mode_shows_status_icon() {
-        let pad = make_pad("Test Note", false, false);
+        let pad = make_pad("Test Note", false);
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
 
         let data =
@@ -746,7 +747,7 @@ mod tests {
 
     #[test]
     fn test_notes_mode_gives_more_title_width() {
-        let pad = make_pad("Test Note", false, false);
+        let pad = make_pad("Test Note", false);
         let dp = make_display_pad(pad.clone(), DisplayIndex::Regular(1));
         let dp2 = make_display_pad(pad, DisplayIndex::Regular(1));
 

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -1,4 +1,6 @@
-use super::complete::{active_pads_completer, all_pads_completer, deleted_pads_completer};
+use super::complete::{
+    active_pads_completer, all_pads_completer, archived_pads_completer, deleted_pads_completer,
+};
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use once_cell::sync::Lazy;
 use standout::cli::{render_help_with_topics, App, CommandGroup, Dispatch, HelpConfig};
@@ -170,6 +172,8 @@ fn should_show_custom_help() -> bool {
         "move",
         "mv",
         "restore",
+        "archive",
+        "unarchive",
         "pin",
         "p",
         "unpin",
@@ -232,6 +236,9 @@ fn command_groups() -> Vec<CommandGroup> {
                 Some("peek".into()),
                 Some("move".into()),
                 Some("delete".into()),
+                None,
+                Some("archive".into()),
+                Some("unarchive".into()),
                 None,
                 Some("pin".into()),
                 Some("unpin".into()),
@@ -320,6 +327,10 @@ pub enum Commands {
         /// Show deleted pads
         #[arg(long)]
         deleted: bool,
+
+        /// Show archived pads
+        #[arg(long)]
+        archived: bool,
 
         /// Peek at pad content
         #[arg(long)]
@@ -421,8 +432,26 @@ pub enum Commands {
         indexes: Vec<String>,
     },
 
+    /// Archive pads (move to cold storage)
+    #[command(display_order = 15)]
+    #[dispatch(pure, template = "modification_result")]
+    Archive {
+        /// Indexes of pads to archive (e.g. 1 3 5)
+        #[arg(required = true, num_args = 1.., add = active_pads_completer())]
+        indexes: Vec<String>,
+    },
+
+    /// Unarchive pads (restore from archive)
+    #[command(display_order = 16)]
+    #[dispatch(pure, template = "modification_result")]
+    Unarchive {
+        /// Indexes of archived pads (e.g. ar1 ar2 or just 1 2)
+        #[arg(required = true, num_args = 1.., add = archived_pads_completer())]
+        indexes: Vec<String>,
+    },
+
     /// Pin one or more pads (makes them delete-protected)
-    #[command(alias = "p", display_order = 15)]
+    #[command(alias = "p", display_order = 17)]
     #[dispatch(pure, template = "modification_result")]
     Pin {
         /// Indexes of the pads (e.g. 1 3 5)
@@ -431,7 +460,7 @@ pub enum Commands {
     },
 
     /// Unpin one or more pads
-    #[command(alias = "u", display_order = 16)]
+    #[command(alias = "u", display_order = 18)]
     #[dispatch(pure, template = "modification_result")]
     Unpin {
         /// Indexes of the pads (e.g. p1 p2 p3)

--- a/crates/padzapp/src/attributes/filter.rs
+++ b/crates/padzapp/src/attributes/filter.rs
@@ -222,16 +222,4 @@ mod tests {
         let filter = AttrFilter::eq("status", AttrValue::Bool(true));
         assert!(!filter.matches(&meta_with_status(TodoStatus::Done)));
     }
-
-    #[test]
-    fn filter_deleted() {
-        let filter = AttrFilter::eq("deleted", AttrValue::Bool(true));
-
-        let mut deleted_meta = Metadata::new("Test".into());
-        deleted_meta.is_deleted = true;
-        deleted_meta.deleted_at = Some(chrono::Utc::now());
-
-        assert!(filter.matches(&deleted_meta));
-        assert!(!filter.matches(&Metadata::new("Test".into())));
-    }
 }

--- a/crates/padzapp/src/attributes/spec.rs
+++ b/crates/padzapp/src/attributes/spec.rs
@@ -109,7 +109,6 @@ pub const ATTRIBUTES: &[AttributeSpec] = &[
     AttributeSpec::new("pinned", AttributeKind::BoolWithTimestamp)
         .filterable()
         .has_coupling(), // pinned also sets delete_protected
-    AttributeSpec::new("deleted", AttributeKind::BoolWithTimestamp).filterable(),
     // Simple boolean attributes
     AttributeSpec::new("protected", AttributeKind::Bool),
     // Enum attributes
@@ -144,7 +143,6 @@ mod tests {
     #[test]
     fn attributes_registry_has_expected_entries() {
         assert!(get_spec("pinned").is_some());
-        assert!(get_spec("deleted").is_some());
         assert!(get_spec("protected").is_some());
         assert!(get_spec("status").is_some());
         assert!(get_spec("tags").is_some());
@@ -165,15 +163,6 @@ mod tests {
         assert!(spec.has_coupling);
         assert!(!spec.propagates_up);
         assert!(!spec.cascades_on_delete);
-    }
-
-    #[test]
-    fn deleted_spec_is_correct() {
-        let spec = get_spec("deleted").unwrap();
-        assert_eq!(spec.name, "deleted");
-        assert_eq!(spec.kind, AttributeKind::BoolWithTimestamp);
-        assert!(spec.filterable);
-        assert!(!spec.has_coupling);
     }
 
     #[test]
@@ -214,7 +203,6 @@ mod tests {
     fn filterable_attrs_returns_expected() {
         let filterable: Vec<_> = filterable_attrs().collect();
         assert!(filterable.contains(&"pinned"));
-        assert!(filterable.contains(&"deleted"));
         assert!(filterable.contains(&"status"));
         assert!(filterable.contains(&"tags"));
         assert!(!filterable.contains(&"protected"));

--- a/crates/padzapp/src/commands/archive.rs
+++ b/crates/padzapp/src/commands/archive.rs
@@ -1,0 +1,197 @@
+use crate::commands::CmdResult;
+use crate::error::Result;
+use crate::index::{DisplayPad, PadSelector};
+use crate::model::Scope;
+use crate::store::Bucket;
+use crate::store::DataStore;
+use uuid::Uuid;
+
+use super::helpers::{indexed_pads, resolve_selectors};
+
+pub fn run<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    selectors: &[PadSelector],
+) -> Result<CmdResult> {
+    let resolved = resolve_selectors(store, scope, selectors, false)?;
+    let mut result = CmdResult::default();
+
+    let mut archived_uuids: Vec<Uuid> = Vec::new();
+    let mut processed_ids = std::collections::HashSet::new();
+
+    for (_display_index, uuid) in resolved {
+        if !processed_ids.insert(uuid) {
+            continue;
+        }
+
+        let pad = store.get_pad(&uuid, scope, Bucket::Active)?;
+        let parent_id = pad.metadata.parent_id;
+
+        // Find descendants (children, grandchildren, etc.)
+        let descendants = super::helpers::get_descendant_ids(store, scope, &[uuid])?;
+
+        // Move pad + all descendants from Active to Archived
+        let mut ids_to_move = vec![uuid];
+        ids_to_move.extend(&descendants);
+        store.move_pads(&ids_to_move, scope, Bucket::Active, Bucket::Archived)?;
+
+        for id in &descendants {
+            processed_ids.insert(*id);
+        }
+
+        // Propagate status change to parent (archived child no longer affects parent status)
+        crate::todos::propagate_status_change(store, scope, parent_id)?;
+
+        archived_uuids.push(uuid);
+    }
+
+    // Re-index to get the new archived indexes
+    let indexed = indexed_pads(store, scope)?;
+    for uuid in archived_uuids {
+        if let Some(dp) = super::helpers::find_pad_by_uuid(&indexed, uuid, |_| true) {
+            result.affected_pads.push(DisplayPad {
+                pad: dp.pad.clone(),
+                index: dp.index.clone(),
+                matches: None,
+                children: Vec::new(),
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{create, get};
+    use crate::index::DisplayIndex;
+    use crate::model::Scope;
+    use crate::store::bucketed::BucketedStore;
+    use crate::store::mem_backend::MemBackend;
+
+    #[test]
+    fn archives_pad() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Title".into(), "".into(), None).unwrap();
+        run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        let archived = get::run(
+            &store,
+            Scope::Project,
+            get::PadFilter {
+                status: get::PadStatusFilter::Archived,
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+        assert_eq!(archived.listed_pads.len(), 1);
+        assert!(matches!(
+            archived.listed_pads[0].index,
+            DisplayIndex::Archived(1)
+        ));
+
+        // Active should be empty
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
+        assert_eq!(active.listed_pads.len(), 0);
+    }
+
+    #[test]
+    fn archive_parent_moves_children() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        // Both should be archived
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Active)
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Archived)
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn archive_nested_pad_via_path() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Archive just the child
+        run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![
+                DisplayIndex::Regular(1),
+                DisplayIndex::Regular(1),
+            ])],
+        )
+        .unwrap();
+
+        // Parent still active, child archived
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
+        assert_eq!(active.listed_pads.len(), 1);
+        assert_eq!(active.listed_pads[0].pad.metadata.title, "Parent");
+        assert_eq!(active.listed_pads[0].children.len(), 0);
+
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Archived)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+}

--- a/crates/padzapp/src/commands/export.rs
+++ b/crates/padzapp/src/commands/export.rs
@@ -317,16 +317,23 @@ mod tests {
     use super::*;
     use crate::commands::create;
     use crate::model::Scope;
-    use crate::store::memory::InMemoryStore;
+    use crate::store::bucketed::BucketedStore;
+    use crate::store::mem_backend::MemBackend;
 
     #[test]
     fn test_resolve_pads_exports_active_by_default() {
-        let mut store = InMemoryStore::new();
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
         create::run(&mut store, Scope::Project, "Active".into(), "".into(), None).unwrap();
 
-        let mut del_pad = crate::model::Pad::new("Deleted".into(), "".into());
-        del_pad.metadata.is_deleted = true;
-        store.save_pad(&del_pad, Scope::Project).unwrap();
+        let del_pad = crate::model::Pad::new("Deleted".into(), "".into());
+        store
+            .save_pad(&del_pad, Scope::Project, crate::store::Bucket::Deleted)
+            .unwrap();
 
         let pads = resolve_pads(&store, Scope::Project, &[]).unwrap();
         assert_eq!(pads.len(), 1);
@@ -335,7 +342,12 @@ mod tests {
 
     #[test]
     fn test_write_archive_produces_content() {
-        let mut store = InMemoryStore::new();
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
         create::run(
             &mut store,
             Scope::Project,
@@ -523,7 +535,12 @@ mod tests {
     }
     #[test]
     fn test_export_empty_does_nothing() {
-        let store = InMemoryStore::new();
+        let store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
         // No pads created
         let res = run(&store, Scope::Project, &[]).unwrap();
         assert!(res
@@ -541,7 +558,12 @@ mod tests {
     #[test]
     fn test_export_single_file_creates_file() {
         use std::path::Path;
-        let mut store = InMemoryStore::new();
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
         create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
 
         // Since run_single_file forces writing to CWD with a sanitized name,

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -5,7 +5,12 @@ use std::fs;
 
 pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
     let dir = paths.scope_dir(scope)?;
-    fs::create_dir_all(&dir)?;
+
+    // Create scope root and bucket subdirectories
+    fs::create_dir_all(dir.join("active"))?;
+    fs::create_dir_all(dir.join("archived"))?;
+    fs::create_dir_all(dir.join("deleted"))?;
+
     let mut result = CmdResult::default();
     result.add_message(CmdMessage::success(format!(
         "Initialized padz store at {}",

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -66,6 +66,7 @@ use crate::model::Scope;
 use serde::Serialize;
 use std::path::PathBuf;
 
+pub mod archive;
 pub mod create;
 pub mod delete;
 pub mod doctor;
@@ -84,6 +85,7 @@ pub mod status;
 pub mod tagging;
 pub mod tags;
 
+pub mod unarchive;
 pub mod update;
 pub mod view;
 

--- a/crates/padzapp/src/commands/unarchive.rs
+++ b/crates/padzapp/src/commands/unarchive.rs
@@ -1,0 +1,207 @@
+use crate::commands::CmdResult;
+use crate::error::Result;
+use crate::index::{DisplayIndex, DisplayPad, PadSelector};
+use crate::model::Scope;
+use crate::store::Bucket;
+use crate::store::DataStore;
+use uuid::Uuid;
+
+use super::helpers::{indexed_pads, resolve_selectors};
+
+pub fn run<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    selectors: &[PadSelector],
+) -> Result<CmdResult> {
+    let resolved = resolve_selectors(store, scope, selectors, false)?;
+    let mut result = CmdResult::default();
+
+    let mut unarchived_uuids: Vec<Uuid> = Vec::new();
+    let mut processed_ids = std::collections::HashSet::new();
+
+    for (_display_index, uuid) in resolved {
+        if !processed_ids.insert(uuid) {
+            continue;
+        }
+
+        // Only unarchive pads that are in the Archived bucket
+        let pad = match store.get_pad(&uuid, scope, Bucket::Archived) {
+            Ok(p) => p,
+            Err(_) => continue, // Skip if not in Archived (idempotent)
+        };
+        let parent_id = pad.metadata.parent_id;
+
+        // Find descendants in the tree
+        let descendants = super::helpers::get_descendant_ids(store, scope, &[uuid])?;
+
+        // Move pad + all descendants from Archived to Active
+        let mut ids_to_move = vec![uuid];
+        ids_to_move.extend(&descendants);
+        store.move_pads(&ids_to_move, scope, Bucket::Archived, Bucket::Active)?;
+
+        for id in &descendants {
+            processed_ids.insert(*id);
+        }
+
+        // If unarchiving a child whose parent is still in Archived, clear parent_id
+        if let Some(pid) = parent_id {
+            if !processed_ids.contains(&pid) && store.get_pad(&pid, scope, Bucket::Active).is_err()
+            {
+                let mut restored_pad = store.get_pad(&uuid, scope, Bucket::Active)?;
+                restored_pad.metadata.parent_id = None;
+                store.save_pad(&restored_pad, scope, Bucket::Active)?;
+            }
+        }
+
+        // Propagate status change to parent (unarchived child affects status again)
+        crate::todos::propagate_status_change(store, scope, parent_id)?;
+
+        unarchived_uuids.push(uuid);
+    }
+
+    // Re-index to get the new regular indexes
+    let indexed = indexed_pads(store, scope)?;
+    for uuid in unarchived_uuids {
+        if let Some(dp) = super::helpers::find_pad_by_uuid(&indexed, uuid, |idx| {
+            matches!(idx, DisplayIndex::Regular(_) | DisplayIndex::Pinned(_))
+        }) {
+            result.affected_pads.push(DisplayPad {
+                pad: dp.pad.clone(),
+                index: dp.index.clone(),
+                matches: None,
+                children: Vec::new(),
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{archive, create, get};
+    use crate::index::DisplayIndex;
+    use crate::model::Scope;
+    use crate::store::bucketed::BucketedStore;
+    use crate::store::mem_backend::MemBackend;
+
+    #[test]
+    fn unarchives_pad() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Title".into(), "".into(), None).unwrap();
+
+        // Archive it
+        archive::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        // Unarchive it
+        let result = run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Archived(1)])],
+        )
+        .unwrap();
+
+        assert_eq!(result.affected_pads.len(), 1);
+        assert!(matches!(
+            result.affected_pads[0].index,
+            DisplayIndex::Regular(1)
+        ));
+
+        // Verify active again
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
+        assert_eq!(active.listed_pads.len(), 1);
+
+        // Verify archived is empty
+        let archived = get::run(
+            &store,
+            Scope::Project,
+            get::PadFilter {
+                status: get::PadStatusFilter::Archived,
+                ..Default::default()
+            },
+            &[],
+        )
+        .unwrap();
+        assert_eq!(archived.listed_pads.len(), 0);
+    }
+
+    #[test]
+    fn unarchive_parent_restores_children() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Archive parent (moves child too)
+        archive::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        // Unarchive parent
+        run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Archived(1)])],
+        )
+        .unwrap();
+
+        // Both should be active again
+        let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
+        assert_eq!(active.listed_pads.len(), 1);
+        assert_eq!(active.listed_pads[0].pad.metadata.title, "Parent");
+        assert_eq!(active.listed_pads[0].children.len(), 1);
+    }
+
+    #[test]
+    fn unarchive_non_archived_is_noop() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
+
+        let result = run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        assert_eq!(result.affected_pads.len(), 0);
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Active)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+}

--- a/crates/padzapp/src/commands/view.rs
+++ b/crates/padzapp/src/commands/view.rs
@@ -2,7 +2,7 @@ use crate::commands::CmdResult;
 use crate::error::Result;
 use crate::index::PadSelector;
 use crate::model::Scope;
-use crate::store::DataStore;
+use crate::store::{Bucket, DataStore};
 
 use super::helpers::pads_by_selectors;
 
@@ -12,7 +12,11 @@ pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> 
     // Collect paths for each pad (for editor integration)
     let paths: Vec<_> = pads
         .iter()
-        .filter_map(|dp| store.get_pad_path(&dp.pad.metadata.id, scope).ok())
+        .filter_map(|dp| {
+            store
+                .get_pad_path(&dp.pad.metadata.id, scope, Bucket::Active)
+                .ok()
+        })
         .collect();
 
     let mut result = CmdResult::default().with_listed_pads(pads);

--- a/crates/padzapp/src/store/bucketed.rs
+++ b/crates/padzapp/src/store/bucketed.rs
@@ -1,0 +1,363 @@
+//! # Bucketed Store
+//!
+//! Wraps three [`PadStore`] instances (active, archived, deleted) to provide
+//! bucket-aware storage. Each inner store manages its own subdirectory with
+//! independent `data.json` and pad content files.
+//!
+//! Tags are stored at the scope root (shared across buckets) via a separate backend.
+
+use super::backend::StorageBackend;
+use super::pad_store::PadStore;
+use super::{Bucket, DataStore, DoctorReport};
+use crate::error::Result;
+use crate::model::{Pad, Scope};
+use crate::tags::TagEntry;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+/// A store that manages three lifecycle buckets (active, archived, deleted)
+/// plus a scope-level tag backend.
+pub struct BucketedStore<B: StorageBackend> {
+    pub(crate) active: PadStore<B>,
+    pub(crate) archived: PadStore<B>,
+    pub(crate) deleted: PadStore<B>,
+    /// Separate backend at the scope root for tags (shared across buckets).
+    pub(crate) tag_backend: B,
+}
+
+impl<B: StorageBackend> BucketedStore<B> {
+    pub fn new(active: B, archived: B, deleted: B, tag_backend: B) -> Self {
+        Self {
+            active: PadStore::with_backend(active),
+            archived: PadStore::with_backend(archived),
+            deleted: PadStore::with_backend(deleted),
+            tag_backend,
+        }
+    }
+
+    fn store(&self, bucket: Bucket) -> &PadStore<B> {
+        match bucket {
+            Bucket::Active => &self.active,
+            Bucket::Archived => &self.archived,
+            Bucket::Deleted => &self.deleted,
+        }
+    }
+
+    fn store_mut(&mut self, bucket: Bucket) -> &mut PadStore<B> {
+        match bucket {
+            Bucket::Active => &mut self.active,
+            Bucket::Archived => &mut self.archived,
+            Bucket::Deleted => &mut self.deleted,
+        }
+    }
+
+    /// Access the active inner store (for testing/internal use)
+    pub fn active_store(&self) -> &PadStore<B> {
+        &self.active
+    }
+
+    /// Access the active inner store mutably
+    pub fn active_store_mut(&mut self) -> &mut PadStore<B> {
+        &mut self.active
+    }
+
+    /// Synchronize all buckets with their backends.
+    pub fn sync(&self, scope: crate::model::Scope) -> crate::error::Result<()> {
+        self.active.sync(scope)?;
+        self.archived.sync(scope)?;
+        self.deleted.sync(scope)?;
+        Ok(())
+    }
+}
+
+impl<B: StorageBackend> DataStore for BucketedStore<B> {
+    fn save_pad(&mut self, pad: &Pad, scope: Scope, bucket: Bucket) -> Result<()> {
+        self.store_mut(bucket).save_pad(pad, scope)
+    }
+
+    fn get_pad(&self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<Pad> {
+        self.store(bucket).get_pad(id, scope)
+    }
+
+    fn list_pads(&self, scope: Scope, bucket: Bucket) -> Result<Vec<Pad>> {
+        self.store(bucket).list_pads(scope)
+    }
+
+    fn delete_pad(&mut self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<()> {
+        self.store_mut(bucket).delete_pad(id, scope)
+    }
+
+    fn move_pad(&mut self, id: &Uuid, scope: Scope, from: Bucket, to: Bucket) -> Result<Pad> {
+        if from == to {
+            return self.get_pad(id, scope, from);
+        }
+
+        // 1. Read from source
+        let pad = self.store(from).get_pad(id, scope)?;
+
+        // 2. Write to destination (content first = orphan-safe)
+        self.store_mut(to).save_pad(&pad, scope)?;
+
+        // 3. Remove from source
+        // Crash between 2 and 3: pad in both. Source doctor cleans the zombie. Safe.
+        self.store_mut(from).delete_pad(id, scope)?;
+
+        Ok(pad)
+    }
+
+    fn move_pads(
+        &mut self,
+        ids: &[Uuid],
+        scope: Scope,
+        from: Bucket,
+        to: Bucket,
+    ) -> Result<Vec<Pad>> {
+        let mut moved = Vec::with_capacity(ids.len());
+        for id in ids {
+            moved.push(self.move_pad(id, scope, from, to)?);
+        }
+        Ok(moved)
+    }
+
+    fn get_pad_path(&self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<PathBuf> {
+        self.store(bucket).get_pad_path(id, scope)
+    }
+
+    fn doctor(&mut self, scope: Scope) -> Result<DoctorReport> {
+        let active_report = self.active.doctor(scope)?;
+        let archived_report = self.archived.doctor(scope)?;
+        let deleted_report = self.deleted.doctor(scope)?;
+
+        Ok(DoctorReport {
+            fixed_missing_files: active_report.fixed_missing_files
+                + archived_report.fixed_missing_files
+                + deleted_report.fixed_missing_files,
+            recovered_files: active_report.recovered_files
+                + archived_report.recovered_files
+                + deleted_report.recovered_files,
+            fixed_content_files: active_report.fixed_content_files
+                + archived_report.fixed_content_files
+                + deleted_report.fixed_content_files,
+        })
+    }
+
+    fn load_tags(&self, scope: Scope) -> Result<Vec<TagEntry>> {
+        self.tag_backend.load_tags(scope)
+    }
+
+    fn save_tags(&mut self, scope: Scope, tags: &[TagEntry]) -> Result<()> {
+        self.tag_backend.save_tags(scope, tags)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Scope;
+    use crate::store::mem_backend::MemBackend;
+
+    type BucketedInMemoryStore = BucketedStore<MemBackend>;
+
+    fn make_store() -> BucketedInMemoryStore {
+        BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        )
+    }
+
+    #[test]
+    fn test_save_and_get_in_active() {
+        let mut store = make_store();
+        let pad = Pad::new("Active Pad".into(), "Content".into());
+        let id = pad.metadata.id;
+
+        store
+            .save_pad(&pad, Scope::Project, Bucket::Active)
+            .unwrap();
+
+        let retrieved = store.get_pad(&id, Scope::Project, Bucket::Active).unwrap();
+        assert_eq!(retrieved.metadata.title, "Active Pad");
+    }
+
+    #[test]
+    fn test_buckets_are_isolated() {
+        let mut store = make_store();
+
+        let active_pad = Pad::new("Active".into(), "".into());
+        let deleted_pad = Pad::new("Deleted".into(), "".into());
+        let archived_pad = Pad::new("Archived".into(), "".into());
+
+        store
+            .save_pad(&active_pad, Scope::Project, Bucket::Active)
+            .unwrap();
+        store
+            .save_pad(&deleted_pad, Scope::Project, Bucket::Deleted)
+            .unwrap();
+        store
+            .save_pad(&archived_pad, Scope::Project, Bucket::Archived)
+            .unwrap();
+
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Active)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Deleted)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Archived)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        assert_eq!(
+            store.list_pads(Scope::Project, Bucket::Active).unwrap()[0]
+                .metadata
+                .title,
+            "Active"
+        );
+    }
+
+    #[test]
+    fn test_move_pad_between_buckets() {
+        let mut store = make_store();
+        let pad = Pad::new("Moving Pad".into(), "Content".into());
+        let id = pad.metadata.id;
+
+        store
+            .save_pad(&pad, Scope::Project, Bucket::Active)
+            .unwrap();
+
+        // Move from Active to Deleted
+        let moved = store
+            .move_pad(&id, Scope::Project, Bucket::Active, Bucket::Deleted)
+            .unwrap();
+        assert_eq!(moved.metadata.title, "Moving Pad");
+
+        // Should be gone from Active
+        assert!(store.get_pad(&id, Scope::Project, Bucket::Active).is_err());
+
+        // Should be in Deleted
+        let in_deleted = store.get_pad(&id, Scope::Project, Bucket::Deleted).unwrap();
+        assert_eq!(in_deleted.metadata.title, "Moving Pad");
+    }
+
+    #[test]
+    fn test_move_pads_batch() {
+        let mut store = make_store();
+        let pad1 = Pad::new("Pad 1".into(), "".into());
+        let pad2 = Pad::new("Pad 2".into(), "".into());
+        let id1 = pad1.metadata.id;
+        let id2 = pad2.metadata.id;
+
+        store
+            .save_pad(&pad1, Scope::Project, Bucket::Active)
+            .unwrap();
+        store
+            .save_pad(&pad2, Scope::Project, Bucket::Active)
+            .unwrap();
+
+        let moved = store
+            .move_pads(
+                &[id1, id2],
+                Scope::Project,
+                Bucket::Active,
+                Bucket::Archived,
+            )
+            .unwrap();
+        assert_eq!(moved.len(), 2);
+
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Active)
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Archived)
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_move_same_bucket_is_noop() {
+        let mut store = make_store();
+        let pad = Pad::new("Same Bucket".into(), "".into());
+        let id = pad.metadata.id;
+
+        store
+            .save_pad(&pad, Scope::Project, Bucket::Active)
+            .unwrap();
+
+        let moved = store
+            .move_pad(&id, Scope::Project, Bucket::Active, Bucket::Active)
+            .unwrap();
+        assert_eq!(moved.metadata.title, "Same Bucket");
+
+        // Should still be in Active
+        assert_eq!(
+            store
+                .list_pads(Scope::Project, Bucket::Active)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_delete_pad_from_bucket() {
+        let mut store = make_store();
+        let pad = Pad::new("To Delete".into(), "".into());
+        let id = pad.metadata.id;
+
+        store
+            .save_pad(&pad, Scope::Project, Bucket::Deleted)
+            .unwrap();
+        store
+            .delete_pad(&id, Scope::Project, Bucket::Deleted)
+            .unwrap();
+
+        assert!(store.get_pad(&id, Scope::Project, Bucket::Deleted).is_err());
+    }
+
+    #[test]
+    fn test_doctor_across_buckets() {
+        let mut store = make_store();
+        let report = store.doctor(Scope::Project).unwrap();
+
+        // Empty store, nothing to fix
+        assert_eq!(report.fixed_missing_files, 0);
+        assert_eq!(report.recovered_files, 0);
+        assert_eq!(report.fixed_content_files, 0);
+    }
+
+    #[test]
+    fn test_tags_are_scope_level() {
+        let mut store = make_store();
+        let tags = vec![
+            TagEntry::new("work".to_string()),
+            TagEntry::new("rust".to_string()),
+        ];
+
+        store.save_tags(Scope::Project, &tags).unwrap();
+
+        let loaded = store.load_tags(Scope::Project).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].name, "work");
+    }
+}

--- a/crates/padzapp/src/store/fs.rs
+++ b/crates/padzapp/src/store/fs.rs
@@ -1,21 +1,46 @@
+use super::bucketed::BucketedStore;
 use super::fs_backend::FsBackend;
 use super::pad_store::PadStore;
 use std::path::PathBuf;
 
-pub type FileStore = PadStore<FsBackend>;
+pub type FileStore = BucketedStore<FsBackend>;
 
 impl FileStore {
-    pub fn new(project_root: Option<PathBuf>, global_root: PathBuf) -> Self {
-        let backend = FsBackend::new(project_root, global_root);
-        PadStore::with_backend(backend)
+    /// Create a new bucketed file store from project/global root paths.
+    ///
+    /// Each bucket gets its own subdirectory:
+    /// - `{root}/active/`  — active pads (data.json + pad-*.txt)
+    /// - `{root}/archived/` — archived pads
+    /// - `{root}/deleted/`  — deleted pads
+    /// - `{root}/`          — scope-level files (tags.json, padz.toml)
+    pub fn new_fs(project_root: Option<PathBuf>, global_root: PathBuf) -> Self {
+        BucketedStore::new(
+            FsBackend::new(
+                project_root.as_ref().map(|r| r.join("active")),
+                global_root.join("active"),
+            ),
+            FsBackend::new(
+                project_root.as_ref().map(|r| r.join("archived")),
+                global_root.join("archived"),
+            ),
+            FsBackend::new(
+                project_root.as_ref().map(|r| r.join("deleted")),
+                global_root.join("deleted"),
+            ),
+            // Tag backend at scope root (shared across buckets)
+            FsBackend::new(project_root, global_root),
+        )
     }
 
     pub fn with_file_ext(mut self, ext: &str) -> Self {
-        self.backend = self.backend.with_file_ext(ext);
+        self.active = PadStore::with_backend(self.active.backend.with_file_ext(ext));
+        self.archived = PadStore::with_backend(self.archived.backend.with_file_ext(ext));
+        self.deleted = PadStore::with_backend(self.deleted.backend.with_file_ext(ext));
+        // tag_backend doesn't need file_ext (no content files)
         self
     }
 
     pub fn file_ext(&self) -> &str {
-        self.backend.file_ext()
+        self.active.backend.file_ext()
     }
 }

--- a/crates/padzapp/src/store/memory.rs
+++ b/crates/padzapp/src/store/memory.rs
@@ -21,7 +21,6 @@ impl InMemoryStore {
 pub mod fixtures {
     use super::*;
     use crate::model::{Pad, Scope};
-    use crate::store::DataStore;
 
     pub struct StoreFixture {
         pub store: InMemoryStore,
@@ -65,9 +64,7 @@ pub mod fixtures {
         }
 
         pub fn with_deleted_pad(mut self, title: &str, scope: Scope) -> Self {
-            let mut pad = Pad::new(title.to_string(), "Deleted content".to_string());
-            pad.metadata.is_deleted = true;
-            pad.metadata.deleted_at = Some(chrono::Utc::now());
+            let pad = Pad::new(title.to_string(), "Deleted content".to_string());
             self.store.save_pad(&pad, scope).unwrap();
             self
         }
@@ -81,7 +78,6 @@ mod tests {
     use crate::error::PadzError;
     use crate::model::Scope;
     use crate::store::backend::StorageBackend;
-    use crate::store::DataStore;
     use crate::tags::TagEntry;
     use uuid::Uuid;
 
@@ -119,13 +115,12 @@ mod tests {
 
         let active = pads.iter().find(|p| p.metadata.title == "Active").unwrap();
         assert!(!active.metadata.is_pinned);
-        assert!(!active.metadata.is_deleted);
 
         let pinned = pads.iter().find(|p| p.metadata.title == "Pinned").unwrap();
         assert!(pinned.metadata.is_pinned);
 
-        let deleted = pads.iter().find(|p| p.metadata.title == "Deleted").unwrap();
-        assert!(deleted.metadata.is_deleted);
+        // Verify deleted pad exists (it's just a regular pad saved to the store)
+        assert!(pads.iter().any(|p| p.metadata.title == "Deleted"));
 
         let generic = pads
             .iter()

--- a/crates/padzapp/src/test_utils.rs
+++ b/crates/padzapp/src/test_utils.rs
@@ -19,7 +19,7 @@ impl TestEnv {
     pub fn new() -> Self {
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
         let root = temp_dir.path().to_path_buf();
-        let store = FileStore::new(Some(root.clone()), root.clone());
+        let store = FileStore::new_fs(Some(root.clone()), root.clone());
         Self {
             _temp_dir: temp_dir,
             store,

--- a/crates/padzapp/tests/fs_wrapper_test.rs
+++ b/crates/padzapp/tests/fs_wrapper_test.rs
@@ -8,7 +8,7 @@ fn test_filestore_wrapper_methods() {
     let glob = TempDir::new().unwrap();
 
     // Test new
-    let store = FileStore::new(Some(proj.path().to_path_buf()), glob.path().to_path_buf());
+    let store = FileStore::new_fs(Some(proj.path().to_path_buf()), glob.path().to_path_buf());
 
     // Test config method delegtion
     let store = store.with_file_ext(".md");

--- a/crates/padzapp/tests/title_referencing.rs
+++ b/crates/padzapp/tests/title_referencing.rs
@@ -1,10 +1,16 @@
 use padzapp::api::PadzApi;
 use padzapp::commands::PadzPaths;
 use padzapp::model::Scope;
-use padzapp::store::memory::InMemoryStore;
+use padzapp::store::bucketed::BucketedStore;
+use padzapp::store::mem_backend::MemBackend;
 
-fn setup() -> PadzApi<InMemoryStore> {
-    let store = InMemoryStore::new();
+fn setup() -> PadzApi<BucketedStore<MemBackend>> {
+    let store = BucketedStore::new(
+        MemBackend::new(),
+        MemBackend::new(),
+        MemBackend::new(),
+        MemBackend::new(),
+    );
     let paths = PadzPaths {
         project: Some(std::path::PathBuf::from(".padz")),
         global: std::path::PathBuf::from(".padz"),

--- a/live-tests/base-fixture.sh
+++ b/live-tests/base-fixture.sh
@@ -11,7 +11,7 @@
 #   - Tagged pads: with unique and shared tags
 #   - Pinned pads: protected from deletion
 #   - Completed pads: marked as done
-#   - Deleted pads: soft-deleted, visible with --deleted
+#   - Deleted pads: moved to deleted bucket, visible with --deleted
 #
 # Title convention: "<Scope> pad: <description>" for easy debugging
 # =============================================================================

--- a/live-tests/tests/archive.bats
+++ b/live-tests/tests/archive.bats
@@ -1,0 +1,234 @@
+#!/usr/bin/env bats
+# =============================================================================
+# ARCHIVE / UNARCHIVE TESTS
+# =============================================================================
+# Tests for archiving pads (moving to cold storage) and unarchiving them.
+#
+# Archive moves pads from active → archived bucket.
+# Unarchive moves pads from archived → active bucket.
+# Children always move with their parent.
+#
+# =============================================================================
+
+load '../lib/helpers.bash'
+load '../lib/assertions.bash'
+load '../lib/backdoors.bash'
+
+# -----------------------------------------------------------------------------
+# ARCHIVE
+# -----------------------------------------------------------------------------
+
+@test "archive: pad disappears from active list" {
+    "${PADZ_BIN}" -g create --no-editor "Archive Test Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Archive Test Pad" global)
+
+    run "${PADZ_BIN}" -g archive "${index}"
+    assert_success
+
+    assert_pad_not_exists "Archive Test Pad" global
+}
+
+@test "archive: pad appears in archived list" {
+    "${PADZ_BIN}" -g create --no-editor "Archive Visible Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Archive Visible Pad" global)
+
+    "${PADZ_BIN}" -g archive "${index}" >/dev/null
+
+    local archived_json
+    archived_json=$(list_archived_pads global)
+    [[ "${archived_json}" == *"Archive Visible Pad"* ]]
+}
+
+@test "archive: archived pad count increases" {
+    local before
+    before=$(count_archived_pads global)
+
+    "${PADZ_BIN}" -g create --no-editor "Archive Count Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Archive Count Pad" global)
+    "${PADZ_BIN}" -g archive "${index}" >/dev/null
+
+    local after
+    after=$(count_archived_pads global)
+    [[ "${after}" -gt "${before}" ]]
+}
+
+@test "archive: content file moves to archived bucket" {
+    "${PADZ_BIN}" -g create --no-editor "Archive File Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Archive File Pad" global)
+    local uuid
+    uuid=$(get_pad_id "${index}" global)
+
+    # Verify file exists in active bucket
+    backdoor_content_exists "${uuid}" global active
+
+    "${PADZ_BIN}" -g archive "${index}" >/dev/null
+
+    # Should now be in archived bucket, not active
+    ! backdoor_content_exists "${uuid}" global active
+    backdoor_content_exists "${uuid}" global archived
+}
+
+@test "archive: parent moves children too" {
+    "${PADZ_BIN}" -g create --no-editor "Archive Parent" >/dev/null
+    local parent_idx
+    parent_idx=$(find_pad_by_title "Archive Parent" global)
+
+    "${PADZ_BIN}" -g create --no-editor --inside "${parent_idx}" "Archive Child" >/dev/null
+
+    # Archive the parent
+    "${PADZ_BIN}" -g archive "${parent_idx}" >/dev/null
+
+    # Both should be gone from active
+    assert_pad_not_exists "Archive Parent" global
+    assert_pad_not_exists "Archive Child" global
+
+    # Both should be in archived
+    local archived_json
+    archived_json=$(list_archived_pads global)
+    [[ "${archived_json}" == *"Archive Parent"* ]]
+    [[ "${archived_json}" == *"Archive Child"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# UNARCHIVE
+# -----------------------------------------------------------------------------
+
+@test "unarchive: pad returns to active list" {
+    "${PADZ_BIN}" -g create --no-editor "Unarchive Test Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Unarchive Test Pad" global)
+    "${PADZ_BIN}" -g archive "${index}" >/dev/null
+
+    # Find the archived index by title
+    local ar_index
+    ar_index=$(find_archived_pad_by_title "Unarchive Test Pad" global)
+
+    run "${PADZ_BIN}" -g unarchive "${ar_index}"
+    assert_success
+
+    assert_pad_exists "Unarchive Test Pad" global
+}
+
+@test "unarchive: pad disappears from archived list" {
+    "${PADZ_BIN}" -g create --no-editor "Unarchive Gone Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Unarchive Gone Pad" global)
+    "${PADZ_BIN}" -g archive "${index}" >/dev/null
+
+    # Verify it's in archived
+    local archived_json
+    archived_json=$(list_archived_pads global)
+    [[ "${archived_json}" == *"Unarchive Gone Pad"* ]]
+
+    # Find the archived index by title and unarchive
+    local ar_index
+    ar_index=$(find_archived_pad_by_title "Unarchive Gone Pad" global)
+    "${PADZ_BIN}" -g unarchive "${ar_index}" >/dev/null
+
+    # Should no longer be in archived list
+    archived_json=$(list_archived_pads global)
+    [[ "${archived_json}" != *"Unarchive Gone Pad"* ]]
+}
+
+@test "unarchive: content file moves back to active bucket" {
+    "${PADZ_BIN}" -g create --no-editor "Unarchive File Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Unarchive File Pad" global)
+    local uuid
+    uuid=$(get_pad_id "${index}" global)
+
+    "${PADZ_BIN}" -g archive "${index}" >/dev/null
+    backdoor_content_exists "${uuid}" global archived
+
+    # Find the archived index by title and unarchive
+    local ar_index
+    ar_index=$(find_archived_pad_by_title "Unarchive File Pad" global)
+    "${PADZ_BIN}" -g unarchive "${ar_index}" >/dev/null
+
+    # Should be back in active bucket
+    backdoor_content_exists "${uuid}" global active
+    ! backdoor_content_exists "${uuid}" global archived
+}
+
+@test "unarchive: parent brings children back" {
+    "${PADZ_BIN}" -g create --no-editor "Unarchive Parent" >/dev/null
+    local parent_idx
+    parent_idx=$(find_pad_by_title "Unarchive Parent" global)
+
+    "${PADZ_BIN}" -g create --no-editor --inside "${parent_idx}" "Unarchive Child" >/dev/null
+
+    # Archive parent (takes child)
+    "${PADZ_BIN}" -g archive "${parent_idx}" >/dev/null
+    assert_pad_not_exists "Unarchive Parent" global
+    assert_pad_not_exists "Unarchive Child" global
+
+    # Find the archived parent and unarchive
+    local ar_index
+    ar_index=$(find_archived_pad_by_title "Unarchive Parent" global)
+    "${PADZ_BIN}" -g unarchive "${ar_index}" >/dev/null
+
+    assert_pad_exists "Unarchive Parent" global
+    assert_pad_exists "Unarchive Child" global
+}
+
+# -----------------------------------------------------------------------------
+# DELETE → BUCKET
+# -----------------------------------------------------------------------------
+
+@test "delete: content file moves to deleted bucket" {
+    "${PADZ_BIN}" -g create --no-editor "Delete Bucket Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Delete Bucket Pad" global)
+    local uuid
+    uuid=$(get_pad_id "${index}" global)
+
+    backdoor_content_exists "${uuid}" global active
+
+    "${PADZ_BIN}" -g delete "${index}" >/dev/null
+
+    ! backdoor_content_exists "${uuid}" global active
+    backdoor_content_exists "${uuid}" global deleted
+}
+
+@test "restore: content file moves back to active bucket" {
+    "${PADZ_BIN}" -g create --no-editor "Restore Bucket Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Restore Bucket Pad" global)
+    local uuid
+    uuid=$(get_pad_id "${index}" global)
+
+    "${PADZ_BIN}" -g delete "${index}" >/dev/null
+    backdoor_content_exists "${uuid}" global deleted
+
+    # Find the deleted index by title and restore
+    local d_index
+    d_index=$(find_deleted_pad_by_title "Restore Bucket Pad" global)
+    "${PADZ_BIN}" -g restore "${d_index}" >/dev/null
+
+    backdoor_content_exists "${uuid}" global active
+    ! backdoor_content_exists "${uuid}" global deleted
+}
+
+# -----------------------------------------------------------------------------
+# PROJECT SCOPE
+# -----------------------------------------------------------------------------
+
+@test "archive: works in project scope" {
+    cd "${PROJECT_A}"
+    "${PADZ_BIN}" create --no-editor "Project Archive Pad" >/dev/null
+    local index
+    index=$(find_pad_by_title "Project Archive Pad" project)
+
+    run "${PADZ_BIN}" archive "${index}"
+    assert_success
+
+    assert_pad_not_exists "Project Archive Pad" project
+
+    local archived_json
+    archived_json=$(list_archived_pads project)
+    [[ "${archived_json}" == *"Project Archive Pad"* ]]
+}

--- a/live-tests/tests/editor-flow.bats
+++ b/live-tests/tests/editor-flow.bats
@@ -42,7 +42,7 @@ teardown() {
 
     # Verify there's a pad-*.txt file in the data dir
     local pad_count
-    pad_count=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | wc -l | tr -d ' ')
+    pad_count=$(ls "${PADZ_GLOBAL_DATA}"/active/pad-*.txt 2>/dev/null | wc -l | tr -d ' ')
     [[ "${pad_count}" -gt 0 ]]
 }
 
@@ -50,7 +50,7 @@ teardown() {
     "${PADZ_BIN}" -g create --no-editor "Naming Test" >/dev/null
 
     local pad_file
-    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/active/pad-*.txt 2>/dev/null | head -1)
     local filename
     filename=$(basename "${pad_file}")
 
@@ -62,7 +62,7 @@ teardown() {
     "${PADZ_BIN}" -g create --no-editor "Content Match" >/dev/null
 
     local pad_file
-    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/active/pad-*.txt 2>/dev/null | head -1)
     local file_content
     file_content=$(cat "${pad_file}")
 
@@ -80,7 +80,7 @@ teardown() {
 
     # Find the pad file and change its content (simulating editor)
     local pad_file
-    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/active/pad-*.txt 2>/dev/null | head -1)
 
     # Write new content with different title
     printf 'Changed Title\n\nNew body content' > "${pad_file}"
@@ -100,7 +100,7 @@ teardown() {
 
     # Empty the pad file (simulating editor clearing content)
     local pad_file
-    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/active/pad-*.txt 2>/dev/null | head -1)
     truncate -s 0 "${pad_file}"
 
     # Touch to ensure mtime is newer
@@ -125,7 +125,7 @@ teardown() {
 
     # Find and modify the file
     local pad_file
-    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/pad-*.txt 2>/dev/null | head -1)
+    pad_file=$(ls "${PADZ_GLOBAL_DATA}"/active/pad-*.txt 2>/dev/null | head -1)
     printf 'Updated Title\n\nUpdated body via file edit' > "${pad_file}"
 
     # Touch to trigger staleness


### PR DESCRIPTION
## Summary

- **Bucketed storage**: Replaced flat `.padz/` store with three lifecycle buckets (`active/`, `archived/`, `deleted/`). Pad location IS lifecycle state — removed `is_deleted` from Metadata entirely.
- **Archive/unarchive commands**: `padz archive` moves pads to cold storage, `padz unarchive` brings them back. `--archived` flag on `list` to view archived pads. Children always move with their parent.
- **Automatic migration**: Legacy flat-layout stores are detected and auto-migrated on first run (partitions pads by `is_deleted` flag, moves files to bucket subdirs, strips legacy fields).

## Architecture

- `BucketedStore<B>` wraps three `PadStore<B>` instances (active/archived/deleted) + a scope-level tag backend
- `Bucket` enum (`Active`, `Archived`, `Deleted`) added to all `DataStore` trait methods
- `DisplayIndex` gains `Archived(usize)` variant (`ar1`, `ar2`, etc.)
- `move_pad`: save-to-dest then delete-from-source (crash between = orphan in dest, source doctor cleans)
- Delete/restore now use bucket moves instead of metadata flag toggling

## Test plan

- [x] 436 unit tests pass (`cargo test`)
- [x] Clippy clean
- [x] 96 live bats tests pass (including 12 new archive/unarchive tests)
- [x] Migration tests (flat→bucketed, idempotent, all-active, no-data-json)
- [x] Doctor works across all three buckets
- [x] Content files physically move between bucket directories
- [x] Children move with parent on archive/unarchive/delete/restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)