### PR TITLE
Rename file_ext to format with per-pad override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Changed**
+  - **Renamed `file_ext` to `format`** — The config key, CLI option, and internal APIs now use `format` instead of `file_ext`. Accepts aliases: `markdown` → `md`, `text` → `txt`. Breaking change in config (`padz.toml`): rename `file_ext = "md"` to `format = "md"`.
+  - **`--format` flag on `create`** — Override the global format for a single pad: `padz create --format md "My Note"`. The override only affects the new pad; subsequent pads use the global setting.
+  - **Mixed-format data store** — The store now fully supports pads with different file extensions. Changing the format setting does not migrate or rename existing pads. Reading/editing pads works regardless of their original extension.
+  - **Extension-preserving updates** — Editing or updating an existing pad preserves its original file extension, even if the global format has changed since creation.
+
 ## [0.25.1] - 2026-03-09
 
 ## [0.25.1] - 2026-03-09

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -424,6 +424,7 @@ pub fn create(
     #[flag] editor: bool,
     #[flag(name = "no_editor")] no_editor: bool,
     #[arg] inside: Option<String>,
+    #[arg] format: Option<String>,
     #[arg] title: Vec<String>,
 ) -> Result<Output<Value>, anyhow::Error> {
     let state = get_state(ctx);
@@ -433,6 +434,26 @@ pub fn create(
         Some(title.join(" "))
     };
     let inside = inside.as_deref();
+    let format_ref = format.as_deref();
+
+    // Helper to call create_pad with or without format override
+    fn do_create(
+        state: &AppState,
+        title: String,
+        content: String,
+        inside: Option<&str>,
+        format: Option<&str>,
+    ) -> std::result::Result<padzapp::commands::CmdResult, anyhow::Error> {
+        state.with_api(|api| {
+            if let Some(fmt) = format {
+                api.create_pad_with_format(state.scope, title, content, inside, fmt)
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            } else {
+                api.create_pad(state.scope, title, content, inside)
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+        })
+    }
 
     // --editor forces interactive editor; --no-editor forces skip;
     // default: todos mode with title args skips editor
@@ -446,10 +467,7 @@ pub fn create(
         let expanded = raw_text.replace("\\n", "\n");
         let (title, body) =
             extract_title_and_body(&expanded).unwrap_or_else(|| (String::new(), String::new()));
-        let result = state.with_api(|api| {
-            api.create_pad(state.scope, title.clone(), body.clone(), inside)
-                .map_err(|e| anyhow::anyhow!("{}", e))
-        })?;
+        let result = do_create(state, title.clone(), body.clone(), inside, format_ref)?;
         // Copy to clipboard
         let clipboard_text = format_for_clipboard(&title, &body);
         let _ = copy_to_clipboard(&clipboard_text);
@@ -470,20 +488,14 @@ pub fn create(
             (_, false) => parsed.title, // parsed has title, no CLI override
             (None, true) => String::new(),
         };
-        let result = state.with_api(|api| {
-            api.create_pad(state.scope, final_title, parsed.content, inside)
-                .map_err(|e| anyhow::anyhow!("{}", e))
-        })?;
+        let result = do_create(state, final_title, parsed.content, inside, format_ref)?;
         // Copy to clipboard
         copy_content_to_clipboard(&raw);
         result
     } else {
         // Interactive: create pad first, then open real file in editor
         let initial_title = title_arg.clone().unwrap_or_default();
-        let create_result = state.with_api(|api| {
-            api.create_pad(state.scope, initial_title, String::new(), inside)
-                .map_err(|e| anyhow::anyhow!("{}", e))
-        })?;
+        let create_result = do_create(state, initial_title, String::new(), inside, format_ref)?;
         let pad_path = create_result.pad_paths[0].clone();
         let pad_id = create_result.affected_pads[0].pad.metadata.id;
 

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -307,6 +307,10 @@ pub enum Commands {
         #[arg(long, short = 'i')]
         inside: Option<String>,
 
+        /// File format for this pad (e.g., md, txt, markdown, text). Overrides global setting.
+        #[arg(long, short = 'f')]
+        format: Option<String>,
+
         /// Title words (joined with spaces, optional - opens empty editor if not provided)
         #[arg(trailing_var_arg = true)]
         title: Vec<String>,
@@ -638,12 +642,12 @@ pub enum ConfigSubcommand {
     },
     /// Show the resolved value for a config key
     Get {
-        /// Dotted key path (e.g. "file_ext")
+        /// Dotted key path (e.g. "format")
         key: String,
     },
     /// Set a configuration value
     Set {
-        /// Dotted key path (e.g. "file_ext")
+        /// Dotted key path (e.g. "format")
         key: String,
         /// Value to set
         value: String,

--- a/crates/padz/tests/format_e2e.rs
+++ b/crates/padz/tests/format_e2e.rs
@@ -1,0 +1,321 @@
+#![allow(deprecated)]
+
+use assert_cmd::cargo::cargo_bin;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn padz_cmd() -> Command {
+    Command::new(cargo_bin("padz"))
+}
+
+/// Helper to set up a project with git + padz init
+fn setup_project(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    let project = temp.path().join("project");
+    let global_dir = temp.path().join("global");
+
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&global_dir).unwrap();
+    fs::create_dir(project.join(".git")).unwrap();
+
+    // Init padz
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["init"])
+        .assert()
+        .success();
+
+    (project, global_dir)
+}
+
+#[test]
+fn test_create_uses_default_txt_format() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Create a pad (default format = txt)
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "hello"])
+        .assert()
+        .success();
+
+    // Check that a .txt file was created in .padz/active/
+    let active_dir = project.join(".padz").join("active");
+    let entries: Vec<_> = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".txt")
+        })
+        .collect();
+
+    assert_eq!(entries.len(), 1, "Expected one .txt pad file");
+}
+
+#[test]
+fn test_create_with_format_override_creates_md() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Create a pad with --format md
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "--format", "md", "markdown pad"])
+        .assert()
+        .success();
+
+    // Check that a .md file was created
+    let active_dir = project.join(".padz").join("active");
+    let entries: Vec<_> = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".md")
+        })
+        .collect();
+
+    assert_eq!(entries.len(), 1, "Expected one .md pad file");
+}
+
+#[test]
+fn test_format_override_does_not_affect_subsequent_creates() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Create first pad with --format md
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "--format", "md", "md pad"])
+        .assert()
+        .success();
+
+    // Create second pad without format (should use default .txt)
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "txt pad"])
+        .assert()
+        .success();
+
+    let active_dir = project.join(".padz").join("active");
+    let md_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".md")
+        })
+        .count();
+    let txt_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".txt")
+        })
+        .count();
+
+    assert_eq!(md_count, 1, "Expected one .md file");
+    assert_eq!(txt_count, 1, "Expected one .txt file");
+}
+
+#[test]
+fn test_mixed_formats_list_and_view_work() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Create pads with different formats
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "--format", "md", "markdown note"])
+        .assert()
+        .success();
+
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "plain text note"])
+        .assert()
+        .success();
+
+    // List should show both
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["list", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("markdown note"))
+        .stdout(predicate::str::contains("plain text note"));
+
+    // View each should work
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["view", "1", "--output", "json"])
+        .assert()
+        .success();
+
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["view", "2", "--output", "json"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_config_set_format_affects_new_pads() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Set global format to md
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["config", "set", "format", "md"])
+        .assert()
+        .success();
+
+    // Create a pad (should use md from config)
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "after config change"])
+        .assert()
+        .success();
+
+    let active_dir = project.join(".padz").join("active");
+    let md_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".md")
+        })
+        .count();
+
+    assert_eq!(md_count, 1, "New pad should use .md from config");
+}
+
+#[test]
+fn test_config_set_format_does_not_rename_existing_pads() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Create a pad with default .txt
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "old pad"])
+        .assert()
+        .success();
+
+    // Change format to md
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["config", "set", "format", "md"])
+        .assert()
+        .success();
+
+    // The existing .txt pad should still be a .txt file
+    let active_dir = project.join(".padz").join("active");
+    let txt_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".txt")
+        })
+        .count();
+
+    assert_eq!(
+        txt_count, 1,
+        "Existing .txt pad should NOT be migrated to .md"
+    );
+
+    // And the old pad should still be listable
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["list", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("old pad"));
+}
+
+#[test]
+fn test_format_alias_markdown_creates_md() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Create with "markdown" alias
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args([
+            "create",
+            "--no-editor",
+            "--format",
+            "markdown",
+            "alias test",
+        ])
+        .assert()
+        .success();
+
+    let active_dir = project.join(".padz").join("active");
+    let md_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".md")
+        })
+        .count();
+
+    assert_eq!(md_count, 1, "\"markdown\" alias should create .md file");
+}
+
+#[test]
+fn test_format_alias_text_creates_txt() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Set format to md first
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["config", "set", "format", "md"])
+        .assert()
+        .success();
+
+    // Create with "text" alias (should override config and create .txt)
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "--format", "text", "text alias"])
+        .assert()
+        .success();
+
+    let active_dir = project.join(".padz").join("active");
+    let txt_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".txt")
+        })
+        .count();
+
+    assert_eq!(txt_count, 1, "\"text\" alias should create .txt file");
+}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -74,9 +74,11 @@
 //! - Storage behavior (tested in store modules)
 
 use crate::commands;
