### PR TITLE
feat: add --editor / -e flag to padz create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **`padz create -e / --editor`** — Force editor mode. Opens the editor regardless of mode (notes or todos). Opposite of `--no-editor`. Conflicts with `--no-editor` if both are specified.
+
 ## [0.20.0] - 2026-02-17
 
 ## [0.20.0] - 2026-02-17

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -413,6 +413,7 @@ fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<String>) {
 #[handler]
 pub fn create(
     #[ctx] ctx: &CommandContext,
+    #[flag] editor: bool,
     #[flag(name = "no_editor")] no_editor: bool,
     #[arg] inside: Option<String>,
     #[arg] title: Vec<String>,
@@ -425,8 +426,10 @@ pub fn create(
     };
     let inside = inside.as_deref();
 
-    // In todos mode, having title args implies quick-create (skip editor)
-    let skip_editor = no_editor || (state.mode == PadzMode::Todos && title_arg.is_some());
+    // --editor forces interactive editor; --no-editor forces skip;
+    // default: todos mode with title args skips editor
+    let skip_editor =
+        !editor && (no_editor || (state.mode == PadzMode::Todos && title_arg.is_some()));
 
     let result = if skip_editor {
         // Quick-create: use args directly, no editor

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -293,6 +293,10 @@ pub enum Commands {
     #[command(alias = "n", display_order = 1)]
     #[dispatch(pure, template = "modification_result")]
     Create {
+        /// Force opening the editor (even in todos mode)
+        #[arg(long, short = 'e', conflicts_with = "no_editor")]
+        editor: bool,
+
         /// Skip opening the editor
         #[arg(long)]
         no_editor: bool,

--- a/live-tests/tests/mode.bats
+++ b/live-tests/tests/mode.bats
@@ -154,6 +154,31 @@ load '../lib/assertions.bash'
     fi
 }
 
+@test "mode: todos create -e forces editor even with args" {
+    "${PADZ_BIN}" -g config set mode todos >/dev/null
+
+    # In todos mode, title args normally skip editor (quick-create).
+    # -e / --editor should force the editor open anyway.
+    # EDITOR=true exits immediately → empty → aborts
+    run "${PADZ_BIN}" -g create -e "Should Force Editor"
+
+    # The pad should NOT exist because editor was forced open,
+    # EDITOR=true produced empty content, so create aborted.
+    if pad_exists "Should Force Editor" global; then
+        echo "FAIL: -e flag should force editor in todos mode, not quick-create" >&2
+        return 1
+    fi
+
+    # Reset
+    "${PADZ_BIN}" -g config set mode notes >/dev/null
+}
+
+@test "mode: --editor and --no-editor conflict" {
+    run "${PADZ_BIN}" -g create --editor --no-editor "Conflicting Flags"
+    assert_failure
+}
+
+
 # -----------------------------------------------------------------------------
 # EDIT: quick-edit in todos mode
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `-e` / `--editor` flag to `padz create` that forces the editor to open regardless of mode
- In todos mode, title args normally trigger quick-create (skip editor); `-e` overrides this and opens the editor anyway
- `--editor` and `--no-editor` conflict if both are specified (clap enforces this)

## Test plan
- [x] Unit tests pass (`cargo test`)
- [x] All 102 live tests pass (`live-tests/run-tests`)
- [x] New test: `todos create -e` forces editor even with args
- [x] New test: `--editor` and `--no-editor` conflict produces error

🤖 Generated with [Claude Code](https://claude.com/claude-code)