### PR TITLE
feat: add UUID support for pad identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **UUID support** — Pads can now be referenced by their UUID in any command that accepts pad IDs. UUIDs are parsed before range detection so hyphens in UUIDs don't confuse the range parser.
+  - **`padz uuid <id>...`** — New command to print full UUIDs, one per line. Supports ranges (e.g. `padz uuid 1-3`). Clean output for scripting/piping.
+  - **`--uuid` flag** on `list`, `search`, `peek`, and `view` — Shows short 8-char UUID prefix next to pad titles in list views, and full UUID in view output.
+
 ## [0.22.0] - 2026-02-28
 
 ## [0.22.0] - 2026-02-28

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -179,6 +179,7 @@ fn should_show_custom_help() -> bool {
         "unpin",
         "u",
         "path",
+        "uuid",
         "complete",
         "done",
         "reopen",
@@ -239,6 +240,7 @@ fn command_groups() -> Vec<CommandGroup> {
                 Some("pin".into()),
                 Some("unpin".into()),
                 Some("path".into()),
+                Some("uuid".into()),
                 None,
                 Some("complete".into()),
                 Some("reopen".into()),
@@ -349,6 +351,10 @@ pub enum Commands {
         /// Filter by tag(s) (can be specified multiple times, uses AND logic)
         #[arg(long = "tag", short = 't', num_args = 1..)]
         tags: Vec<String>,
+
+        /// Show short UUIDs next to pad titles
+        #[arg(long)]
+        uuid: bool,
     },
 
     /// Search pads (dedicated command)
@@ -361,6 +367,10 @@ pub enum Commands {
         /// Filter by tag(s) (can be specified multiple times, uses AND logic)
         #[arg(long = "tag", short = 't', num_args = 1..)]
         tags: Vec<String>,
+
+        /// Show short UUIDs next to pad titles
+        #[arg(long)]
+        uuid: bool,
     },
 
     /// Peek at pad content previews
@@ -374,6 +384,10 @@ pub enum Commands {
         /// Filter by tag(s) (can be specified multiple times, uses AND logic)
         #[arg(long = "tag", short = 't', num_args = 1..)]
         tags: Vec<String>,
+
+        /// Show short UUIDs next to pad titles
+        #[arg(long)]
+        uuid: bool,
     },
 
     // --- Pad operations ---
@@ -388,6 +402,10 @@ pub enum Commands {
         /// Peek at pad content
         #[arg(long)]
         peek: bool,
+
+        /// Show UUID in view output
+        #[arg(long)]
+        uuid: bool,
     },
 
     /// Edit a pad in the editor
@@ -484,6 +502,15 @@ pub enum Commands {
     #[command(display_order = 17)]
     #[dispatch(pure)]
     Path {
+        /// Indexes of the pads (e.g. 1 p1 d1)
+        #[arg(required = true, num_args = 1.., add = all_pads_completer())]
+        indexes: Vec<String>,
+    },
+
+    /// Print the UUID of one or more pads
+    #[command(display_order = 17)]
+    #[dispatch(pure)]
+    Uuid {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]
         indexes: Vec<String>,

--- a/crates/padz/src/cli/templates/view.jinja
+++ b/crates/padz/src/cli/templates/view.jinja
@@ -8,6 +8,9 @@
 {%- if not loop.first %}
 ---
 {% endif -%}
+{%- if pad.uuid %}
+[info]uuid: {{ pad.uuid }}[/info]
+{% endif -%}
 {{ pad.title }}
 
 {{ pad.content }}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -312,6 +312,15 @@ impl<S: DataStore> PadzApi<S> {
         commands::paths::run(&self.store, scope, &selectors)
     }
 
+    pub fn pad_uuids<I: AsRef<str>>(
+        &self,
+        scope: Scope,
+        indexes: &[I],
+    ) -> Result<commands::CmdResult> {
+        let selectors = parse_selectors(indexes)?;
+        commands::uuid::run(&self.store, scope, &selectors)
+    }
+
     pub fn get_path_by_id(&self, scope: Scope, id: uuid::Uuid) -> Result<std::path::PathBuf> {
         use crate::store::Bucket;
         self.store.get_pad_path(&id, scope, Bucket::Active)

--- a/crates/padzapp/src/commands/get.rs
+++ b/crates/padzapp/src/commands/get.rs
@@ -180,6 +180,25 @@ fn filter_by_selectors(
                     }
                 }
             }
+            PadSelector::Uuid(uuid) => {
+                let found = linearized
+                    .iter()
+                    .find(|(_, dp)| dp.pad.metadata.id == *uuid);
+
+                match found {
+                    Some((_, dp)) => {
+                        if !matched
+                            .iter()
+                            .any(|m: &DisplayPad| m.pad.metadata.id == dp.pad.metadata.id)
+                        {
+                            matched.push((*dp).clone());
+                        }
+                    }
+                    None => {
+                        return Err(PadzError::Api(format!("No pad found with UUID {}", uuid)));
+                    }
+                }
+            }
             PadSelector::Title(term) => {
                 let term_lower = term.to_lowercase();
                 let matches: Vec<&DisplayPad> = linearized

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -87,6 +87,7 @@ pub mod tags;
 
 pub mod unarchive;
 pub mod update;
+pub mod uuid;
 pub mod view;
 
 #[derive(Debug, Clone)]

--- a/crates/padzapp/src/commands/uuid.rs
+++ b/crates/padzapp/src/commands/uuid.rs
@@ -1,0 +1,102 @@
+use crate::commands::CmdResult;
+use crate::error::Result;
+use crate::index::PadSelector;
+use crate::model::Scope;
+use crate::store::DataStore;
+
+use super::helpers::resolve_selectors;
+
+pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+    let resolved = resolve_selectors(store, scope, selectors, false)?;
+    let mut result = CmdResult::default();
+
+    for (_, uuid) in resolved {
+        result
+            .messages
+            .push(super::CmdMessage::info(uuid.to_string()));
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::create;
+    use crate::index::DisplayIndex;
+    use crate::model::Scope;
+    use crate::store::bucketed::BucketedStore;
+    use crate::store::mem_backend::MemBackend;
+
+    #[test]
+    fn test_uuid_single_pad() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        let created =
+            create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
+        let expected_uuid = created.affected_pads[0].pad.metadata.id;
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].content, expected_uuid.to_string());
+    }
+
+    #[test]
+    fn test_uuid_multiple_pads() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 2);
+    }
+
+    #[test]
+    fn test_uuid_range() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Pad C".into(), "".into(), None).unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Range(
+                vec![DisplayIndex::Regular(1)],
+                vec![DisplayIndex::Regular(3)],
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(result.messages.len(), 3);
+    }
+}


### PR DESCRIPTION
## Summary

- **UUID input**: Any command that accepts pad IDs now accepts full UUIDs (e.g. `padz delete 550e8400-e29b-41d4-a716-446655440000`)
- **`padz uuid <id>...`**: New command prints full UUIDs, one per line — clean for scripting (`padz uuid 1-3` prints 3 UUIDs)
- **`--uuid` flag**: Added to `list`, `search`, `peek`, and `view` — shows short 8-char UUID prefix in list views and full UUID in view output

## Test plan

- [x] `cargo test` — all 401 unit + 30 integration tests pass
- [x] `cargo clippy` — clean, no warnings
- [ ] `padz create "Test pad"` then `padz uuid 1` — prints the full UUID
- [ ] `padz list --uuid` — shows `(xxxxxxxx) Test pad`
- [ ] Copy UUID and `padz view <full-uuid>` — resolves correctly
- [ ] `padz delete <full-uuid>` — deletes the right pad
- [ ] `padz uuid 1-3` — prints 3 UUIDs (range works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)