### PR TITLE
Fix double title in view output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Fixed**
+  - **Double title in `view` output** — `padz view` was rendering the title twice because `pad.content` (which includes the title) was passed directly to the template that also renders the title separately. Now extracts just the body before passing to the template.
+
 ## [0.25.0] - 2026-03-02
 
 ## [0.25.0] - 2026-03-02

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -342,9 +342,13 @@ impl<'a> ScopedApi<'a> {
             .listed_pads
             .iter()
             .map(|dp| {
+                // Extract body (content minus title) to avoid double-title in output
+                let body = extract_title_and_body(&dp.pad.content)
+                    .map(|(_, b)| b)
+                    .unwrap_or_default();
                 let mut v = serde_json::json!({
                     "title": dp.pad.metadata.title,
-                    "content": dp.pad.content,
+                    "content": body,
                 });
                 if show_uuid {
                     v["uuid"] = serde_json::json!(dp.pad.metadata.id.to_string());


### PR DESCRIPTION
## Summary
- `padz view` was rendering the title twice: once from the template's `{{ pad.title }}` and again as the first line of `{{ pad.content }}` (which stores the full normalized content including title)
- Now extracts just the body (content minus title) before passing to the view template

## Test plan
- [x] `padz view 1` no longer shows duplicate title
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)