### PR TITLE
Redesign tag CLI as unified `padz tag` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,74 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [0.19.1] - 2026-02-15
-
-## [0.19.1] - 2026-02-15
-
-- **Added**
-  - **Bucketed storage architecture** - Replaced flat store with three lifecycle buckets (`active/`, `archived/`, `deleted/`). Pad location IS lifecycle state — no more `is_deleted` metadata flag. Each bucket has its own `data.json` and content files.
-  - **Archive/unarchive commands** - `padz archive` moves pads to cold storage; `padz unarchive` brings them back. Children always move with their parent.
-  - **`--archived` flag for list** - `padz list --archived` shows archived pads (indexed as `ar1`, `ar2`, etc.)
-  - **Automatic migration** - Legacy flat-layout stores are auto-migrated to bucketed layout on first run. Pads with `is_deleted` move to `deleted/` bucket.
-
-- **Changed**
-  - **Delete/restore use bucket moves** - Delete moves pads from `active/` to `deleted/`; restore moves them back. No more metadata flag toggling.
-  - **Removed `is_deleted` from metadata** - Bucket membership determines lifecycle state. The `deleted` attribute is gone.
-  - **Editor opens real pad files** - Create and edit now open the actual pad file in `.padz/` instead of a temporary file in `/tmp`. This means:
-    - **Crash resilience**: If the editor or system crashes, content is preserved on disk and recovered automatically by reconciliation
-    - **Path autocomplete**: Editor autocomplete suggests project-relative paths (e.g., `../README.md`) instead of `/tmp` files
-    - **No temp file dependency**: Removed `standout-input` dependency from the CLI crate
-  - **Fixed double-title bug in edit** - The edit handler no longer duplicates the title in the editor buffer (`Title\n\nTitle\n\nBody` → `Title\n\nBody`)
-
-- **Fixed**
-  - **Tag display in list view** - Tags were invisible and broke column alignment. Two root causes: standout's `tabular().row()` counted BBCode markup (`[tag]...[/tag]`) as display width, and padz compensated by shrinking the title column per-row, misaligning the time column. Fixed by upgrading to standout 6.2.0 (BBCode-aware width measurement) and switching to sub-columns — title and tags are now sub-columns within a constant-width parent column, with tags right-aligned and the title absorbing remaining space per-row.
-
-## [0.19.0] - 2026-02-13
-
-## [0.19.0] - 2026-02-13
-
-- **Added**
-  - **Todo mode toggle** - New `mode` config (`notes` | `todos`, default `notes`) that adapts padz for note-taking or task management:
-    - **Display**: Todos mode shows status icons (⚪︎ ☉︎︎ ⚫︎); notes mode hides them and gives more title width
-    - **Quick-create**: In todos mode, `padz create Buy Milk` skips the editor; supports `\n` for multi-line (`padz create 'Buy Groceries\nMilk\nEggs'`)
-    - **Quick-edit**: In todos mode, `padz edit 1 Updated Title` updates directly without opening the editor
-    - **Purge**: In todos mode, `padz purge` removes both Done and Deleted pads; in notes mode only Deleted
-
-- **Changed**
-  - **Compact timestamps** - List timestamps now use compact format (` 3d ⏲`, `23h ⏲`) instead of verbose (`3 days ago`), reclaiming ~9 chars for title display. Removed `timeago` dependency.
-  - **Unified pin marker position** - Pin marker `⚲` now appears in the left column (col 0) for both pinned and regular sections, instead of appearing on the right side in the regular list
-  - **Fixed pinned section indentation** - Children of pinned pads now indent correctly, matching the regular list layout. Removed the `right_pin` column.
-
-## [0.18.0] - 2026-02-10
-
-## [0.18.0] - 2026-02-10
-
-- **Added**
-  - **Peek command** - `padz peek` / `padz peek 2 3` shows pad listing with content previews. Shortcut for `padz list --peek`, supports ID filtering and tag filtering.
-
-## [0.17.0] - 2026-02-10
-
-## [0.17.0] - 2026-02-10
-
-- **Added**
-  - **List command ID filtering** - `padz list 2`, `padz list 3 5`, `padz list 1-3` to constrain which pads are shown. Selected pads include their full subtree of children. Uses existing `parse_selectors` infrastructure for ID resolution (paths, ranges, titles).
-  - **Bats live-tests in CI** - Added bats live-tests to pre-commit hook and CI workflow
-
-- **Changed**
-  - **Upgraded standout to v6.0.2** - Major upgrade through 3.8.0 → 4.0.0 → 5.0.0 → 6.0.2, adopting unified single-threaded API, `#[handler]` proc macro, declarative `InputChain` for stdin/editor input, `Output::Render` for template rendering, `pipe_to_clipboard` dispatch attribute, and explicit template mappings for all commands
-  - **ScopedApi pattern** - All handlers migrated to `ScopedApi` wrapper that binds scope, handles error conversion, and wraps results. Handler bodies reduced from ~10 lines to 1-2 lines (~200+ lines of boilerplate removed)
-  - **`#[handler]` macro migration** - All handlers use standout's `#[handler]` macro with `#[dispatch(pure)]` for auto-extraction of CLI args via `#[arg]`, `#[flag]`, and `#[ctx]` annotations
-  - **Unified create/open editor flow** - Extracted shared `edit_and_copy_pads` helper; create now opens the real pad file in editor (same as open) instead of using a temp file
-  - **Consolidated edit/open handlers** - Open dispatches to edit handler; extracted `read_piped_input()` helper shared by create and edit
-  - **Normalized naked invocation** - Extracted `build_dispatch_app()` and `handle_dispatch_result()` for a unified dispatch path; naked invocation injects synthetic command and uses same flow
-  - **View uses template rendering** - View handler returns structured data for `view.jinja` template with automatic clipboard piping (ANSI stripped) instead of manual `println!` and clipboard code
-
-- **Fixed**
-  - View output no longer consumes stdout — clipboard copy is separate from terminal rendering
-  - Handler errors now propagate as non-zero exit codes
-  - Create title priority: CLI title always wins over piped content title
-  - Empty/whitespace piped content in edit returns error instead of silent success
-
 ## [0.16.0] - 2026-01-30
 
 ## [0.16.0] - 2026-01-30
