### PR TITLE
Add `padz delete --completed` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **`padz delete --completed`** — Soft-delete all pads marked as done/completed in a single command. Replaces the previous `--done` flag. Logic moved from CLI handler to command layer for proper testability.
+
 ## [0.24.0] - 2026-03-01
 
 ## [0.24.0] - 2026-03-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Added**
   - **`padz delete --completed`** — Soft-delete all pads marked as done/completed in a single command. Replaces the previous `--done` flag. Logic moved from CLI handler to command layer for proper testability.
+  - **`--completed` flag on `list` and `search`** — Filter to show only completed pads. Replaces the previous `--done` flag on `list` and adds the filter to `search` for the first time.
 
 ## [0.24.0] - 2026-03-01
 

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -537,14 +537,14 @@ pub fn list(
     #[flag] archived: bool,
     #[flag] peek: bool,
     #[flag] planned: bool,
-    #[flag] done: bool,
+    #[flag] completed: bool,
     #[flag(name = "in_progress")] in_progress: bool,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
     let todo_status = if planned {
         Some(TodoStatus::Planned)
-    } else if done {
+    } else if completed {
         Some(TodoStatus::Done)
     } else if in_progress {
         Some(TodoStatus::InProgress)
@@ -588,13 +588,18 @@ pub fn peek(
 pub fn search(
     #[ctx] ctx: &CommandContext,
     #[arg] term: String,
+    #[flag] completed: bool,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
     let filter = PadFilter {
         status: PadStatusFilter::Active,
         search_term: Some(term),
-        todo_status: None,
+        todo_status: if completed {
+            Some(TodoStatus::Done)
+        } else {
+            None
+        },
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -28,7 +28,7 @@ use standout_macros::handler;
 use std::cell::RefCell;
 use std::io::IsTerminal;
 
-use super::render::{build_list_result_value, build_modification_result_value};
+use super::render::{build_list_result_value, build_modification_result_value, ListOptions};
 
 // =============================================================================
 // App State Types (for standout's type-based app_state lookup)
@@ -305,15 +305,22 @@ impl<'a> ScopedApi<'a> {
         ids: &[String],
         show_uuid: bool,
     ) -> Result<Output<Value>, anyhow::Error> {
+        let filtered = filter.search_term.is_some()
+            || filter.todo_status.is_some()
+            || filter.tags.is_some()
+            || !ids.is_empty();
         let result = self.call(|api, scope| api.get_pads(scope, filter, ids))?;
         Ok(Output::Render(build_list_result_value(
             &result.listed_pads,
-            peek,
-            show_deleted_help,
             &result.messages,
-            self.state.output_mode,
-            self.state.mode,
-            show_uuid,
+            ListOptions {
+                peek,
+                show_deleted_help,
+                output_mode: self.state.output_mode,
+                mode: self.state.mode,
+                show_uuid,
+                filtered,
+            },
         )))
     }
 

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -431,12 +431,12 @@ pub enum Commands {
     #[dispatch(pure, template = "modification_result")]
     Delete {
         /// Indexes of the pads (e.g. 1 3 5)
-        #[arg(num_args = 1.., add = active_pads_completer(), required_unless_present = "done_status")]
+        #[arg(num_args = 1.., add = active_pads_completer(), required_unless_present = "completed")]
         indexes: Vec<String>,
 
-        /// Delete all pads marked as done
-        #[arg(long = "done", conflicts_with = "indexes")]
-        done_status: bool,
+        /// Delete all pads marked as completed
+        #[arg(long = "completed", conflicts_with = "indexes")]
+        completed: bool,
     },
 
     /// Restore deleted pads

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -337,15 +337,15 @@ pub enum Commands {
         peek: bool,
 
         /// Show only planned pads
-        #[arg(long, conflicts_with_all = ["done", "in_progress"])]
+        #[arg(long, conflicts_with_all = ["completed", "in_progress"])]
         planned: bool,
 
-        /// Show only done pads
+        /// Show only completed pads
         #[arg(long, conflicts_with_all = ["planned", "in_progress"])]
-        done: bool,
+        completed: bool,
 
         /// Show only in-progress pads
-        #[arg(long, conflicts_with_all = ["planned", "done"])]
+        #[arg(long, conflicts_with_all = ["planned", "completed"])]
         in_progress: bool,
 
         /// Filter by tag(s) (can be specified multiple times, uses AND logic)
@@ -363,6 +363,10 @@ pub enum Commands {
     Search {
         /// Search term
         term: String,
+
+        /// Show only completed pads
+        #[arg(long)]
+        completed: bool,
 
         /// Filter by tag(s) (can be specified multiple times, uses AND logic)
         #[arg(long = "tag", short = 't', num_args = 1..)]

--- a/crates/padz/src/cli/templates/list.jinja
+++ b/crates/padz/src/cli/templates/list.jinja
@@ -1,4 +1,6 @@
-{%- if empty -%}
+{%- if empty_filtered -%}
+[info]No matching pads.[/info]{{ "" | nl -}}
+{%- elif empty -%}
 [empty-message]No pads yet, create one with `padz create`[/empty-message]{{ "" | nl -}}
 {{ help_text }}
 {%- else -%}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -140,6 +140,11 @@ impl<S: DataStore> PadzApi<S> {
         commands::delete::run(&mut self.store, scope, &selectors)
     }
 
+    /// Soft-deletes all active pads marked as Done (completed).
+    pub fn delete_completed_pads(&mut self, scope: Scope) -> Result<commands::CmdResult> {
+        commands::delete::run_completed(&mut self.store, scope)
+    }
+
     pub fn pin_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,

--- a/crates/padzapp/src/commands/get.rs
+++ b/crates/padzapp/src/commands/get.rs
@@ -113,9 +113,9 @@ fn filter_pad_by_attrs(mut dp: DisplayPad, filters: &[AttrFilter]) -> Option<Dis
         .filter_map(|child| filter_pad_by_attrs(child, filters))
         .collect();
 
-    // Include this pad if it matches ALL filters (AND logic)
+    // Include this pad if it matches ALL filters OR has matching children
     let matches_all = filters.iter().all(|f| f.matches(&dp.pad.metadata));
-    if matches_all {
+    if matches_all || !dp.children.is_empty() {
         Some(dp)
     } else {
         None


### PR DESCRIPTION
## Summary
- Adds `--completed` flag to `padz delete` that soft-deletes all pads marked as done/completed
- Replaces the previous `--done` flag with the more intuitive `--completed` name
- Moves the filtering logic from the CLI handler layer down to the command layer (`run_completed`) for proper testability

## Test plan
- [x] `delete_completed_deletes_done_pads` — verifies Done pads are moved to Deleted bucket
- [x] `delete_completed_with_no_done_pads_returns_empty` — no-op when nothing is completed
- [x] `delete_completed_skips_in_progress_pads` — only Done status is affected, InProgress stays
- [x] All existing tests pass (pre-commit hook runs full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)