+use crate::config::normalize_format;
 use crate::error::{PadzError, Result};
 use crate::index::{parse_index_or_range, PadSelector};
 use crate::model::{Pad, Scope};
+use crate::store::fs::FileStore;
 use crate::store::DataStore;
 
 /// The main API facade for padz operations.
@@ -561,6 +563,32 @@ fn normalize_single_to_deleted(s: &str) -> String {
 }
 
 // parse_index_or_range and parse_path removed (imported from index.rs)
+
+/// FileStore-specific methods that support format overrides.
+impl PadzApi<FileStore> {
+    /// Create a pad with an explicit format override (e.g., "md", "txt").
+    /// The format is temporary — it only affects this pad's file extension.
+    pub fn create_pad_with_format(
+        &mut self,
+        scope: Scope,
+        title: String,
+        content: String,
+        parent: Option<&str>,
+        format: &str,
+    ) -> Result<commands::CmdResult> {
+        let parent_selector = if let Some(p) = parent {
+            Some(parse_index_or_range(p).map_err(PadzError::Api)?)
+        } else {
+            None
+        };
+        let prev_format = self.store.format_ext().to_string();
+        let normalized = normalize_format(format);
+        self.store.set_format(&normalized);
+        let result = commands::create::run(&mut self.store, scope, title, content, parent_selector);
+        self.store.set_format(&prev_format);
+        result
+    }
+}
 
 pub use crate::model::TodoStatus;
 pub use commands::get::{PadFilter, PadStatusFilter};

