### PR TITLE
Add nested pad output with --flat/--tree/--indented flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **Nested pad output** — `view`, `copy`, and `export` commands now recursively include children by default (`--tree`). Use `--flat` for the previous behavior (selected pad only) or `--indented` for 4-space indentation per nesting level. Centralized tree-walking logic ensures consistent behavior across all content-output commands.
+
 ## [0.27.1] - 2026-03-28
 
 ## [0.27.1] - 2026-03-28

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -16,7 +16,7 @@
 
 use padzapp::api::{PadFilter, PadStatusFilter, PadzApi, TodoStatus};
 use padzapp::clipboard::{copy_to_clipboard, format_for_clipboard};
-use padzapp::commands::CmdResult;
+use padzapp::commands::{CmdResult, NestingMode};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
 use padzapp::model::{extract_title_and_body, Scope};
@@ -256,11 +256,12 @@ impl<'a> ScopedApi<'a> {
         &self,
         indexes: &[String],
         single_file: Option<&str>,
+        nesting: NestingMode,
     ) -> Result<Output<Value>, anyhow::Error> {
         let result = if let Some(title) = single_file {
-            self.call(|api, scope| api.export_pads_single_file(scope, indexes, title))?
+            self.call(|api, scope| api.export_pads_single_file(scope, indexes, title, nesting))?
         } else {
-            self.call(|api, scope| api.export_pads(scope, indexes))?
+            self.call(|api, scope| api.export_pads(scope, indexes, nesting))?
         };
         self.messages(result)
     }
