### PR TITLE
feat: add `padz init --link` for persistent data directory sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **`padz init --link <PATH>`** — Persistent data directory linking. Allows multiple directories to share the same padz data store without passing `--data` on every invocation. Creates a `.padz/link` file that redirects to the target project's data. Supports `--unlink` to remove the link. Validates target is initialized and rejects chained links.
+
 ## [0.19.2] - 2026-02-16
 
 ## [0.19.2] - 2026-02-16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "standout",
  "standout-dispatch",
  "standout-macros",
+ "tempfile",
  "unicode-width",
 ]
 

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -35,3 +35,4 @@ anyhow = "1.0"
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.2"
+tempfile = "3.10.1"

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -566,7 +566,15 @@ pub enum Commands {
     /// Initialize the store (optional utility)
     #[command(display_order = 32)]
     #[dispatch(pure, template = "messages")]
-    Init,
+    Init {
+        /// Link to another project's padz data
+        #[arg(long, value_name = "PATH", conflicts_with = "unlink")]
+        link: Option<String>,
+
+        /// Remove an existing link
+        #[arg(long, conflicts_with = "link")]
+        unlink: bool,
+    },
 
     /// Shell completion setup
     #[command(display_order = 34, name = "completion")]

--- a/crates/padz/tests/init_link_e2e.rs
+++ b/crates/padz/tests/init_link_e2e.rs
@@ -1,0 +1,183 @@
+#![allow(deprecated)]
+
+use assert_cmd::cargo::cargo_bin;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn padz_cmd() -> Command {
+    Command::new(cargo_bin("padz"))
+}
+
+#[test]
+fn test_init_link_full_workflow() {
+    let temp = TempDir::new().unwrap();
+    let project_a = temp.path().join("project-a");
+    let project_b = temp.path().join("project-b");
+
+    // Create git repos
+    fs::create_dir_all(&project_a).unwrap();
+    fs::create_dir_all(&project_b).unwrap();
+    fs::create_dir(project_a.join(".git")).unwrap();
+    fs::create_dir(project_b.join(".git")).unwrap();
+
+    let global_dir = temp.path().join("global");
+    fs::create_dir_all(&global_dir).unwrap();
+
+    // 1. Init project-a
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_a)
+        .args(["init"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Initialized"));
+
+    // 2. Create a pad in project-a
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_a)
+        .args(["create", "--no-editor", "hello from A"])
+        .assert()
+        .success();
+
+    // 3. Link project-b to project-a
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_b)
+        .args(["init", "--link", project_a.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Linked to"));
+
+    // Verify link file was created
+    assert!(project_b.join(".padz").join("link").exists());
+
+    // 4. List from project-b — should see project-a's pad
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_b)
+        .args(["list", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello from A"));
+
+    // 5. Create a pad from project-b — should appear in project-a's store
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_b)
+        .args(["create", "--no-editor", "from B via link"])
+        .assert()
+        .success();
+
+    // Verify it shows in project-a's listing
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_a)
+        .args(["list", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("from B via link"));
+
+    // 6. Unlink
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_b)
+        .args(["init", "--unlink"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Unlinked"));
+
+    // Verify link file removed
+    assert!(!project_b.join(".padz").join("link").exists());
+
+    // 7. List from project-b after unlink — should be empty (no local data)
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project_b)
+        .args(["list", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().or(predicate::str::contains("hello from A").not()));
+}
+
+#[test]
+fn test_init_link_rejects_nonexistent_target() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir(project.join(".git")).unwrap();
+
+    let global_dir = temp.path().join("global");
+    fs::create_dir_all(&global_dir).unwrap();
+
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["init", "--link", "/nonexistent/path"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_init_link_rejects_uninitialized_target() {
+    let temp = TempDir::new().unwrap();
+    let target = temp.path().join("target");
+    let source = temp.path().join("source");
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir(source.join(".git")).unwrap();
+    // Target has no .padz at all
+
+    let global_dir = temp.path().join("global");
+    fs::create_dir_all(&global_dir).unwrap();
+
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&source)
+        .args(["init", "--link", target.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_init_unlink_errors_when_no_link() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir(project.join(".git")).unwrap();
+
+    let global_dir = temp.path().join("global");
+    fs::create_dir_all(&global_dir).unwrap();
+
+    // Init without link
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["init"])
+        .assert()
+        .success();
+
+    // Unlink should fail
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["init", "--unlink"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_init_link_and_unlink_conflict() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+
+    // --link and --unlink should conflict
+    padz_cmd()
+        .current_dir(&project)
+        .args(["init", "--link", "/some/path", "--unlink"])
+        .assert()
+        .failure();
+}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -343,6 +343,18 @@ impl<S: DataStore> PadzApi<S> {
         commands::init::run(&self.paths, scope)
     }
 
+    pub fn init_link(
+        &self,
+        local_padz: &std::path::Path,
+        target: &std::path::Path,
+    ) -> Result<commands::CmdResult> {
+        commands::init::link(local_padz, target)
+    }
+
+    pub fn init_unlink(&self, local_padz: &std::path::Path) -> Result<commands::CmdResult> {
+        commands::init::unlink(local_padz)
+    }
+
     pub fn paths(&self) -> &commands::PadzPaths {
         &self.paths
     }

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -1,7 +1,8 @@
 use crate::commands::{CmdMessage, CmdResult, PadzPaths};
-use crate::error::Result;
+use crate::error::{PadzError, Result};
 use crate::model::Scope;
 use std::fs;
+use std::path::Path;
 
 pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
     let dir = paths.scope_dir(scope)?;
@@ -30,4 +31,195 @@ pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
     ));
 
     Ok(result)
+}
+
+/// Create a persistent link from the current project's `.padz/` to another project's data.
+///
+/// This writes an absolute path into `.padz/link` so that all subsequent padz invocations
+/// in the current directory transparently use the target project's data store.
+///
+/// `local_padz` is the **pre-resolution** `.padz/` directory (i.e., the CWD-based one,
+/// before any existing link is followed).
+pub fn link(local_padz: &Path, target: &Path) -> Result<CmdResult> {
+    // Canonicalize target
+    let target = target.canonicalize().map_err(|_| {
+        PadzError::Store(format!(
+            "Target path '{}' does not exist or is not accessible",
+            target.display()
+        ))
+    })?;
+
+    // Determine target .padz dir
+    let target_padz = if target.file_name().is_some_and(|n| n == ".padz") {
+        target.clone()
+    } else {
+        target.join(".padz")
+    };
+
+    // Validate target has been initialized
+    if !target_padz.join("active").exists() {
+        return Err(PadzError::Store(format!(
+            "Target '{}' has not been initialized. Run `padz init` there first.",
+            target_padz.display()
+        )));
+    }
+
+    // Reject chained links
+    if target_padz.join("link").exists() {
+        return Err(PadzError::Store(format!(
+            "Target '{}' is itself a link. Chained links are not supported.",
+            target_padz.display()
+        )));
+    }
+
+    // Create local .padz/ dir if needed
+    fs::create_dir_all(local_padz)?;
+
+    // Write the link file — store the project root (parent of .padz)
+    let target_root = target_padz.parent().unwrap_or(&target_padz);
+    fs::write(
+        local_padz.join("link"),
+        target_root.to_string_lossy().as_bytes(),
+    )?;
+
+    let mut result = CmdResult::default();
+    result.add_message(CmdMessage::success(format!(
+        "Linked to {}",
+        target_padz.display()
+    )));
+    Ok(result)
+}
+
+/// Remove an existing link file.
+///
+/// `local_padz` is the **pre-resolution** `.padz/` directory.
+pub fn unlink(local_padz: &Path) -> Result<CmdResult> {
+    let link_file = local_padz.join("link");
+
+    if !link_file.exists() {
+        return Err(PadzError::Store(
+            "No link exists in this project.".to_string(),
+        ));
+    }
+
+    fs::remove_file(&link_file)?;
+
+    let mut result = CmdResult::default();
+    result.add_message(CmdMessage::success("Unlinked.".to_string()));
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn init_padz_dir(dir: &Path) {
+        fs::create_dir_all(dir.join("active")).unwrap();
+        fs::create_dir_all(dir.join("archived")).unwrap();
+        fs::create_dir_all(dir.join("deleted")).unwrap();
+    }
+
+    #[test]
+    fn test_link_creates_link_file() {
+        let temp = TempDir::new().unwrap();
+
+        // Set up target with initialized .padz
+        let target = temp.path().join("project-a");
+        fs::create_dir_all(&target).unwrap();
+        init_padz_dir(&target.join(".padz"));
+
+        // Set up source
+        let source_padz = temp.path().join("project-b").join(".padz");
+        fs::create_dir_all(&source_padz).unwrap();
+
+        let result = link(&source_padz, &target).unwrap();
+
+        assert!(source_padz.join("link").exists());
+        let link_content = fs::read_to_string(source_padz.join("link")).unwrap();
+        assert_eq!(
+            PathBuf::from(link_content.trim()),
+            target.canonicalize().unwrap()
+        );
+        assert!(result.messages[0].content.contains("Linked to"));
+    }
+
+    #[test]
+    fn test_link_validates_target_exists() {
+        let temp = TempDir::new().unwrap();
+
+        let source_padz = temp.path().join("project-b").join(".padz");
+        fs::create_dir_all(&source_padz).unwrap();
+
+        let result = link(&source_padz, &temp.path().join("nonexistent"));
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn test_link_validates_target_initialized() {
+        let temp = TempDir::new().unwrap();
+
+        // Target exists but not initialized (no active/ dir)
+        let target = temp.path().join("project-a");
+        fs::create_dir_all(target.join(".padz")).unwrap();
+
+        let source_padz = temp.path().join("project-b").join(".padz");
+        fs::create_dir_all(&source_padz).unwrap();
+
+        let result = link(&source_padz, &target);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("not been initialized"));
+    }
+
+    #[test]
+    fn test_link_rejects_chain() {
+        let temp = TempDir::new().unwrap();
+
+        // Target is itself a link
+        let target = temp.path().join("project-a");
+        init_padz_dir(&target.join(".padz"));
+        fs::write(target.join(".padz").join("link"), "/some/path").unwrap();
+
+        let source_padz = temp.path().join("project-b").join(".padz");
+        fs::create_dir_all(&source_padz).unwrap();
+
+        let result = link(&source_padz, &target);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("itself a link"));
+    }
+
+    #[test]
+    fn test_unlink_removes_link_file() {
+        let temp = TempDir::new().unwrap();
+
+        let padz_dir = temp.path().join(".padz");
+        fs::create_dir_all(&padz_dir).unwrap();
+        fs::write(padz_dir.join("link"), "/some/path").unwrap();
+
+        let result = unlink(&padz_dir).unwrap();
+
+        assert!(!padz_dir.join("link").exists());
+        assert!(result.messages[0].content.contains("Unlinked"));
+    }
+
+    #[test]
+    fn test_unlink_errors_when_no_link() {
+        let temp = TempDir::new().unwrap();
+
+        let padz_dir = temp.path().join(".padz");
+        fs::create_dir_all(&padz_dir).unwrap();
+
+        let result = unlink(&padz_dir);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No link exists"));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `padz init --link <PATH>` to create a persistent link from one project's `.padz/` to another project's data store, eliminating the need to pass `--data` on every invocation
- Adds `padz init --unlink` to remove an existing link
- Link resolution happens transparently during initialization — all commands work as if the data were local
- Validates that the target is initialized and rejects chained links (A→B→C)

## How it works

A file `.padz/link` stores the absolute path to the target project root. During `initialize()`, if this file is found, padz follows the redirect and uses the target's `.padz/` directory. The `--data` CLI flag still takes priority over links.

**Use case:** sharing padz data across git worktrees or sibling project directories:
```bash
cd /workspace/project-b
padz init --link /workspace/project-a
padz list   # sees project-a's pads
```

## Test plan

- [x] Unit tests for `resolve_link()` — follows link, no-op when absent, errors on broken/chained/uninitialized targets (5 tests)
- [x] Unit tests for `link()`/`unlink()` commands — creates file, validates target, rejects chains, removes file, errors when absent (6 tests)
- [x] Unit test for `initialize()` following a link end-to-end
- [x] E2E tests using `assert_cmd` — full workflow (init→link→create→verify shared data→unlink), nonexistent target, uninitialized target, no-link unlink, arg conflicts (5 tests)
- [x] All 448 existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)