@@ -319,15 +251,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - Demo flow verification script
   - Live testing shell
 
-[Unreleased]: https://github.com/arthur-debert/padz/compare/v0.19.1...HEAD
-[0.19.1]: https://github.com/arthur-debert/padz/compare/v0.19.0...v0.19.1
-[0.19.1]: https://github.com/arthur-debert/padz/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/arthur-debert/padz/compare/v0.18.0...v0.19.0
-[0.19.0]: https://github.com/arthur-debert/padz/compare/v0.18.0...v0.19.0
-[0.18.0]: https://github.com/arthur-debert/padz/compare/v0.17.0...v0.18.0
-[0.18.0]: https://github.com/arthur-debert/padz/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/arthur-debert/padz/compare/v0.16.0...v0.17.0
-[0.17.0]: https://github.com/arthur-debert/padz/compare/v0.16.0...v0.17.0
+[Unreleased]: https://github.com/arthur-debert/padz/compare/v0.16.0...HEAD
 [0.16.0]: https://github.com/arthur-debert/padz/compare/v0.15.1...v0.16.0
 [0.16.0]: https://github.com/arthur-debert/padz/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/arthur-debert/padz/compare/v0.15.0...v0.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Changed**
+  - Unified `padz tag` subcommand replacing `add-tag`, `remove-tag`, and `tags` commands
+  - `padz tag add <id>... <tag>...` with positional args and auto-creation of tags
+  - `padz tag list` and `padz tag list <id>...` now output just tag names (consistent format)
+
 ## [0.16.0] - 2026-01-30
 
 ## [0.16.0] - 2026-01-30

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -433,7 +433,7 @@ fn truncate_match_segments_to_json(
 
 fn format_tags_display(tags: &[String]) -> String {
     tags.iter()
-        .map(|t| format!("\u{300c}{}\u{300d}", t))
+        .map(|t| format!("\u{300c}[tag]{}[/tag]\u{300d}", t.trim()))
         .collect::<Vec<_>>()
         .join(" ")
 }

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -185,11 +185,7 @@ fn should_show_custom_help() -> bool {
         "purge",
         "export",
         "import",
-        "add_tag",
-        "add-tag",
-        "remove_tag",
-        "remove-tag",
-        "tags",
+        "tag",
         "doctor",
         "config",
         "init",
@@ -250,9 +246,7 @@ fn command_groups() -> Vec<CommandGroup> {
                 Some("import".into()),
                 Some("export".into()),
                 None,
-                Some("tags".into()),
-                Some("add_tag".into()),
-                Some("remove_tag".into()),
+                Some("tag".into()),
             ],
         },
         CommandGroup {
@@ -509,32 +503,6 @@ pub enum Commands {
         indexes: Vec<String>,
     },
 
-    /// Add tags to pads
-    #[command(name = "add_tag", alias = "add-tag", display_order = 23)]
-    #[dispatch(pure, template = "modification_result")]
-    AddTag {
-        /// Indexes of the pads (e.g. 1 3 5 or 1-5)
-        #[arg(required = true, num_args = 1.., add = active_pads_completer())]
-        indexes: Vec<String>,
-
-        /// Tag(s) to add (can be specified multiple times)
-        #[arg(long = "tag", short = 't', required = true, num_args = 1..)]
-        tags: Vec<String>,
-    },
-
-    /// Remove tags from pads
-    #[command(name = "remove_tag", alias = "remove-tag", display_order = 24)]
-    #[dispatch(pure, template = "modification_result")]
-    RemoveTag {
-        /// Indexes of the pads (e.g. 1 3 5 or 1-5)
-        #[arg(required = true, num_args = 1.., add = active_pads_completer())]
-        indexes: Vec<String>,
-
-        /// Tag(s) to remove (can be specified multiple times) - if omitted, clears all tags
-        #[arg(long = "tag", short = 't', num_args = 1..)]
-        tags: Vec<String>,
-    },
-
     // --- Data operations ---
     /// Permanently delete pads
     #[command(display_order = 20)]
@@ -579,7 +547,7 @@ pub enum Commands {
     /// Manage tags
     #[command(subcommand, display_order = 25)]
     #[dispatch(nested)]
-    Tags(TagsCommands),
+    Tag(TagCommands),
 
     // --- Misc commands ---
     /// Check and fix data inconsistencies
@@ -639,39 +607,53 @@ pub enum ConfigSubcommand {
     },
 }
 
-/// Tags subcommands
+/// Tag subcommands
 #[derive(Subcommand, Dispatch, Debug)]
-#[dispatch(handlers = handlers::tags)]
-pub enum TagsCommands {
-    /// List all defined tags
-    #[command(alias = "ls", display_order = 25)]
-    #[dispatch(pure, template = "messages")]
-    List,
-
-    /// Create a new tag
-    #[command(display_order = 26)]
-    #[dispatch(pure, template = "messages")]
-    Create {
-        /// Name of the tag to create
-        name: String,
+#[dispatch(handlers = handlers::tag)]
+pub enum TagCommands {
+    /// Add tags to pads (auto-creates tags if needed)
+    #[command(display_order = 25)]
+    #[dispatch(pure, template = "modification_result")]
+    Add {
+        /// Pad selectors followed by tag names (e.g. 1 2 feature work)
+        #[arg(required = true, num_args = 1..)]
+        args: Vec<String>,
     },
 
-    /// Delete a tag (removes from all pads)
-    #[command(alias = "rm", display_order = 27)]
-    #[dispatch(pure, template = "messages")]
-    Delete {
-        /// Name of the tag to delete
-        name: String,
+    /// Remove tags from pads
+    #[command(display_order = 26)]
+    #[dispatch(pure, template = "modification_result")]
+    Remove {
+        /// Pad selectors followed by tag names (e.g. 1 2 feature work)
+        #[arg(required = true, num_args = 1..)]
+        args: Vec<String>,
     },
 
     /// Rename a tag (updates all pads)
-    #[command(alias = "mv", display_order = 28)]
+    #[command(alias = "mv", display_order = 27)]
     #[dispatch(pure, template = "messages")]
     Rename {
         /// Current name of the tag
         old_name: String,
         /// New name for the tag
         new_name: String,
+    },
+
+    /// Delete a tag (removes from all pads)
+    #[command(alias = "rm", display_order = 28)]
+    #[dispatch(pure, template = "messages")]
+    Delete {
+        /// Name of the tag to delete
+        name: String,
+    },
+
+    /// List all defined tags, or tags for specific pads
+    #[command(alias = "ls", display_order = 29)]
+    #[dispatch(pure, template = "messages")]
+    List {
+        /// Pad IDs to show tags for (e.g. 1, 2 3, 1-3). If omitted, lists all tags.
+        #[arg(num_args = 0..)]
+        ids: Vec<String>,
     },
 }
 

--- a/crates/padz/src/cli/templates/_pad_line.jinja
+++ b/crates/padz/src/cli/templates/_pad_line.jinja
@@ -25,7 +25,7 @@
     {"name": "content", "width": pad.title_width, "sub_columns": {
         "columns": [
             {"width": "fill", "overflow": "truncate", "style": title_style},
-            {"width": {"min": 0, "max": 30}, "align": "right", "style": "tag"}
+            {"width": {"min": 0, "max": 30}, "align": "right"}
         ],
         "separator": " "
     }},

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -354,6 +354,16 @@ impl<S: DataStore> PadzApi<S> {
         commands::tags::list_tags(&self.store, scope)
     }
 
+    /// List tags for specific pads.
+    pub fn list_pad_tags<I: AsRef<str>>(
+        &self,
+        scope: Scope,
+        indexes: &[I],
+    ) -> Result<commands::CmdResult> {
+        let selectors = parse_selectors(indexes)?;
+        commands::tags::list_pad_tags(&self.store, scope, &selectors)
+    }
+
     /// Create a new tag in the registry.
     pub fn create_tag(&mut self, scope: Scope, name: &str) -> Result<commands::CmdResult> {
         commands::tags::create_tag(&mut self.store, scope, name)
@@ -396,16 +406,6 @@ impl<S: DataStore> PadzApi<S> {
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
         commands::tagging::remove_tags(&mut self.store, scope, &selectors, tags)
-    }
-
-    /// Clear all tags from pads.
-    pub fn clear_tags_from_pads<I: AsRef<str>>(
-        &mut self,
-        scope: Scope,
-        indexes: &[I],
-    ) -> Result<commands::CmdResult> {
-        let selectors = parse_selectors(indexes)?;
-        commands::tagging::clear_tags(&mut self.store, scope, &selectors)
     }
 }
 
@@ -1120,26 +1120,6 @@ mod tests {
             .unwrap();
 
         assert!(result.messages[0].content.contains("Removed tag"));
-        assert!(result.affected_pads[0].pad.metadata.tags.is_empty());
-    }
-
-    #[test]
-    fn test_api_clear_tags_from_pads() {
-        let mut api = make_api();
-        api.create_pad(Scope::Project, "Test".into(), "".into(), None)
-            .unwrap();
-        api.create_tag(Scope::Project, "work").unwrap();
-        api.create_tag(Scope::Project, "rust").unwrap();
-        api.add_tags_to_pads(
-            Scope::Project,
-            &["1"],
-            &["work".to_string(), "rust".to_string()],
-        )
-        .unwrap();
-
-        let result = api.clear_tags_from_pads(Scope::Project, &["1"]).unwrap();
-
-        assert!(result.messages[0].content.contains("Cleared tags"));
         assert!(result.affected_pads[0].pad.metadata.tags.is_empty());
     }
 

--- a/live-tests/base-fixture.sh
+++ b/live-tests/base-fixture.sh
@@ -32,17 +32,12 @@ padz -g create --no-editor "Global pad: Projects Overview"
 # Create a nested global pad (child of "Projects Overview" which is index 4)
 padz -g create --no-editor --inside 4 "Global pad: Backend Tasks"
 
-# Create tags first, then apply them
-padz -g tags create work
-padz -g tags create important
-padz -g tags create reference
-
-# Tag some global pads (using display indexes)
+# Tag some global pads (using display indexes, tags auto-created)
 # "Meeting Notes" = 1, "Quick Reference" = 2, "API Documentation" = 3
-# Note: Use -- to separate -t options from positional INDEXES argument
-padz -g add-tag -t work -t important -- 1
-padz -g add-tag -t reference -- 2 3
-padz -g add-tag -t work -- 3
+# Tags are auto-created when first used
+padz -g tag add 1 work important
+padz -g tag add 2 3 reference
+padz -g tag add 3 work
 
 # Pin a global pad
 padz -g pin 2
@@ -80,16 +75,10 @@ padz create --no-editor "Project pad: Sprint Backlog"
 padz create --no-editor --inside 4 "Project pad: Sprint Item Alpha"
 padz create --no-editor --inside 4 "Project pad: Sprint Item Beta"
 
-# Create project tags first
-padz tags create feature
-padz tags create priority
-padz tags create bug
-padz tags create testing
-
-# Tag some project pads
-padz add-tag -t feature -t priority -- 1
-padz add-tag -t bug -t priority -- 2
-padz add-tag -t testing -- 3
+# Tag some project pads (tags auto-created)
+padz tag add 1 feature priority
+padz tag add 2 bug priority
+padz tag add 3 testing
 
 # Pin a project pad
 padz pin 1

--- a/live-tests/tests/tags.bats
+++ b/live-tests/tests/tags.bats
@@ -57,7 +57,6 @@ load '../lib/assertions.bash'
     run "${PADZ_BIN}" -g tag list "${index}"
     assert_success
     assert_output_contains "mylisttag"
-    assert_output_contains "Pad For Tag List"
 }
 
 @test "tag list <id> <id>: shows tags for multiple pads" {
@@ -75,14 +74,14 @@ load '../lib/assertions.bash'
     assert_output_contains "tagb"
 }
 
-@test "tag list: pad with no tags shows (no tags)" {
+@test "tag list <id>: pad with no tags shows No tags defined" {
     "${PADZ_BIN}" -g create --no-editor "No Tags Pad" >/dev/null
     local index
     index=$(find_pad_by_title "No Tags Pad" global)
 
     run "${PADZ_BIN}" -g tag list "${index}"
     assert_success
-    assert_output_contains "no tags"
+    assert_output_contains "No tags defined"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Unified `padz tag` subcommand** replaces fragmented `add_tag`, `remove_tag`, and `tags` commands with a single `tag` subcommand using positional args
- **Auto-create tags on first use** — no separate `padz tags create` step needed
- **`tag list` shows per-pad tags** — `padz tag list 1 2` shows tags for those pads (piggybacking on existing multi-ID/range resolution)
- **Cleaner `tag list` output** — removed "X tags defined" preamble, just outputs tag names

### New CLI interface
```
padz tag add <id>... <tag>...        # add tags, auto-create if needed
padz tag remove <id>... <tag>...     # remove tags from pads
padz tag rename <old> <new>          # rename globally
padz tag delete <name>               # delete from registry + all pads
padz tag list                        # list all tags
padz tag list <id>...                # show tags for specific pads
```

## Test plan
- [x] `cargo test` — 380 unit tests pass
- [x] `live-tests/run-tests` — all 100 bats tests pass (13 tag-specific)
- [x] Fixture updated to use new `padz tag add` syntax
- [x] Old commands (`add_tag`, `remove_tag`, `tags create`) no longer parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)