@@ -330,25 +331,57 @@ impl<'a> ScopedApi<'a> {
         &self,
         indexes: &[String],
         show_uuid: bool,
+        nesting: NestingMode,
     ) -> Result<Output<Value>, anyhow::Error> {
-        let result = self.call(|api, scope| api.view_pads(scope, indexes))?;
+        let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
         // Copy content to clipboard
         for dp in &result.listed_pads {
             copy_content_to_clipboard(&dp.pad.content);
         }
 
+        let indent_per_level = match nesting {
+            NestingMode::Indented => 4,
+            _ => 0,
+        };
+
         let pads: Vec<serde_json::Value> = result
             .listed_pads
             .iter()
-            .map(|dp| {
+            .enumerate()
+            .map(|(i, dp)| {
+                let depth = result.listed_depths.get(i).copied().unwrap_or(0);
+                let indent = " ".repeat(depth * indent_per_level);
+
                 // Extract body (content minus title) to avoid double-title in output
                 let body = extract_title_and_body(&dp.pad.content)
                     .map(|(_, b)| b)
                     .unwrap_or_default();
+
+                // Apply indentation to content lines if indented mode
+                let (display_title, display_body) = if indent.is_empty() {
+                    (dp.pad.metadata.title.clone(), body)
+                } else {
+                    let indented_body = body
+                        .lines()
+                        .map(|line| {
+                            if line.is_empty() {
+                                String::new()
+                            } else {
+                                format!("{}{}", indent, line)
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    (
+                        format!("{}{}", indent, dp.pad.metadata.title),
+                        indented_body,
+                    )
+                };
+
                 let mut v = serde_json::json!({
-                    "title": dp.pad.metadata.title,
-                    "content": body,
+                    "title": display_title,
+                    "content": display_body,
                 });
                 if show_uuid {
                     v["uuid"] = serde_json::json!(dp.pad.metadata.id.to_string());
@@ -361,26 +394,71 @@ impl<'a> ScopedApi<'a> {
 
     // --- Copy operations ---
 
-    pub fn copy_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
-        let result = self.call(|api, scope| api.view_pads(scope, indexes))?;
+    pub fn copy_pads(
+        &self,
+        indexes: &[String],
+        nesting: NestingMode,
+    ) -> Result<Output<Value>, anyhow::Error> {
+        let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
         // Copy content to clipboard
-        for dp in &result.listed_pads {
-            copy_content_to_clipboard(&dp.pad.content);
+        let indent_per_level = match nesting {
+            NestingMode::Indented => 4,
+            _ => 0,
+        };
+
+        let mut clipboard_parts: Vec<String> = Vec::new();
+        for (i, dp) in result.listed_pads.iter().enumerate() {
+            let depth = result.listed_depths.get(i).copied().unwrap_or(0);
+            let indent = " ".repeat(depth * indent_per_level);
+            let formatted = if indent.is_empty() {
+                format_for_clipboard(
+                    &dp.pad.metadata.title,
+                    &extract_title_and_body(&dp.pad.content)
+                        .map(|(_, b)| b)
+                        .unwrap_or_default(),
+                )
+            } else {
+                let body = extract_title_and_body(&dp.pad.content)
+                    .map(|(_, b)| b)
+                    .unwrap_or_default();
+                let indented_body = body
+                    .lines()
+                    .map(|line| {
+                        if line.is_empty() {
+                            String::new()
+                        } else {
+                            format!("{}{}", indent, line)
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                format_for_clipboard(
+                    &format!("{}{}", indent, dp.pad.metadata.title),
+                    &indented_body,
+                )
+            };
+            clipboard_parts.push(formatted);
         }
 
-        let count = result.listed_pads.len();
-        let label = if count == 1 { "pad" } else { "pads" };
-        let titles: Vec<&str> = result
+        let clipboard_text = clipboard_parts.join("\n---\n\n");
+        let _ = copy_to_clipboard(&clipboard_text);
+
+        // Report using only the root-level (depth 0) pad titles
+        let root_titles: Vec<&str> = result
             .listed_pads
             .iter()
-            .map(|dp| dp.pad.metadata.title.as_str())
+            .enumerate()
+            .filter(|(i, _)| result.listed_depths.get(*i).copied().unwrap_or(0) == 0)
+            .map(|(_, dp)| dp.pad.metadata.title.as_str())
             .collect();
+        let count = root_titles.len();
+        let label = if count == 1 { "pad" } else { "pads" };
         let msg = format!(
             "Copied {} {} to clipboard: {}",
             count,
             label,
-            titles.join(", ")
+            root_titles.join(", ")
         );
 
         Ok(Output::Render(serde_json::json!({
@@ -393,6 +471,19 @@ impl<'a> ScopedApi<'a> {
 fn api(ctx: &CommandContext) -> ScopedApi<'_> {
     ScopedApi {
         state: get_state(ctx),
+    }
+}
+
+/// Parse --flat/--tree/--indented flags into a NestingMode.
+/// Default is Tree when none specified.
+fn parse_nesting_mode(flat: bool, _tree: bool, indented: bool) -> NestingMode {
+    if flat {
+        NestingMode::Flat
+    } else if indented {
+        NestingMode::Indented
+    } else {
+        // --tree or default
+        NestingMode::Tree
     }
 }
 
@@ -668,8 +759,12 @@ pub fn view(
     #[arg] indexes: Vec<String>,
     #[flag(name = "peek")] _peek: bool, // Reserved for future use
     #[flag] uuid: bool,
+    #[flag] flat: bool,
+    #[flag] tree: bool,
+    #[flag] indented: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
-    api(ctx).view_pads(&indexes, uuid)
+    let nesting = parse_nesting_mode(flat, tree, indented);
+    api(ctx).view_pads(&indexes, uuid, nesting)
 }
 
 #[handler]
@@ -677,8 +772,12 @@ pub fn copy(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
     #[flag(name = "peek")] _peek: bool, // Reserved for future use
+    #[flag] flat: bool,
+    #[flag] tree: bool,
+    #[flag] indented: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
-    api(ctx).copy_pads(&indexes)
+    let nesting = parse_nesting_mode(flat, tree, indented);
+    api(ctx).copy_pads(&indexes, nesting)
 }
 
 #[handler]
@@ -751,8 +850,12 @@ pub fn edit(
 
     // Interactive editor: open real pad file
     let view_result = state.with_api(|api| {
-        api.view_pads(state.scope, &index_args)
-            .map_err(|e| anyhow::anyhow!("{}", e))
+        api.view_pads(
+            state.scope,
+            &index_args,
+            padzapp::commands::NestingMode::Flat,
+        )
+        .map_err(|e| anyhow::anyhow!("{}", e))
     })?;
 
     let pad = view_result
@@ -932,8 +1035,12 @@ pub fn export(
     #[ctx] ctx: &CommandContext,
     #[arg(name = "single_file")] single_file: Option<String>,
     #[arg] indexes: Vec<String>,
+    #[flag] flat: bool,
+    #[flag] tree: bool,
+    #[flag] indented: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
-    api(ctx).export_pads(&indexes, single_file.as_deref())
+    let nesting = parse_nesting_mode(flat, tree, indented);
+    api(ctx).export_pads(&indexes, single_file.as_deref(), nesting)
 }
 
 #[handler]

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -335,12 +335,15 @@ impl<'a> ScopedApi<'a> {
     ) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
-        // Copy content to clipboard
-        for dp in &result.listed_pads {
-            copy_content_to_clipboard(&dp.pad.content);
+        // Copy content to clipboard (only root-level pads for tree/indented)
+        for (i, dp) in result.listed_pads.iter().enumerate() {
+            let depth = result.listed_depths.get(i).copied().unwrap_or(0);
+            if depth == 0 {
+                copy_content_to_clipboard(&dp.pad.content);
+            }
         }
 
-        let indent_per_level = match nesting {
+        let indent_per_level: usize = match nesting {
             NestingMode::Indented => 4,
             _ => 0,
         };
@@ -362,17 +365,7 @@ impl<'a> ScopedApi<'a> {
                 let (display_title, display_body) = if indent.is_empty() {
                     (dp.pad.metadata.title.clone(), body)
                 } else {
-                    let indented_body = body
-                        .lines()
-                        .map(|line| {
-                            if line.is_empty() {
-                                String::new()
-                            } else {
-                                format!("{}{}", indent, line)
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n");
+                    let indented_body = indent_lines(&body, &indent);
                     (
                         format!("{}{}", indent, dp.pad.metadata.title),
                         indented_body,
@@ -382,6 +375,7 @@ impl<'a> ScopedApi<'a> {
                 let mut v = serde_json::json!({
                     "title": display_title,
                     "content": display_body,
+                    "depth": depth,
                 });
                 if show_uuid {
                     v["uuid"] = serde_json::json!(dp.pad.metadata.id.to_string());
@@ -401,47 +395,37 @@ impl<'a> ScopedApi<'a> {
     ) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
-        // Copy content to clipboard
-        let indent_per_level = match nesting {
+        let indent_per_level: usize = match nesting {
             NestingMode::Indented => 4,
             _ => 0,
         };
 
-        let mut clipboard_parts: Vec<String> = Vec::new();
+        // Build clipboard text: root pads separated by ---, children appended under parent
+        let mut clipboard_text = String::new();
         for (i, dp) in result.listed_pads.iter().enumerate() {
             let depth = result.listed_depths.get(i).copied().unwrap_or(0);
             let indent = " ".repeat(depth * indent_per_level);
-            let formatted = if indent.is_empty() {
-                format_for_clipboard(
-                    &dp.pad.metadata.title,
-                    &extract_title_and_body(&dp.pad.content)
-                        .map(|(_, b)| b)
-                        .unwrap_or_default(),
-                )
+            let body = extract_title_and_body(&dp.pad.content)
+                .map(|(_, b)| b)
+                .unwrap_or_default();
+
+            // --- separator only between root-level pads (not between parent and child)
+            if depth == 0 && !clipboard_text.is_empty() {
+                clipboard_text.push_str("\n---\n\n");
+            } else if depth > 0 {
+                clipboard_text.push_str("\n\n");
+            }
+
+            if indent.is_empty() {
+                clipboard_text.push_str(&format_for_clipboard(&dp.pad.metadata.title, &body));
             } else {
-                let body = extract_title_and_body(&dp.pad.content)
-                    .map(|(_, b)| b)
-                    .unwrap_or_default();
-                let indented_body = body
-                    .lines()
-                    .map(|line| {
-                        if line.is_empty() {
-                            String::new()
-                        } else {
-                            format!("{}{}", indent, line)
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                format_for_clipboard(
+                clipboard_text.push_str(&format_for_clipboard(
                     &format!("{}{}", indent, dp.pad.metadata.title),
-                    &indented_body,
-                )
-            };
-            clipboard_parts.push(formatted);
+                    &indent_lines(&body, &indent),
+                ));
+            }
         }
 
-        let clipboard_text = clipboard_parts.join("\n---\n\n");
         let _ = copy_to_clipboard(&clipboard_text);
 
         // Report using only the root-level (depth 0) pad titles
@@ -493,6 +477,20 @@ fn copy_content_to_clipboard(content: &str) {
         let clipboard_text = format_for_clipboard(&title, &body);
         let _ = copy_to_clipboard(&clipboard_text);
     }
+}
+
+/// Indent each non-empty line with the given prefix.
+fn indent_lines(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("{}{}", prefix, line)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Try to read content from piped stdin.

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -1006,6 +1006,145 @@ mod tests {
         assert_eq!(total2, w, "Todos: columns sum {total2} != line_width {w}");
     }
 
+    fn make_display_pad_with_children(
+        pad: Pad,
+        index: DisplayIndex,
+        children: Vec<DisplayPad>,
+    ) -> DisplayPad {
+        DisplayPad {
+            pad,
+            index,
+            matches: None,
+            children,
+        }
+    }
+
+    fn default_list_options() -> ListOptions {
+        ListOptions {
+            peek: false,
+            show_deleted_help: false,
+            output_mode: OutputMode::Text,
+            mode: PadzMode::Todos,
+            show_uuid: false,
+            filtered: false,
+        }
+    }
+
+    #[test]
+    fn test_build_list_nested_pad_produces_indent() {
+        let child = make_display_pad(make_pad("Child Note", false), DisplayIndex::Regular(1));
+        let parent = make_display_pad_with_children(
+            make_pad("Parent Note", false),
+            DisplayIndex::Regular(1),
+            vec![child],
+        );
+
+        let data = build_list_result_value(&[parent], &[], default_list_options());
+
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        // Should be flattened: parent + child = 2 entries
+        assert_eq!(pads.len(), 2, "parent + child should produce 2 pad entries");
+
+        // Parent at depth 0: no indent
+        let parent_indent = pads[0].get("indent").and_then(|v| v.as_str()).unwrap();
+        assert_eq!(parent_indent, "", "root pad should have empty indent");
+
+        // Child at depth 1: 2-space indent
+        let child_indent = pads[1].get("indent").and_then(|v| v.as_str()).unwrap();
+        assert_eq!(
+            child_indent, "  ",
+            "depth-1 child should have 2-space indent"
+        );
+    }
+
+    #[test]
+    fn test_build_list_nested_title_width_reduced_by_indent() {
+        let child = make_display_pad(make_pad("Child", false), DisplayIndex::Regular(1));
+        let parent = make_display_pad_with_children(
+            make_pad("Parent", false),
+            DisplayIndex::Regular(1),
+            vec![child],
+        );
+
+        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+
+        let parent_width = pads[0].get("title_width").and_then(|v| v.as_u64()).unwrap();
+        let child_width = pads[1].get("title_width").and_then(|v| v.as_u64()).unwrap();
+
+        // Child title_width should be exactly 2 less than parent (indent = depth * 2)
+        assert_eq!(
+            parent_width - child_width,
+            2,
+            "child title_width should be 2 less than parent"
+        );
+    }
+
+    #[test]
+    fn test_build_list_deep_nesting_indent_accumulates() {
+        let grandchild = make_display_pad(make_pad("Grandchild", false), DisplayIndex::Regular(1));
+        let child = make_display_pad_with_children(
+            make_pad("Child", false),
+            DisplayIndex::Regular(1),
+            vec![grandchild],
+        );
+        let parent = make_display_pad_with_children(
+            make_pad("Parent", false),
+            DisplayIndex::Regular(1),
+            vec![child],
+        );
+
+        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+
+        assert_eq!(pads.len(), 3, "3-level tree should produce 3 entries");
+
+        let indents: Vec<&str> = pads
+            .iter()
+            .map(|p| p.get("indent").and_then(|v| v.as_str()).unwrap())
+            .collect();
+        assert_eq!(indents, vec!["", "  ", "    "]);
+    }
+
+    #[test]
+    fn test_build_list_nested_preserves_order_parent_then_children() {
+        let child_a = make_display_pad(make_pad("Alpha", false), DisplayIndex::Regular(2));
+        let child_b = make_display_pad(make_pad("Beta", false), DisplayIndex::Regular(1));
+        let parent = make_display_pad_with_children(
+            make_pad("Root", false),
+            DisplayIndex::Regular(1),
+            vec![child_b, child_a],
+        );
+
+        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+
+        let titles: Vec<&str> = pads
+            .iter()
+            .map(|p| p.get("title").and_then(|v| v.as_str()).unwrap())
+            .collect();
+        assert_eq!(titles, vec!["Root", "Beta", "Alpha"]);
+    }
+
+    #[test]
+    fn test_build_list_nested_pin_marker_only_at_root() {
+        let child = make_display_pad(make_pad("Child", true), DisplayIndex::Pinned(1));
+        let parent = make_display_pad_with_children(
+            make_pad("Parent", true),
+            DisplayIndex::Pinned(1),
+            vec![child],
+        );
+
+        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+
+        let parent_pin = pads[0].get("left_pin").and_then(|v| v.as_str()).unwrap();
+        let child_pin = pads[1].get("left_pin").and_then(|v| v.as_str()).unwrap();
+
+        assert_eq!(parent_pin, PIN_MARKER, "root pinned pad should show marker");
+        assert_eq!(child_pin, "", "nested pinned pad should NOT show marker");
+    }
+
     #[test]
     fn test_modification_result_title_width_invariant() {
         let pad = make_pad("Test", false);

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -415,6 +415,18 @@ pub enum Commands {
         /// Show UUID in view output
         #[arg(long)]
         uuid: bool,
+
+        /// Show only the selected pad(s), no children
+        #[arg(long, conflicts_with_all = ["tree", "indented"])]
+        flat: bool,
+
+        /// Recursively include children (default)
+        #[arg(long, conflicts_with_all = ["flat", "indented"])]
+        tree: bool,
+
+        /// Recursively include children with 4-space indentation per level
+        #[arg(long, conflicts_with_all = ["flat", "tree"])]
+        indented: bool,
     },
 
     /// Copy one or more pads to the clipboard (without printing)
@@ -428,6 +440,18 @@ pub enum Commands {
         /// Peek at pad content
         #[arg(long)]
         peek: bool,
+
+        /// Show only the selected pad(s), no children
+        #[arg(long, conflicts_with_all = ["tree", "indented"])]
+        flat: bool,
+
+        /// Recursively include children (default)
+        #[arg(long, conflicts_with_all = ["flat", "indented"])]
+        tree: bool,
+
+        /// Recursively include children with 4-space indentation per level
+        #[arg(long, conflicts_with_all = ["flat", "tree"])]
+        indented: bool,
     },
 
     /// Edit a pad in the editor
@@ -585,6 +609,18 @@ pub enum Commands {
         /// Indexes of the pads (e.g. 1 2) - if omitted, exports all active pads
         #[arg(required = false, num_args = 0.., add = active_pads_completer())]
         indexes: Vec<String>,
+
+        /// Show only the selected pad(s), no children
+        #[arg(long, conflicts_with_all = ["tree", "indented"])]
+        flat: bool,
+
+        /// Recursively include children (default)
+        #[arg(long, conflicts_with_all = ["flat", "indented"])]
+        tree: bool,
+
+        /// Recursively include children with 4-space indentation per level
+        #[arg(long, conflicts_with_all = ["flat", "tree"])]
+        indented: bool,
     },
 
     /// Import files as pads

--- a/crates/padz/src/cli/templates/view.jinja
+++ b/crates/padz/src/cli/templates/view.jinja
@@ -1,18 +1,20 @@
 {#- View template - clipboard-friendly output -#}
-{#- Outputs title + blank line + content, suitable for pasting -#}
+{#- depth=0 pads separated by ---, children appear under their parent -#}
 
 {% if pads | length == 0 -%}
 [empty-message]No pads found.[/empty-message]
 {% else -%}
 {% for pad in pads -%}
-{%- if not loop.first %}
+{%- if not loop.first -%}
+{%- if pad.depth == 0 %}
 ---
 {% endif -%}
+{%- endif -%}
 {%- if pad.uuid %}
 [info]uuid: {{ pad.uuid }}[/info]
 {% endif -%}
 {{ pad.title }}
 
 {{ pad.content }}
-{%- endfor %}
+{% endfor -%}
 {% endif %}

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -128,9 +128,10 @@ impl<S: DataStore> PadzApi<S> {
         &self,
         scope: Scope,
         indexes: &[I],
+        nesting: commands::NestingMode,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        commands::view::run(&self.store, scope, &selectors)
+        commands::view::run(&self.store, scope, &selectors, nesting)
     }
 
     pub fn delete_pads<I: AsRef<str>>(
@@ -282,9 +283,10 @@ impl<S: DataStore> PadzApi<S> {
         &self,
         scope: Scope,
         indexes: &[I],
+        nesting: commands::NestingMode,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        commands::export::run(&self.store, scope, &selectors)
+        commands::export::run(&self.store, scope, &selectors, nesting)
     }
 
     pub fn export_pads_single_file<I: AsRef<str>>(
@@ -292,9 +294,10 @@ impl<S: DataStore> PadzApi<S> {
         scope: Scope,
         indexes: &[I],
         title: &str,
+        nesting: commands::NestingMode,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        commands::export::run_single_file(&self.store, scope, &selectors, title)
+        commands::export::run_single_file(&self.store, scope, &selectors, title, nesting)
     }
 
     pub fn import_pads(
@@ -737,7 +740,9 @@ mod tests {
         api.create_pad(Scope::Project, "Test".into(), "".into(), None)
             .unwrap();
 
-        let result = api.view_pads(Scope::Project, &["1"]).unwrap();
+        let result = api
+            .view_pads(Scope::Project, &["1"], commands::NestingMode::Flat)
+            .unwrap();
 
         assert_eq!(result.listed_pads.len(), 1);
         assert_eq!(result.listed_pads[0].pad.metadata.title, "Test");

--- a/crates/padzapp/src/commands/export.rs
+++ b/crates/padzapp/src/commands/export.rs
@@ -1,4 +1,4 @@
-use crate::commands::{CmdMessage, CmdResult};
+use crate::commands::{CmdMessage, CmdResult, NestingMode};
 use crate::error::{PadzError, Result};
 use crate::index::DisplayIndex;
 use crate::index::DisplayPad;
@@ -13,7 +13,7 @@ use pulldown_cmark_to_cmark::cmark;
 use std::fs::File;
 use std::io::Write;
 
-use super::helpers::{indexed_pads, pads_by_selectors};
+use super::helpers::{collect_nested_pads, indexed_pads, pads_by_selectors, NestedPad};
 
 /// Format for single-file export, determined by file extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,7 +41,12 @@ pub struct SingleFileExportResult {
     pub format: SingleFileFormat,
 }
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+pub fn run<S: DataStore>(
+    store: &S,
+    scope: Scope,
+    selectors: &[PadSelector],
+    nesting: NestingMode,
+) -> Result<CmdResult> {
     // 1. Resolve pads
     let pads = resolve_pads(store, scope, selectors)?;
 
@@ -51,17 +56,37 @@ pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> 
         return Ok(res);
     }
 
+    let nested = resolve_nested(store, scope, &pads, nesting)?;
+
     // 2. Prepare output file
     let now = Utc::now();
     let filename = format!("padz-{}.tar.gz", now.format("%Y-%m-%d_%H:%M:%S"));
     let file = File::create(&filename).map_err(PadzError::Io)?;
 
     // 3. Write archive
-    write_archive(file, &pads)?;
+    write_archive(file, &nested)?;
 
     let mut result = CmdResult::default();
     result.add_message(CmdMessage::success(format!("Exported to {}", filename)));
     Ok(result)
+}
+
+fn resolve_nested<S: DataStore>(
+    store: &S,
+    scope: Scope,
+    pads: &[DisplayPad],
+    nesting: NestingMode,
+) -> Result<Vec<NestedPad>> {
+    match nesting {
+        NestingMode::Flat => Ok(pads
+            .iter()
+            .map(|dp| NestedPad {
+                pad: dp.clone(),
+                depth: 0,
+            })
+            .collect()),
+        NestingMode::Tree | NestingMode::Indented => collect_nested_pads(store, scope, pads),
+    }
 }
 
 fn resolve_pads<S: DataStore>(
@@ -79,11 +104,12 @@ fn resolve_pads<S: DataStore>(
     }
 }
 
-fn write_archive<W: Write>(writer: W, pads: &[DisplayPad]) -> Result<()> {
+fn write_archive<W: Write>(writer: W, pads: &[NestedPad]) -> Result<()> {
     let enc = GzEncoder::new(writer, Compression::default());
     let mut tar = tar::Builder::new(enc);
 
-    for dp in pads {
+    for np in pads {
+        let dp = &np.pad;
         let title = &dp.pad.metadata.title;
         let safe_title = sanitize_filename(title);
         let entry_name = format!(
@@ -127,6 +153,7 @@ pub fn run_single_file<S: DataStore>(
     scope: Scope,
     selectors: &[PadSelector],
     title: &str,
+    nesting: NestingMode,
 ) -> Result<CmdResult> {
     let pads = resolve_pads(store, scope, selectors)?;
 
@@ -136,8 +163,10 @@ pub fn run_single_file<S: DataStore>(
         return Ok(res);
     }
 
+    let nested = resolve_nested(store, scope, &pads, nesting)?;
+
     let format = SingleFileFormat::from_filename(title);
-    let result = merge_pads_to_single_file(&pads, title, format);
+    let result = merge_pads_to_single_file(&nested, title, format);
 
     // Write to file
     let filename = sanitize_output_filename(title, format);
@@ -154,7 +183,7 @@ pub fn run_single_file<S: DataStore>(
 
 /// Merge pads into a single file content string.
 pub fn merge_pads_to_single_file(
-    pads: &[DisplayPad],
+    pads: &[NestedPad],
     title: &str,
     format: SingleFileFormat,
 ) -> SingleFileExportResult {
@@ -166,28 +195,51 @@ pub fn merge_pads_to_single_file(
 }
 
 /// Merge pads as plain text with headers separating each file.
-fn merge_as_text(pads: &[DisplayPad]) -> String {
+fn merge_as_text(pads: &[NestedPad]) -> String {
     let mut output = String::new();
 
-    for (i, dp) in pads.iter().enumerate() {
+    for (i, np) in pads.iter().enumerate() {
+        let dp = &np.pad;
         if i > 0 {
             output.push_str("\n\n");
         }
 
+        let indent = "    ".repeat(np.depth);
+
         // Add header with pad title
         let title = &dp.pad.metadata.title;
         let separator = "=".repeat(title.len().max(40));
+        output.push_str(&indent);
         output.push_str(&separator);
         output.push('\n');
+        output.push_str(&indent);
         output.push_str(title);
         output.push('\n');
+        output.push_str(&indent);
         output.push_str(&separator);
         output.push_str("\n\n");
 
         // Add pad content (skip the title line since we already printed it)
         let content = &dp.pad.content;
         if let Some(body_start) = content.find("\n\n") {
-            output.push_str(content[body_start + 2..].trim());
+            let body = content[body_start + 2..].trim();
+            if !indent.is_empty() {
+                for line in body.lines() {
+                    if line.is_empty() {
+                        output.push('\n');
+                    } else {
+                        output.push_str(&indent);
+                        output.push_str(line);
+                        output.push('\n');
+                    }
+                }
+                // Remove trailing newline to match original behavior
+                if output.ends_with('\n') && body.ends_with(|_: char| true) {
+                    output.pop();
+                }
+            } else {
+                output.push_str(body);
+            }
         }
     }
 
@@ -195,7 +247,7 @@ fn merge_as_text(pads: &[DisplayPad]) -> String {
 }
 
 /// Merge pads as markdown with the export title as H1 and bumped headers.
-fn merge_as_markdown(pads: &[DisplayPad], export_title: &str) -> String {
+fn merge_as_markdown(pads: &[NestedPad], export_title: &str) -> String {
     let mut output = String::new();
 
     // Export title as H1
@@ -203,13 +255,17 @@ fn merge_as_markdown(pads: &[DisplayPad], export_title: &str) -> String {
     output.push_str(export_title);
     output.push_str("\n\n");
 
-    for (i, dp) in pads.iter().enumerate() {
+    for (i, np) in pads.iter().enumerate() {
+        let dp = &np.pad;
         if i > 0 {
             output.push_str("\n\n---\n\n");
         }
 
-        // Pad title becomes H2
-        output.push_str("## ");
+        // Pad title heading level based on depth: depth 0 = H2, depth 1 = H3, etc.
+        let heading_level = (2 + np.depth).min(6);
+        let hashes = "#".repeat(heading_level);
+        output.push_str(&hashes);
+        output.push(' ');
         output.push_str(&dp.pad.metadata.title);
         output.push_str("\n\n");
 
@@ -222,8 +278,8 @@ fn merge_as_markdown(pads: &[DisplayPad], export_title: &str) -> String {
         };
 
         if !body.is_empty() {
-            // Bump all headers in the body
-            let bumped = bump_markdown_headers(body);
+            // Bump all headers in the body by (2 + depth) to nest under the pad heading
+            let bumped = bump_markdown_headers_by(body, 2 + np.depth);
             output.push_str(&bumped);
         }
     }
@@ -234,6 +290,11 @@ fn merge_as_markdown(pads: &[DisplayPad], export_title: &str) -> String {
 /// Bump all markdown header levels by 2 (H1->H3, H2->H4, etc., H6 stays H6).
 /// Uses pulldown-cmark for proper markdown parsing.
 pub fn bump_markdown_headers(content: &str) -> String {
+    bump_markdown_headers_by(content, 2)
+}
+
+/// Bump all markdown header levels by `amount`, capped at H6.
+pub fn bump_markdown_headers_by(content: &str, amount: usize) -> String {
     let options = Options::all();
     let parser = Parser::new_ext(content, options);
 
@@ -245,7 +306,7 @@ pub fn bump_markdown_headers(content: &str) -> String {
                 classes,
                 attrs,
             }) => {
-                let new_level = bump_heading_level(level);
+                let new_level = bump_heading_level_by(level, amount);
                 Event::Start(Tag::Heading {
                     level: new_level,
                     id,
@@ -254,7 +315,7 @@ pub fn bump_markdown_headers(content: &str) -> String {
                 })
             }
             Event::End(TagEnd::Heading(level)) => {
-                let new_level = bump_heading_level(level);
+                let new_level = bump_heading_level_by(level, amount);
                 Event::End(TagEnd::Heading(new_level))
             }
             other => other,
@@ -262,20 +323,28 @@ pub fn bump_markdown_headers(content: &str) -> String {
         .collect();
 
     let mut output = String::new();
-    // cmark returns Result, unwrap is safe for valid events
     cmark(events.iter(), &mut output).expect("cmark serialization failed");
     output
 }
 
-/// Bump a heading level by 2, capped at H6.
-fn bump_heading_level(level: HeadingLevel) -> HeadingLevel {
-    match level {
-        HeadingLevel::H1 => HeadingLevel::H3,
-        HeadingLevel::H2 => HeadingLevel::H4,
-        HeadingLevel::H3 => HeadingLevel::H5,
-        HeadingLevel::H4 => HeadingLevel::H6,
-        HeadingLevel::H5 => HeadingLevel::H6,
-        HeadingLevel::H6 => HeadingLevel::H6,
+/// Bump a heading level by `amount`, capped at H6.
+fn bump_heading_level_by(level: HeadingLevel, amount: usize) -> HeadingLevel {
+    let current = match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    };
+    let new = (current + amount).min(6);
+    match new {
+        1 => HeadingLevel::H1,
+        2 => HeadingLevel::H2,
+        3 => HeadingLevel::H3,
+        4 => HeadingLevel::H4,
+        5 => HeadingLevel::H5,
+        _ => HeadingLevel::H6,
     }
 }
 
@@ -340,6 +409,15 @@ mod tests {
         assert_eq!(pads[0].pad.metadata.title, "Active");
     }
 
+    fn flat_nested(pads: &[DisplayPad]) -> Vec<NestedPad> {
+        pads.iter()
+            .map(|dp| NestedPad {
+                pad: dp.clone(),
+                depth: 0,
+            })
+            .collect()
+    }
+
     #[test]
     fn test_write_archive_produces_content() {
         let mut store = BucketedStore::new(
@@ -359,7 +437,7 @@ mod tests {
         let pads = resolve_pads(&store, Scope::Project, &[]).unwrap();
 
         let mut buf = Vec::new();
-        write_archive(&mut buf, &pads).unwrap();
+        write_archive(&mut buf, &flat_nested(&pads)).unwrap();
 
         assert!(!buf.is_empty());
         // Could verify tar content but that requires untarring.
@@ -446,17 +524,23 @@ mod tests {
     fn test_merge_as_text() {
         use crate::index::DisplayIndex;
 
-        let pad1 = DisplayPad {
-            pad: crate::model::Pad::new("First Pad".into(), "Content one".into()),
-            index: DisplayIndex::Regular(1),
-            matches: None,
-            children: vec![],
+        let pad1 = NestedPad {
+            pad: DisplayPad {
+                pad: crate::model::Pad::new("First Pad".into(), "Content one".into()),
+                index: DisplayIndex::Regular(1),
+                matches: None,
+                children: vec![],
+            },
+            depth: 0,
         };
-        let pad2 = DisplayPad {
-            pad: crate::model::Pad::new("Second Pad".into(), "Content two".into()),
-            index: DisplayIndex::Regular(2),
-            matches: None,
-            children: vec![],
+        let pad2 = NestedPad {
+            pad: DisplayPad {
+                pad: crate::model::Pad::new("Second Pad".into(), "Content two".into()),
+                index: DisplayIndex::Regular(2),
+                matches: None,
+                children: vec![],
+            },
+            depth: 0,
         };
 
         let output = merge_as_text(&[pad1, pad2]);
@@ -475,17 +559,29 @@ mod tests {
     fn test_merge_as_markdown() {
         use crate::index::DisplayIndex;
 
-        let pad1 = DisplayPad {
-            pad: crate::model::Pad::new("First Pad".into(), "# Internal H1\n\nBody text".into()),
-            index: DisplayIndex::Regular(1),
-            matches: None,
-            children: vec![],
+        let pad1 = NestedPad {
+            pad: DisplayPad {
+                pad: crate::model::Pad::new(
+                    "First Pad".into(),
+                    "# Internal H1\n\nBody text".into(),
+                ),
+                index: DisplayIndex::Regular(1),
+                matches: None,
+                children: vec![],
+            },
+            depth: 0,
         };
-        let pad2 = DisplayPad {
-            pad: crate::model::Pad::new("Second Pad".into(), "## Internal H2\n\nMore body".into()),
-            index: DisplayIndex::Regular(2),
-            matches: None,
-            children: vec![],
+        let pad2 = NestedPad {
+            pad: DisplayPad {
+                pad: crate::model::Pad::new(
+                    "Second Pad".into(),
+                    "## Internal H2\n\nMore body".into(),
+                ),
+                index: DisplayIndex::Regular(2),
+                matches: None,
+                children: vec![],
+            },
+            depth: 0,
         };
 
         let output = merge_as_markdown(&[pad1, pad2], "My Export");
@@ -542,13 +638,14 @@ mod tests {
             MemBackend::new(),
         );
         // No pads created
-        let res = run(&store, Scope::Project, &[]).unwrap();
+        let res = run(&store, Scope::Project, &[], NestingMode::Flat).unwrap();
         assert!(res
             .messages
             .iter()
             .any(|m| m.content.contains("No pads to export")));
 
-        let res_single = run_single_file(&store, Scope::Project, &[], "out.md").unwrap();
+        let res_single =
+            run_single_file(&store, Scope::Project, &[], "out.md", NestingMode::Flat).unwrap();
         assert!(res_single
             .messages
             .iter()
@@ -579,7 +676,8 @@ mod tests {
         // So passing "Title.md" results in "Title.md".
         let input_title = format!("{}.md", unique_title);
 
-        let res = run_single_file(&store, Scope::Project, &[], &input_title).unwrap();
+        let res =
+            run_single_file(&store, Scope::Project, &[], &input_title, NestingMode::Flat).unwrap();
 
         assert!(res.messages[0].content.contains("Exported 1 pads"));
         assert!(
@@ -594,5 +692,99 @@ mod tests {
 
         // Cleanup
         let _ = std::fs::remove_file(expected_path);
+    }
+
+    // --- Nesting mode tests ---
+
+    #[test]
+    fn test_merge_as_text_nested() {
+        use crate::index::DisplayIndex;
+
+        let pads = vec![
+            NestedPad {
+                pad: DisplayPad {
+                    pad: crate::model::Pad::new("Parent".into(), "Parent body".into()),
+                    index: DisplayIndex::Regular(1),
+                    matches: None,
+                    children: vec![],
+                },
+                depth: 0,
+            },
+            NestedPad {
+                pad: DisplayPad {
+                    pad: crate::model::Pad::new("Child".into(), "Child body".into()),
+                    index: DisplayIndex::Regular(1),
+                    matches: None,
+                    children: vec![],
+                },
+                depth: 1,
+            },
+        ];
+
+        let output = merge_as_text(&pads);
+
+        // Parent header at depth 0 (no indent)
+        assert!(output.contains("Parent"));
+        assert!(output.contains("Parent body"));
+        // Child header at depth 1 (4-space indent)
+        assert!(output.contains("    Child"));
+        assert!(output.contains("    Child body"));
+    }
+
+    #[test]
+    fn test_merge_as_markdown_nested() {
+        use crate::index::DisplayIndex;
+
+        let pads = vec![
+            NestedPad {
+                pad: DisplayPad {
+                    pad: crate::model::Pad::new("Parent".into(), "Parent body".into()),
+                    index: DisplayIndex::Regular(1),
+                    matches: None,
+                    children: vec![],
+                },
+                depth: 0,
+            },
+            NestedPad {
+                pad: DisplayPad {
+                    pad: crate::model::Pad::new("Child".into(), "# H1 in child".into()),
+                    index: DisplayIndex::Regular(1),
+                    matches: None,
+                    children: vec![],
+                },
+                depth: 1,
+            },
+        ];
+
+        let output = merge_as_markdown(&pads, "Export");
+
+        // H1 title
+        assert!(output.starts_with("# Export"));
+        // Parent at depth 0 -> H2
+        assert!(output.contains("## Parent"));
+        // Child at depth 1 -> H3
+        assert!(output.contains("### Child"));
+        // H1 in child body bumped by (2 + 1) = 3 -> H4
+        assert!(output.contains("#### H1 in child"));
+    }
+
+    #[test]
+    fn test_merge_as_markdown_deep_nesting_caps_at_h6() {
+        use crate::index::DisplayIndex;
+
+        let pads = vec![NestedPad {
+            pad: DisplayPad {
+                pad: crate::model::Pad::new("Deep".into(), "# Heading".into()),
+                index: DisplayIndex::Regular(1),
+                matches: None,
+                children: vec![],
+            },
+            depth: 5, // depth 5 -> heading level 2+5=7 -> capped at 6
+        }];
+
+        let output = merge_as_markdown(&pads, "Export");
+
+        // Title at depth 5 should cap at H6
+        assert!(output.contains("###### Deep"));
     }
 }

--- a/crates/padzapp/src/commands/export.rs
+++ b/crates/padzapp/src/commands/export.rs
@@ -385,6 +385,7 @@ fn sanitize_output_filename(title: &str, format: SingleFileFormat) -> String {
 mod tests {
     use super::*;
     use crate::commands::create;
+    use crate::index::{DisplayIndex, PadSelector};
     use crate::model::Scope;
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
@@ -766,6 +767,136 @@ mod tests {
         assert!(output.contains("### Child"));
         // H1 in child body bumped by (2 + 1) = 3 -> H4
         assert!(output.contains("#### H1 in child"));
+    }
+
+    #[test]
+    fn test_merge_as_text_nested_from_store() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Groceries".into(),
+            "Weekly shopping".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Bread".into(),
+            "Whole wheat".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let pads = resolve_pads(&store, Scope::Project, &[]).unwrap();
+        let nested = resolve_nested(&store, Scope::Project, &pads, NestingMode::Tree).unwrap();
+
+        let output = merge_as_text(&nested);
+
+        // Parent present
+        assert!(output.contains("Groceries"), "should contain parent title");
+        assert!(
+            output.contains("Weekly shopping"),
+            "should contain parent body"
+        );
+        // Child present with indent (depth 1 = 4-space indent in text export)
+        assert!(
+            output.contains("    Bread"),
+            "child title should be indented"
+        );
+        assert!(
+            output.contains("    Whole wheat"),
+            "child body should be indented"
+        );
+    }
+
+    #[test]
+    fn test_merge_as_markdown_nested_from_store() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Project".into(),
+            "# Overview\n\nProject description".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Module A".into(),
+            "## API\n\nEndpoints here".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let pads = resolve_pads(&store, Scope::Project, &[]).unwrap();
+        let nested = resolve_nested(&store, Scope::Project, &pads, NestingMode::Tree).unwrap();
+
+        let output = merge_as_markdown(&nested, "Docs");
+
+        // Export title
+        assert!(output.starts_with("# Docs"));
+        // Parent at depth 0 -> H2
+        assert!(output.contains("## Project"), "parent should be H2");
+        // Child at depth 1 -> H3
+        assert!(output.contains("### Module A"), "child should be H3");
+        // Parent body H1 bumped by 2 -> H3
+        assert!(
+            output.contains("### Overview"),
+            "parent body H1 should become H3"
+        );
+        // Child body H2 bumped by 3 (2+1) -> H5
+        assert!(
+            output.contains("##### API"),
+            "child body H2 should become H5"
+        );
+    }
+
+    #[test]
+    fn test_flat_nesting_produces_no_children_in_export() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Parent".into(),
+            "Parent content".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "Child content".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let pads = resolve_pads(&store, Scope::Project, &[]).unwrap();
+        // Flat mode: should NOT include children
+        let nested = resolve_nested(&store, Scope::Project, &pads, NestingMode::Flat).unwrap();
+
+        // Only root-level pads (Parent) — no Child
+        assert_eq!(nested.len(), 1);
+        assert_eq!(nested[0].pad.pad.metadata.title, "Parent");
+        assert_eq!(nested[0].depth, 0);
     }
 
     #[test]

--- a/crates/padzapp/src/commands/helpers.rs
+++ b/crates/padzapp/src/commands/helpers.rs
@@ -1093,4 +1093,219 @@ mod tests {
         let err = result.unwrap_err();
         assert!(err.to_string().contains("delete protected"));
     }
+
+    // -------------------------------------------------------------------------
+    // collect_nested_pads tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn collect_nested_returns_parent_then_children_with_depths() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child A".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child B".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        // Resolve the parent as a flat pad (how view.rs calls it)
+        let flat = pads_by_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            false,
+        )
+        .unwrap();
+        assert_eq!(flat.len(), 1);
+
+        let nested = collect_nested_pads(&store, Scope::Project, &flat).unwrap();
+
+        assert_eq!(nested.len(), 3);
+        assert_eq!(nested[0].pad.pad.metadata.title, "Parent");
+        assert_eq!(nested[0].depth, 0);
+        // Children newest first: B then A
+        assert_eq!(nested[1].depth, 1);
+        assert_eq!(nested[2].depth, 1);
+    }
+
+    #[test]
+    fn collect_nested_deep_tree_tracks_depth() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Root".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Level 1".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Level 2".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![
+                DisplayIndex::Regular(1),
+                DisplayIndex::Regular(1),
+            ])),
+        )
+        .unwrap();
+
+        let flat = pads_by_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            false,
+        )
+        .unwrap();
+        let nested = collect_nested_pads(&store, Scope::Project, &flat).unwrap();
+
+        let depths: Vec<usize> = nested.iter().map(|np| np.depth).collect();
+        assert_eq!(depths, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn collect_nested_skips_deleted_children() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Keep".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Delete Me".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        // Delete the newest child (index 1.1)
+        crate::commands::delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![
+                DisplayIndex::Regular(1),
+                DisplayIndex::Regular(1),
+            ])],
+        )
+        .unwrap();
+
+        let flat = pads_by_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            false,
+        )
+        .unwrap();
+        let nested = collect_nested_pads(&store, Scope::Project, &flat).unwrap();
+
+        assert_eq!(nested.len(), 2);
+        assert_eq!(nested[0].pad.pad.metadata.title, "Parent");
+        assert_eq!(nested[1].pad.pad.metadata.title, "Keep");
+    }
+
+    #[test]
+    fn collect_nested_leaf_pad_returns_single() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Leaf".into(),
+            "body".into(),
+            None,
+        )
+        .unwrap();
+
+        let flat = pads_by_selectors(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            false,
+        )
+        .unwrap();
+        let nested = collect_nested_pads(&store, Scope::Project, &flat).unwrap();
+
+        assert_eq!(nested.len(), 1);
+        assert_eq!(nested[0].depth, 0);
+        assert_eq!(nested[0].pad.pad.metadata.title, "Leaf");
+    }
+
+    #[test]
+    fn collect_nested_multiple_roots_each_expand() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Root A".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Root B".into(), "".into(), None).unwrap();
+        // Root B is 1, Root A is 2
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child of A".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(2)])),
+        )
+        .unwrap();
+
+        let flat = pads_by_selectors(
+            &store,
+            Scope::Project,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+            ],
+            false,
+        )
+        .unwrap();
+        let nested = collect_nested_pads(&store, Scope::Project, &flat).unwrap();
+
+        // Root B (no children) + Root A + Child of A
+        assert_eq!(nested.len(), 3);
+        assert_eq!(nested[0].pad.pad.metadata.title, "Root B");
+        assert_eq!(nested[0].depth, 0);
+        assert_eq!(nested[1].pad.pad.metadata.title, "Root A");
+        assert_eq!(nested[1].depth, 0);
+        assert_eq!(nested[2].pad.pad.metadata.title, "Child of A");
+        assert_eq!(nested[2].depth, 1);
+    }
 }

--- a/crates/padzapp/src/commands/helpers.rs
+++ b/crates/padzapp/src/commands/helpers.rs
@@ -201,6 +201,61 @@ pub fn pads_by_selectors<S: DataStore>(
     Ok(pads)
 }
 
+/// A pad with its nesting depth, produced by tree-walking.
+#[derive(Debug, Clone)]
+pub struct NestedPad {
+    pub pad: DisplayPad,
+    pub depth: usize,
+}
+
+/// Given a list of resolved (flat) DisplayPads, re-resolve them with their full
+/// subtrees from the indexed tree. Returns a flat sequence of (pad, depth) pairs
+/// in tree-traversal order.
+///
+/// Each selected pad is at depth 0, its children at depth 1, etc.
+/// Only active (non-deleted) children are included.
+pub fn collect_nested_pads<S: DataStore>(
+    store: &S,
+    scope: Scope,
+    root_pads: &[DisplayPad],
+) -> Result<Vec<NestedPad>> {
+    let indexed = indexed_pads(store, scope)?;
+    let mut result = Vec::new();
+
+    for dp in root_pads {
+        // Find this pad in the full indexed tree to get its children
+        if let Some(tree_node) = find_node_by_id(&indexed, dp.pad.metadata.id) {
+            flatten_tree(tree_node, 0, &mut result);
+        } else {
+            // Pad not found in tree (edge case) - include it flat
+            result.push(NestedPad {
+                pad: dp.clone(),
+                depth: 0,
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+fn flatten_tree(dp: &DisplayPad, depth: usize, result: &mut Vec<NestedPad>) {
+    result.push(NestedPad {
+        pad: DisplayPad {
+            pad: dp.pad.clone(),
+            index: dp.index.clone(),
+            matches: dp.matches.clone(),
+            children: Vec::new(), // flatten
+        },
+        depth,
+    });
+    for child in &dp.children {
+        // Skip deleted children in nested output
+        if !matches!(child.index, DisplayIndex::Deleted(_)) {
+            flatten_tree(child, depth + 1, result);
+        }
+    }
+}
+
 pub fn get_descendant_ids<S: DataStore>(
     store: &S,
     scope: Scope,

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -66,6 +66,18 @@ use crate::model::Scope;
 use serde::Serialize;
 use std::path::PathBuf;
 
+/// Controls how nested (parent/child) pads are rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NestingMode {
+    /// Show only the selected pad(s), no children (legacy behavior).
+    Flat,
+    /// Recursively include children, no indentation.
+    #[default]
+    Tree,
+    /// Recursively include children, with 4-space indentation per nesting level.
+    Indented,
+}
+
 pub mod archive;
 pub mod create;
 pub mod delete;
@@ -157,8 +169,13 @@ impl CmdMessage {
 pub struct CmdResult {
     pub affected_pads: Vec<DisplayPad>,
     pub listed_pads: Vec<DisplayPad>,
+    /// Nesting depths for listed_pads (parallel to listed_pads).
+    /// Empty means all pads are at depth 0.
+    pub listed_depths: Vec<usize>,
     pub pad_paths: Vec<PathBuf>,
     pub messages: Vec<CmdMessage>,
+    /// The nesting mode used to produce listed_pads.
+    pub nesting: NestingMode,
 }
 
 impl CmdResult {

--- a/crates/padzapp/src/commands/update.rs
+++ b/crates/padzapp/src/commands/update.rs
@@ -126,7 +126,7 @@ pub fn run_from_content<S: DataStore>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::{create, get, view};
+    use crate::commands::{create, get, view, NestingMode};
     use crate::index::{DisplayIndex, PadSelector};
     use crate::model::Scope;
     use crate::store::bucketed::BucketedStore;
@@ -155,6 +155,7 @@ mod tests {
             &store,
             Scope::Project,
             &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Flat,
         )
         .unwrap()
         .listed_pads;
@@ -201,6 +202,7 @@ mod tests {
             &store,
             Scope::Project,
             &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Flat,
         )
         .unwrap()
         .listed_pads;
@@ -279,6 +281,7 @@ mod tests {
             &store,
             Scope::Project,
             &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Flat,
         )
         .unwrap()
         .listed_pads;

--- a/crates/padzapp/src/commands/view.rs
+++ b/crates/padzapp/src/commands/view.rs
@@ -1,25 +1,317 @@
-use crate::commands::CmdResult;
+use crate::commands::{CmdResult, NestingMode};
 use crate::error::Result;
 use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::{Bucket, DataStore};
 
-use super::helpers::pads_by_selectors;
+use super::helpers::{collect_nested_pads, pads_by_selectors, NestedPad};
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+pub fn run<S: DataStore>(
+    store: &S,
+    scope: Scope,
+    selectors: &[PadSelector],
+    nesting: NestingMode,
+) -> Result<CmdResult> {
     let pads = pads_by_selectors(store, scope, selectors, false)?;
 
+    let nested = match nesting {
+        NestingMode::Flat => pads
+            .iter()
+            .map(|dp| NestedPad {
+                pad: dp.clone(),
+                depth: 0,
+            })
+            .collect(),
+        NestingMode::Tree | NestingMode::Indented => collect_nested_pads(store, scope, &pads)?,
+    };
+
     // Collect paths for each pad (for editor integration)
-    let paths: Vec<_> = pads
+    let paths: Vec<_> = nested
         .iter()
-        .filter_map(|dp| {
+        .filter_map(|np| {
             store
-                .get_pad_path(&dp.pad.metadata.id, scope, Bucket::Active)
+                .get_pad_path(&np.pad.pad.metadata.id, scope, Bucket::Active)
                 .ok()
         })
         .collect();
 
-    let mut result = CmdResult::default().with_listed_pads(pads);
+    let depths: Vec<usize> = nested.iter().map(|np| np.depth).collect();
+    let listed: Vec<_> = nested.into_iter().map(|np| np.pad).collect();
+    let mut result = CmdResult::default().with_listed_pads(listed);
+    result.listed_depths = depths;
     result.pad_paths = paths;
+    result.nesting = nesting;
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::create;
+    use crate::index::{DisplayIndex, PadSelector};
+    use crate::store::bucketed::BucketedStore;
+    use crate::store::mem_backend::MemBackend;
+
+    fn make_store() -> BucketedStore<MemBackend> {
+        BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        )
+    }
+
+    #[test]
+    fn flat_mode_returns_only_selected_pad() {
+        let mut store = make_store();
+        // Create parent with children
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Parent".into(),
+            "Parent body".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child A".into(),
+            "Child A body".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child B".into(),
+            "Child B body".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Flat,
+        )
+        .unwrap();
+
+        assert_eq!(result.listed_pads.len(), 1);
+        assert_eq!(result.listed_pads[0].pad.metadata.title, "Parent");
+        assert_eq!(result.listed_depths, vec![0]);
+    }
+
+    #[test]
+    fn tree_mode_includes_children_recursively() {
+        let mut store = make_store();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Parent".into(),
+            "Parent body".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child A".into(),
+            "Child A body".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child B".into(),
+            "Child B body".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Tree,
+        )
+        .unwrap();
+
+        // Should have parent + 2 children = 3 pads
+        assert_eq!(result.listed_pads.len(), 3);
+        assert_eq!(result.listed_pads[0].pad.metadata.title, "Parent");
+        // Children are newest first: Child B (1.1), Child A (1.2)
+        assert_eq!(result.listed_pads[1].pad.metadata.title, "Child B");
+        assert_eq!(result.listed_pads[2].pad.metadata.title, "Child A");
+        assert_eq!(result.listed_depths, vec![0, 1, 1]);
+    }
+
+    #[test]
+    fn indented_mode_tracks_depth() {
+        let mut store = make_store();
+        create::run(&mut store, Scope::Project, "Root".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Level 1".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Level 2".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![
+                DisplayIndex::Regular(1),
+                DisplayIndex::Regular(1),
+            ])),
+        )
+        .unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Indented,
+        )
+        .unwrap();
+
+        assert_eq!(result.listed_pads.len(), 3);
+        assert_eq!(result.listed_depths, vec![0, 1, 2]);
+        assert_eq!(result.listed_pads[0].pad.metadata.title, "Root");
+        assert_eq!(result.listed_pads[1].pad.metadata.title, "Level 1");
+        assert_eq!(result.listed_pads[2].pad.metadata.title, "Level 2");
+    }
+
+    #[test]
+    fn tree_mode_skips_deleted_children() {
+        let mut store = make_store();
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Active Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        // Create a child then delete it
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Will Delete".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        crate::commands::delete::run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![
+                DisplayIndex::Regular(1),
+                DisplayIndex::Regular(1),
+            ])],
+        )
+        .unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Tree,
+        )
+        .unwrap();
+
+        // Parent + 1 active child (deleted child excluded)
+        assert_eq!(result.listed_pads.len(), 2);
+        assert_eq!(result.listed_pads[0].pad.metadata.title, "Parent");
+        assert_eq!(result.listed_pads[1].pad.metadata.title, "Active Child");
+    }
+
+    #[test]
+    fn tree_mode_on_leaf_pad_returns_just_that_pad() {
+        let mut store = make_store();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Leaf".into(),
+            "content".into(),
+            None,
+        )
+        .unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            NestingMode::Tree,
+        )
+        .unwrap();
+
+        assert_eq!(result.listed_pads.len(), 1);
+        assert_eq!(result.listed_pads[0].pad.metadata.title, "Leaf");
+        assert_eq!(result.listed_depths, vec![0]);
+    }
+
+    #[test]
+    fn tree_mode_multiple_roots_each_expand() {
+        let mut store = make_store();
+        // Create two parents, each with a child
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Parent A".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Parent B".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        // Parent B is 1, Parent A is 2 (newest first)
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child of A".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(2)])),
+        )
+        .unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child of B".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let result = run(
+            &store,
+            Scope::Project,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+            ],
+            NestingMode::Tree,
+        )
+        .unwrap();
+
+        // Parent B + Child of B + Parent A + Child of A = 4
+        assert_eq!(result.listed_pads.len(), 4);
+        assert_eq!(result.listed_pads[0].pad.metadata.title, "Parent B");
+        assert_eq!(result.listed_pads[1].pad.metadata.title, "Child of B");
+        assert_eq!(result.listed_pads[2].pad.metadata.title, "Parent A");
+        assert_eq!(result.listed_pads[3].pad.metadata.title, "Child of A");
+        assert_eq!(result.listed_depths, vec![0, 1, 0, 1]);
+    }
 }

--- a/crates/padzapp/tests/title_referencing.rs
+++ b/crates/padzapp/tests/title_referencing.rs
@@ -1,5 +1,5 @@
 use padzapp::api::PadzApi;
-use padzapp::commands::PadzPaths;
+use padzapp::commands::{NestingMode, PadzPaths};
 use padzapp::model::Scope;
 use padzapp::store::bucketed::BucketedStore;
 use padzapp::store::mem_backend::MemBackend;
@@ -45,11 +45,15 @@ fn test_referencing_by_index() {
     // Created Order: Groceries, Grocery List, Gold.
     // Indexing: Gold (1), Grocery List (2), Groceries (3).
 
-    let res = api.view_pads(Scope::Project, &["1"]).unwrap();
+    let res = api
+        .view_pads(Scope::Project, &["1"], NestingMode::Flat)
+        .unwrap();
     assert_eq!(res.listed_pads.len(), 1);
     assert_eq!(res.listed_pads[0].pad.metadata.title, "Gold");
 
-    let res = api.view_pads(Scope::Project, &["3"]).unwrap();
+    let res = api
+        .view_pads(Scope::Project, &["3"], NestingMode::Flat)
+        .unwrap();
     assert_eq!(res.listed_pads.len(), 1);
     assert_eq!(res.listed_pads[0].pad.metadata.title, "Groceries");
 }
@@ -57,7 +61,9 @@ fn test_referencing_by_index() {
 #[test]
 fn test_referencing_multiple_indexes() {
     let api = setup();
-    let res = api.view_pads(Scope::Project, &["1", "2"]).unwrap();
+    let res = api
+        .view_pads(Scope::Project, &["1", "2"], NestingMode::Flat)
+        .unwrap();
     assert_eq!(res.listed_pads.len(), 2);
     // Gold and Grocery List
 }
@@ -65,7 +71,9 @@ fn test_referencing_multiple_indexes() {
 #[test]
 fn test_referencing_by_title_exact() {
     let api = setup();
-    let res = api.view_pads(Scope::Project, &["Gold"]).unwrap();
+    let res = api
+        .view_pads(Scope::Project, &["Gold"], NestingMode::Flat)
+        .unwrap();
     assert_eq!(res.listed_pads.len(), 1);
     assert_eq!(res.listed_pads[0].pad.metadata.title, "Gold");
 }
@@ -74,7 +82,9 @@ fn test_referencing_by_title_exact() {
 fn test_referencing_by_title_partial() {
     let api = setup();
     // "Gold" is matched by "old"
-    let res = api.view_pads(Scope::Project, &["old"]).unwrap();
+    let res = api
+        .view_pads(Scope::Project, &["old"], NestingMode::Flat)
+        .unwrap();
     assert_eq!(res.listed_pads.len(), 1);
     assert_eq!(res.listed_pads[0].pad.metadata.title, "Gold");
 }
@@ -84,7 +94,9 @@ fn test_referencing_by_title_multi_word_arg() {
     let api = setup();
     // "Grocery List" matched by "Grocery List" (passed as separate args by shell simulation)
     // Actually view_pads takes &[String]. The CLI passes ["Grocery", "List"].
-    let res = api.view_pads(Scope::Project, &["Grocery", "List"]).unwrap();
+    let res = api
+        .view_pads(Scope::Project, &["Grocery", "List"], NestingMode::Flat)
+        .unwrap();
     assert_eq!(res.listed_pads.len(), 1);
     assert_eq!(res.listed_pads[0].pad.metadata.title, "Grocery List");
 }
@@ -93,7 +105,7 @@ fn test_referencing_by_title_multi_word_arg() {
 fn test_referencing_ambiguous() {
     let api = setup();
     // "Gro" matches "Groceries" and "Grocery List"
-    let res = api.view_pads(Scope::Project, &["Gro"]);
+    let res = api.view_pads(Scope::Project, &["Gro"], NestingMode::Flat);
     assert!(res.is_err());
     let err = res.err().unwrap().to_string();
     assert!(err.contains("matches multiple paths"));
@@ -108,7 +120,7 @@ fn test_referencing_mixed_treated_as_title() {
     // "Gold" pad content is "Au". Title "Gold".
     // Search "1 Gold" -> No match.
 
-    let res = api.view_pads(Scope::Project, &["1", "Gold"]);
+    let res = api.view_pads(Scope::Project, &["1", "Gold"], NestingMode::Flat);
     assert!(res.is_err());
     let err = res.err().unwrap().to_string();
     assert!(err.contains("No pad found matching \"1 Gold\""));
@@ -117,6 +129,6 @@ fn test_referencing_mixed_treated_as_title() {
 #[test]
 fn test_referencing_mixed_no_match() {
     let api = setup();
-    let res = api.view_pads(Scope::Project, &["1", "Grocery"]);
+    let res = api.view_pads(Scope::Project, &["1", "Grocery"], NestingMode::Flat);
     assert!(res.is_err());
 }

--- a/live-tests/tests/nested-output.bats
+++ b/live-tests/tests/nested-output.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# =============================================================================
+# NESTED OUTPUT TESTS
+# =============================================================================
+# Tests for --flat / --tree / --indented flags on view, copy, and export.
+# Creates fresh pads to avoid depending on fixture index positions.
+# =============================================================================
+
+load '../lib/helpers.bash'
+load '../lib/assertions.bash'
+
+setup() {
+    # Create a fresh set of nested pads in global scope for each test
+    "${PADZ_BIN}" -g create --no-editor "Nested Test Parent"
+    PARENT_INDEX=$(find_pad_by_title "Nested Test Parent" global)
+
+    "${PADZ_BIN}" -g create --no-editor --inside "${PARENT_INDEX}" "Nested Test Child A"
+    "${PADZ_BIN}" -g create --no-editor --inside "${PARENT_INDEX}" "Nested Test Child B"
+}
+
+teardown() {
+    # Clean up: delete the pads we created (best effort)
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global 2>/dev/null) || true
+    if [[ -n "$idx" ]]; then
+        "${PADZ_BIN}" -g delete "$idx" 2>/dev/null || true
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# VIEW --tree (default)
+# -----------------------------------------------------------------------------
+
+@test "view: default shows parent and children" {
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global)
+
+    run "${PADZ_BIN}" -g view "${idx}"
+    assert_success
+    [[ "$output" == *"Nested Test Parent"* ]]
+    [[ "$output" == *"Nested Test Child A"* ]]
+    [[ "$output" == *"Nested Test Child B"* ]]
+}
+
+@test "view: --tree flag shows parent and children" {
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global)
+
+    run "${PADZ_BIN}" -g view --tree "${idx}"
+    assert_success
+    [[ "$output" == *"Nested Test Parent"* ]]
+    [[ "$output" == *"Nested Test Child"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# VIEW --flat
+# -----------------------------------------------------------------------------
+
+@test "view: --flat shows only selected pad, no children" {
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global)
+
+    run "${PADZ_BIN}" -g view --flat "${idx}"
+    assert_success
+    [[ "$output" == *"Nested Test Parent"* ]]
+    [[ "$output" != *"Nested Test Child A"* ]]
+    [[ "$output" != *"Nested Test Child B"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# VIEW --indented
+# -----------------------------------------------------------------------------
+
+@test "view: --indented shows children with indentation" {
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global)
+
+    run "${PADZ_BIN}" -g view --indented "${idx}"
+    assert_success
+    [[ "$output" == *"Nested Test Parent"* ]]
+    [[ "$output" == *"Nested Test Child"* ]]
+    # Indented children should have leading spaces
+    [[ "$output" == *"    Nested Test Child"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# VIEW on leaf pad
+# -----------------------------------------------------------------------------
+
+@test "view: tree mode on leaf pad shows just that pad" {
+    "${PADZ_BIN}" -g create --no-editor "Leaf Only Pad"
+    local idx
+    idx=$(find_pad_by_title "Leaf Only Pad" global)
+
+    run "${PADZ_BIN}" -g view "${idx}"
+    assert_success
+    [[ "$output" == *"Leaf Only Pad"* ]]
+
+    # Cleanup
+    "${PADZ_BIN}" -g delete "${idx}" 2>/dev/null || true
+}
+
+# -----------------------------------------------------------------------------
+# COPY
+# -----------------------------------------------------------------------------
+
+@test "copy: --flat copies only selected pad" {
+    command -v pbpaste >/dev/null || skip "pbpaste not available"
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global)
+
+    run "${PADZ_BIN}" -g copy --flat "${idx}"
+    assert_success
+
+    local clipboard
+    clipboard=$(pbpaste)
+    [[ "$clipboard" == *"Nested Test Parent"* ]]
+    [[ "$clipboard" != *"Nested Test Child A"* ]]
+    [[ "$clipboard" != *"Nested Test Child B"* ]]
+}
+
+@test "copy: default (tree) copies parent and children" {
+    command -v pbpaste >/dev/null || skip "pbpaste not available"
+    local idx
+    idx=$(find_pad_by_title "Nested Test Parent" global)
+
+    run "${PADZ_BIN}" -g copy "${idx}"
+    assert_success
+    [[ "$output" == *"Copied 1 pad"* ]]
+
+    local clipboard
+    clipboard=$(pbpaste)
+    [[ "$clipboard" == *"Nested Test Parent"* ]]
+    [[ "$clipboard" == *"Nested Test Child"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# FLAG CONFLICTS
+# -----------------------------------------------------------------------------
+
+@test "view: --flat and --tree conflict" {
+    run "${PADZ_BIN}" -g view --flat --tree 1
+    [ "$status" -ne 0 ]
+}
+
+@test "view: --flat and --indented conflict" {
+    run "${PADZ_BIN}" -g view --flat --indented 1
+    [ "$status" -ne 0 ]
+}
+
+@test "copy: --tree and --indented conflict" {
+    run "${PADZ_BIN}" -g copy --tree --indented 1
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- **View, copy, and export** commands now recursively include children by default (`--tree` mode)
- `--flat` restores previous behavior (selected pad only), `--indented` adds 4-space indentation per nesting level
- Centralized tree-walking logic in `collect_nested_pads()` shared across all content-output commands
- View template uses `depth` field to show `---` only between root-level pads, not between parent and child
- Export handles depth in both text (indented separators/body) and markdown (heading level = 2 + depth) formats

## Test plan

- [x] 6 unit tests for `view::run` (flat, tree, indented, leaf, deleted children, multi-root)
- [x] 5 unit tests for `collect_nested_pads` (depths, deep tree, deleted children, leaf, multi-root)
- [x] 5 unit tests for `render.rs` list nesting (indent string, title_width, deep nesting, order, pin marker)
- [x] 6 unit tests for export nesting (text/markdown hand-constructed + store-based, flat mode, H6 cap)
- [x] All existing unit tests updated and passing (503 total)
- [x] 10 bats e2e tests covering view/copy with all nesting modes and flag conflicts
- [x] All 112 bats e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)