--- a/crates/padzapp/src/config.rs
+++ b/crates/padzapp/src/config.rs
@@ -6,7 +6,7 @@
 //! ## Storage Hierarchy
 //!
 //! Configuration is resolved in priority order:
-//! 1. **Environment variables**: `PADZ__FILE_EXT`, `PADZ__IMPORT_EXTENSIONS`, etc.
+//! 1. **Environment variables**: `PADZ__FORMAT`, `PADZ__IMPORT_EXTENSIONS`, etc.
 //! 2. **Project Config**: `.padz/padz.toml` — Overrides everything for this repo.
 //! 3. **Global Config**: OS-appropriate config directory (via `directories` crate).
 //! 4. **Compiled Defaults**: Built-in fallbacks via `#[config(default = ...)]`.
@@ -15,15 +15,15 @@
 //!
 //! | Key | Default | Description |
 //! |-----|---------|-------------|
-//! | `file_ext` | `txt` | Extension for new pad files (e.g., `md`, `txt`) |
+//! | `format` | `txt` | Format for new pad files (e.g., `md`, `txt`, `markdown`, `text`) |
 //! | `import_extensions` | `["md", "txt", "text", "lex"]` | Extensions for `padz import` |
 //! | `mode` | `notes` | UI mode: `notes` (clean) or `todos` (status icons, quick-create) |
 //!
 //! ## Extension Convention
 //!
-//! Extensions are stored **without** leading dots (`md`, not `.md`).
+//! Format values are stored **without** leading dots (`md`, not `.md`).
 //! Dots are stripped on intake via deserialization and added back by accessor
