### PR TITLE
Adapt list/search output to terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Changed**
+  - **Dynamic terminal width** — List and search output now adapts to the actual terminal width instead of being fixed at 100 columns. Minimum width is 30 characters; below that the output wraps. Titles truncate to fit narrow terminals.
+
 ## [0.26.0] - 2026-03-27
 
 ## [0.26.0] - 2026-03-27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "standout-dispatch",
  "standout-macros",
  "tempfile",
+ "terminal_size",
  "unicode-width",
 ]
 

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -29,6 +29,7 @@ standout-dispatch = "6.2.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+terminal_size = "0.4"
 unicode-width = "0.2.2"
 anyhow = "1.0"
 

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -31,9 +31,17 @@ use padzapp::index::{DisplayIndex, DisplayPad};
 use padzapp::peek::format_as_peek;
 use standout::{truncate_to_width, OutputMode};
 
-/// Configuration for list rendering.
-pub const LINE_WIDTH: usize = 100;
+/// Minimum terminal width — below this we stop shrinking and let the terminal wrap.
+pub const MIN_LINE_WIDTH: usize = 30;
 pub const PIN_MARKER: &str = "⚲";
+
+/// Returns the effective line width: the terminal width (if detectable), clamped to at least
+/// `MIN_LINE_WIDTH`.
+pub fn line_width() -> usize {
+    terminal_size::terminal_size()
+        .map(|(w, _)| (w.0 as usize).max(MIN_LINE_WIDTH))
+        .unwrap_or(MIN_LINE_WIDTH)
+}
 
 /// Column widths for list layout (used by standout's `col()` filter)
 pub const COL_LEFT_PIN: usize = 2; // Pin marker or empty ("⚲ " or "  ")
@@ -115,7 +123,7 @@ pub fn build_modification_result_value(
             };
 
             let fixed_columns = COL_LEFT_PIN + col_status + COL_INDEX + COL_TIME;
-            let title_width = LINE_WIDTH.saturating_sub(fixed_columns);
+            let title_width = line_width().saturating_sub(fixed_columns);
 
             json!({
                 "indent": "",
@@ -259,7 +267,7 @@ pub fn build_list_result_value(
         };
 
         let fixed_columns = COL_LEFT_PIN + col_status + COL_INDEX + COL_TIME;
-        let title_width = LINE_WIDTH.saturating_sub(fixed_columns + indent_width);
+        let title_width = line_width().saturating_sub(fixed_columns + indent_width);
 
         // Process matches
         let mut match_lines: Vec<serde_json::Value> = Vec::new();
@@ -281,7 +289,7 @@ pub fn build_list_result_value(
                     .collect();
 
                 let match_indent = indent_width + COL_LEFT_PIN + col_status + COL_INDEX;
-                let match_available = LINE_WIDTH.saturating_sub(COL_TIME + match_indent);
+                let match_available = line_width().saturating_sub(COL_TIME + match_indent);
 
                 // Truncate segments to available width
                 let truncated = truncate_match_segments_to_json(&segments, match_available);


### PR DESCRIPTION
## Summary
- Replace hardcoded `LINE_WIDTH = 100` with dynamic terminal width detection via the `terminal_size` crate
- Output now fits the actual terminal width, with a minimum of 30 columns (below which it wraps)
- Title truncation continues to work at narrow widths thanks to existing `saturating_sub` logic

## Test plan
- [x] All existing unit tests pass (13 render tests, full workspace suite)
- [ ] Manual: resize terminal to various widths and run `padz list` — output should adapt
- [ ] Manual: shrink terminal below 30 columns — output should wrap gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)