### PR TITLE
Fix title weirdness: remove Untitled placeholder and clipboard double-title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Fixed**
+  - **Empty create no longer fills in "Untitled"** — `padz create` with no title now starts with a blank document. Quitting the editor without typing correctly aborts instead of creating a junk "Untitled" pad. Applies to quick-create, piped stdin, and interactive editor paths.
+  - **Clipboard no longer duplicates the title** — `view`, `open`, and `create` (interactive editor) commands were copying title + full content (which already includes the title) to the clipboard. Now correctly extracts title and body before formatting.
+
 ## [0.23.0] - 2026-03-01
 
 ## [0.23.0] - 2026-03-01


### PR DESCRIPTION
## Summary

- **Remove "Untitled" placeholder** — Empty `padz create` calls no longer inject "Untitled" as the default title. All three create paths (quick-create, piped stdin, interactive editor) now start with blank content. Quitting the editor without typing correctly aborts instead of creating a junk pad.
- **Fix clipboard double-title** — `view` and `create` (interactive editor) were calling `format_for_clipboard(title, content)` where `content` already includes the title as its first line, causing the title to appear twice in the clipboard. Now uses `copy_content_to_clipboard()` which correctly extracts title/body before formatting.

## Test plan

- [x] All 401 unit tests + 30 integration tests pass
- [ ] `padz create` → open editor, quit immediately → should abort (no pad created)
- [ ] `padz create` → type content, save, quit → pad created with correct title
- [ ] `padz create --no-editor` → creates empty pad (no "Untitled")
- [ ] `padz view 1` → clipboard contains title once, not twice
- [ ] `echo "My Title" | padz create` → creates pad titled "My Title"

🤖 Generated with [Claude Code](https://claude.com/claude-code)