-//! methods ([`PadzConfig::file_ext()`], [`PadzConfig::import_extensions()`]).
+//! methods ([`PadzConfig::format_ext()`], [`PadzConfig::import_extensions()`]).
 //!
 //! ## CLI Usage
 //!
@@ -74,14 +74,27 @@ fn default_import_ext() -> Vec<String> {
     ]
 }
 
+/// Normalize a format value to a canonical extension.
+///
+/// Accepts aliases like "markdown" → "md", "text" → "txt".
+/// Strips leading dots.
+pub fn normalize_format(raw: &str) -> String {
+    let bare = raw.strip_prefix('.').unwrap_or(raw);
+    match bare.to_lowercase().as_str() {
+        "markdown" => "md".to_string(),
+        "text" => "txt".to_string(),
+        other => other.to_string(),
+    }
+}
+
 /// Configuration for padz, stored in `padz.toml`.
 #[derive(Config, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PadzConfig {
-    /// Extension for new pad files (e.g., "txt", "md", "rs").
-    /// Stored without leading dot; use file_ext() for the dotted form.
+    /// Format for new pad files (e.g., "txt", "md", "markdown", "text").
+    /// Stored without leading dot; use format_ext() for the dotted form.
     #[config(deserialize_with = strip_leading_dot, default = "txt")]
     #[serde(deserialize_with = "strip_leading_dot")]
-    pub file_ext: String,
+    pub format: String,
 
     /// Extensions to look for when importing directories (e.g. "md", "txt").
     /// Stored without leading dots; use import_extensions() for the dotted form.
@@ -97,7 +110,7 @@ pub struct PadzConfig {
 impl Default for PadzConfig {
     fn default() -> Self {
         Self {
-            file_ext: "txt".to_string(),
+            format: "txt".to_string(),
             import_extensions: None,
             mode: PadzMode::default(),
         }
@@ -106,9 +119,10 @@ impl Default for PadzConfig {
 
 impl PadzConfig {
     /// Get the file extension with a leading dot (e.g., `.txt`, `.md`).
-    pub fn file_ext(&self) -> String {
-        let ext = self.file_ext.strip_prefix('.').unwrap_or(&self.file_ext);
-        format!(".{}", ext)
+    /// Normalizes aliases: "markdown" → ".md", "text" → ".txt".
+    pub fn format_ext(&self) -> String {
+        let normalized = normalize_format(&self.format);
+        format!(".{}", normalized)
     }
 
     /// Get import extensions with leading dots (e.g., `.md`, `.txt`),
@@ -134,8 +148,8 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = PadzConfig::default();
-        assert_eq!(config.file_ext, "txt");
-        assert_eq!(config.file_ext(), ".txt");
+        assert_eq!(config.format, "txt");
+        assert_eq!(config.format_ext(), ".txt");
         assert_eq!(
             config.import_extensions(),
             vec![".md", ".txt", ".text", ".lex"]
@@ -143,23 +157,48 @@ mod tests {
     }
 
     #[test]
-    fn test_file_ext_stored_without_dot() {
+    fn test_format_stored_without_dot() {
         let config = PadzConfig {
-            file_ext: "md".to_string(),
+            format: "md".to_string(),
             ..Default::default()
         };
-        assert_eq!(config.file_ext, "md");
-        assert_eq!(config.file_ext(), ".md");
+        assert_eq!(config.format, "md");
+        assert_eq!(config.format_ext(), ".md");
     }
 
     #[test]
-    fn test_file_ext_accessor_handles_legacy_dot() {
+    fn test_format_accessor_handles_legacy_dot() {
         // Even if a dot slips in, accessor still works correctly
         let config = PadzConfig {
-            file_ext: ".rs".to_string(),
+            format: ".rs".to_string(),
             ..Default::default()
         };
-        assert_eq!(config.file_ext(), ".rs");
+        assert_eq!(config.format_ext(), ".rs");
+    }
+
+    #[test]
+    fn test_format_aliases() {
+        let config = PadzConfig {
+            format: "markdown".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(config.format_ext(), ".md");
+
+        let config = PadzConfig {
+            format: "text".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(config.format_ext(), ".txt");
+    }
+
+    #[test]
+    fn test_normalize_format() {
+        assert_eq!(normalize_format("markdown"), "md");
+        assert_eq!(normalize_format("text"), "txt");
+        assert_eq!(normalize_format(".md"), "md");
+        assert_eq!(normalize_format("md"), "md");
+        assert_eq!(normalize_format("txt"), "txt");
+        assert_eq!(normalize_format("rs"), "rs");
     }
 
     #[test]
@@ -192,16 +231,16 @@ mod tests {
     #[test]
     fn test_strip_leading_dot_deserializer() {
         // Simulate what confique does: deserialize a TOML string through our normalizer
-        let toml_str = r#"file_ext = ".md""#;
+        let toml_str = r#"format = ".md""#;
         let config: PadzConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.file_ext, "md");
+        assert_eq!(config.format, "md");
     }
 
     #[test]
     fn test_strip_leading_dot_deserializer_no_dot() {
-        let toml_str = r#"file_ext = "md""#;
+        let toml_str = r#"format = "md""#;
         let config: PadzConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.file_ext, "md");
+        assert_eq!(config.format, "md");
     }
 
     #[test]
@@ -212,21 +251,21 @@ mod tests {
 
     #[test]
     fn test_mode_deserialize_notes() {
-        let toml_str = "file_ext = \"txt\"\nmode = \"notes\"";
+        let toml_str = "format = \"txt\"\nmode = \"notes\"";
         let config: PadzConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.mode, PadzMode::Notes);
     }
 
     #[test]
     fn test_mode_deserialize_todos() {
-        let toml_str = "file_ext = \"txt\"\nmode = \"todos\"";
+        let toml_str = "format = \"txt\"\nmode = \"todos\"";
         let config: PadzConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.mode, PadzMode::Todos);
     }
 
     #[test]
     fn test_mode_defaults_when_absent() {
-        let toml_str = r#"file_ext = "txt""#;
+        let toml_str = r#"format = "txt""#;
         let config: PadzConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.mode, PadzMode::Notes);
     }

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -267,14 +267,14 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
         .search_mode(SearchMode::Merge)
         .load()
         .unwrap_or_default();
-    let file_ext = config.file_ext();
+    let format_ext = config.format_ext();
 
     // Migrate legacy flat layout to bucketed layout (if needed)
     migrate_if_needed(&project_padz_dir);
     migrate_if_needed(&global_data_dir);
 
     let store = FileStore::new_fs(Some(project_padz_dir.clone()), global_data_dir.clone())
-        .with_file_ext(&file_ext);
+        .with_format(&format_ext);
     let paths = PadzPaths {
         project: Some(project_padz_dir),
         global: global_data_dir,

--- a/crates/padzapp/src/store/fs.rs
+++ b/crates/padzapp/src/store/fs.rs
@@ -9,7 +9,7 @@ impl FileStore {
     /// Create a new bucketed file store from project/global root paths.
     ///
     /// Each bucket gets its own subdirectory:
-    /// - `{root}/active/`  — active pads (data.json + pad-*.txt)
+    /// - `{root}/active/`  — active pads (data.json + pad-*.ext)
     /// - `{root}/archived/` — archived pads
     /// - `{root}/deleted/`  — deleted pads
     /// - `{root}/`          — scope-level files (tags.json, padz.toml)
@@ -32,15 +32,21 @@ impl FileStore {
         )
     }
 
-    pub fn with_file_ext(mut self, ext: &str) -> Self {
-        self.active = PadStore::with_backend(self.active.backend.with_file_ext(ext));
-        self.archived = PadStore::with_backend(self.archived.backend.with_file_ext(ext));
-        self.deleted = PadStore::with_backend(self.deleted.backend.with_file_ext(ext));
-        // tag_backend doesn't need file_ext (no content files)
+    pub fn with_format(mut self, ext: &str) -> Self {
+        self.active = PadStore::with_backend(self.active.backend.with_format(ext));
+        self.archived = PadStore::with_backend(self.archived.backend.with_format(ext));
+        self.deleted = PadStore::with_backend(self.deleted.backend.with_format(ext));
+        // tag_backend doesn't need format (no content files)
         self
     }
 
-    pub fn file_ext(&self) -> &str {
-        self.active.backend.file_ext()
+    pub fn set_format(&mut self, ext: &str) {
+        self.active.backend.set_format(ext);
+        self.archived.backend.set_format(ext);
+        self.deleted.backend.set_format(ext);
+    }
+
+    pub fn format_ext(&self) -> &str {
+        self.active.backend.format_ext()
     }
 }

--- a/crates/padzapp/src/store/fs_backend.rs
+++ b/crates/padzapp/src/store/fs_backend.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 pub struct FsBackend {
     project_root: Option<PathBuf>,
     global_root: PathBuf,
-    file_ext: String,
+    format: String,
 }
 
 impl FsBackend {
@@ -20,25 +20,29 @@ impl FsBackend {
         Self {
             project_root,
             global_root,
-            file_ext: ".txt".to_string(),
+            format: ".txt".to_string(),
         }
     }
 
-    pub fn with_file_ext(mut self, ext: &str) -> Self {
-        if ext.starts_with('.') {
-            self.file_ext = ext.to_string();
-        } else {
-            self.file_ext = format!(".{}", ext);
-        }
+    pub fn with_format(mut self, ext: &str) -> Self {
+        self.set_format(ext);
         self
     }
 
-    pub fn file_ext(&self) -> &str {
-        &self.file_ext
+    pub fn set_format(&mut self, ext: &str) {
+        if ext.starts_with('.') {
+            self.format = ext.to_string();
+        } else {
+            self.format = format!(".{}", ext);
+        }
+    }
+
+    pub fn format_ext(&self) -> &str {
+        &self.format
     }
 
     fn pad_filename(&self, id: &Uuid) -> String {
-        format!("pad-{}{}", id, self.file_ext)
+        format!("pad-{}{}", id, self.format)
     }
 
     fn get_store_path_by_scope(&self, scope: Scope) -> Result<PathBuf> {
@@ -58,18 +62,27 @@ impl FsBackend {
         Ok(())
     }
 
+    /// Find the pad file for a given UUID, regardless of its actual extension.
+    ///
+    /// Tries the configured format first (fast path), then scans the directory
+    /// for any file matching `pad-{uuid}.*`. This supports mixed-format stores
+    /// where different pads may have been created with different format settings.
     fn find_pad_file(&self, root: &Path, id: &Uuid) -> Option<PathBuf> {
-        // 1. Configured extension
+        // 1. Try configured format (fast path)
         let path = root.join(self.pad_filename(id));
         if path.exists() {
             return Some(path);
         }
 
-        // 2. Fallback .txt
-        if self.file_ext != ".txt" {
-            let txt_path = root.join(format!("pad-{}.txt", id));
-            if txt_path.exists() {
-                return Some(txt_path);
+        // 2. Scan directory for any matching file (mixed-format support)
+        let prefix = format!("pad-{}", id);
+        if let Ok(entries) = fs::read_dir(root) {
+            for entry in entries.flatten() {
+                if let Some(name) = entry.file_name().to_str() {
+                    if name.starts_with(&prefix) && entry.path().is_file() {
+                        return Some(entry.path());
+                    }
+                }
             }
         }
         None
@@ -145,7 +158,13 @@ impl StorageBackend for FsBackend {
         let root = self.get_store_path_by_scope(scope)?;
         self.ensure_dir(&root)?;
 
-        let target_path = root.join(self.pad_filename(id));
+        // Use existing file path if pad already exists (preserves original extension).
+        // Otherwise use configured format for new pads.
+        let target_path = if let Some(existing) = self.find_pad_file(&root, id) {
+            existing
+        } else {
+            root.join(self.pad_filename(id))
+        };
 
         // Atomic Write
         let tmp_path = root.join(format!(".pad-{}.tmp", Uuid::new_v4()));

--- a/crates/padzapp/src/store/mod.rs
+++ b/crates/padzapp/src/store/mod.rs
@@ -32,9 +32,9 @@
 //!
 //! ## File Extension Handling
 //!
-//! - New pads use the configured `file-ext` (default `.txt`)
-//! - When reading, tries configured extension first, falls back to `.txt`
-//! - Mixed extensions are supported gracefully
+//! - New pads use the configured `format` (default `.txt`)
+//! - When reading, tries configured extension first, scans for any match
+//! - Mixed extensions are fully supported (different pads can have different formats)
 //!
 //! ## Metadata Fields
 //!

--- a/crates/padzapp/tests/fs_backend_test.rs
+++ b/crates/padzapp/tests/fs_backend_test.rs
@@ -145,7 +145,7 @@ fn test_fs_backend_scope_isolation() {
 #[test]
 fn test_fs_backend_custom_extension() {
     let (proj, _glob, backend) = setup();
-    let backend = backend.with_file_ext(".md");
+    let backend = backend.with_format(".md");
 
     let id = Uuid::new_v4();
     let scope = Scope::Project;
@@ -163,7 +163,7 @@ fn test_fs_backend_custom_extension() {
 fn test_fs_backend_extension_fallback() {
     let (proj, _glob, backend) = setup();
     // Configured with .md
-    let backend = backend.with_file_ext(".md");
+    let backend = backend.with_format(".md");
 
     let id = Uuid::new_v4();
     let scope = Scope::Project;
@@ -247,10 +247,10 @@ fn test_fs_backend_scope_available() {
 fn test_fs_backend_extension_without_dot() {
     let (proj, _glob, backend) = setup();
     // Use extension WITHOUT leading dot
-    let backend = backend.with_file_ext("md");
+    let backend = backend.with_format("md");
 
     // Verify it normalizes to have dot
-    assert_eq!(backend.file_ext(), ".md");
+    assert_eq!(backend.format_ext(), ".md");
 
     let id = Uuid::new_v4();
     let scope = Scope::Project;

--- a/crates/padzapp/tests/fs_wrapper_test.rs
+++ b/crates/padzapp/tests/fs_wrapper_test.rs
@@ -10,11 +10,11 @@ fn test_filestore_wrapper_methods() {
     // Test new
     let store = FileStore::new_fs(Some(proj.path().to_path_buf()), glob.path().to_path_buf());
 
-    // Test config method delegtion
-    let store = store.with_file_ext(".md");
+    // Test config method delegation
+    let store = store.with_format(".md");
 
     // Test getter delegation
-    assert_eq!(store.file_ext(), ".md");
+    assert_eq!(store.format_ext(), ".md");
 
     // Verify it still works as a store
     let result = store.sync(Scope::Project);

--- a/live-tests/tests/config-scopes.bats
+++ b/live-tests/tests/config-scopes.bats
@@ -87,7 +87,7 @@ teardown() {
 
 @test "config: list without -g shows merged config" {
     cd "${PROJECT_A}"
-    "${PADZ_BIN}" -g config set file_ext md >/dev/null
+    "${PADZ_BIN}" -g config set format md >/dev/null
     "${PADZ_BIN}" config set mode todos >/dev/null
 
     # Merged list should show both values
@@ -99,7 +99,7 @@ teardown() {
 
 @test "config: list with -g shows only global entries" {
     cd "${PROJECT_A}"
-    "${PADZ_BIN}" -g config set file_ext md >/dev/null
+    "${PADZ_BIN}" -g config set format md >/dev/null
     "${PADZ_BIN}" config set mode todos >/dev/null
 
     # Scoped list should only show global entries
@@ -137,7 +137,7 @@ teardown() {
 
 @test "config: different keys from each scope merge together" {
     cd "${PROJECT_A}"
-    "${PADZ_BIN}" -g config set file_ext md >/dev/null
+    "${PADZ_BIN}" -g config set format md >/dev/null
     "${PADZ_BIN}" config set mode todos >/dev/null
 
     # Both should be visible in merged view


### PR DESCRIPTION
## Summary
- Rename `file_ext` config key to `format` throughout settings, store, API, and CLI
- Add `--format` / `-f` flag on `padz create` to override the global format for a single pad (e.g., `padz create --format md "My Note"`)
- Add format aliases: `markdown` → `md`, `text` → `txt`
- Make the data store fully support mixed file extensions — different pads can have different formats
- Preserve the original file extension when editing/updating existing pads (changing config doesn't rename files)

## Test plan
- [x] 406 unit tests pass
- [x] 8 new e2e tests covering: default format, format override, format isolation between creates, mixed-format list/view, config-driven format, no retroactive migration, format aliases
- [x] 5 existing init_link e2e tests pass
- [x] 102 bats live-tests pass (updated `file_ext` → `format` references)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)