### PR TITLE
Fix nested pad creation via editor losing parent relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Added**
   - **Nested pad output** — `view`, `copy`, and `export` commands now recursively include children by default (`--tree`). Use `--flat` for the previous behavior (selected pad only) or `--indented` for 4-space indentation per nesting level. Centralized tree-walking logic ensures consistent behavior across all content-output commands.
 
+- **Fixed**
+  - **Nested pad creation via editor lost parent relationship** — `padz create -i <parent> -e` would create the child pad, but the parent-child link was silently destroyed before the editor opened. The root cause: `create::run` called `propagate_status_change` immediately after saving the (empty) pad, which triggered `list_pads` → reconciliation → garbage collection of the empty content file and its index entry (including `parent_id`). The pad was later recovered as an orphan with no parent. Fix: `create::run` no longer calls propagation; the CLI handler calls it after the pad has real content (post-editor or post-pipe).
+
 ## [0.27.1] - 2026-03-28
 
 ## [0.27.1] - 2026-03-28

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -586,6 +586,9 @@ pub fn create(
         let (title, body) =
             extract_title_and_body(&expanded).unwrap_or_else(|| (String::new(), String::new()));
         let result = do_create(state, title.clone(), body.clone(), inside, format_ref)?;
+        // Propagate status now — content is non-empty, safe from reconciliation
+        let parent_id = result.affected_pads[0].pad.metadata.parent_id;
+        state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
         // Copy to clipboard
         let clipboard_text = format_for_clipboard(&title, &body);
         let _ = copy_to_clipboard(&clipboard_text);
@@ -607,6 +610,9 @@ pub fn create(
             (None, true) => String::new(),
         };
         let result = do_create(state, final_title, parsed.content, inside, format_ref)?;
+        // Propagate status now — content is non-empty, safe from reconciliation
+        let parent_id = result.affected_pads[0].pad.metadata.parent_id;
+        state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
         // Copy to clipboard
         copy_content_to_clipboard(&raw);
         result
@@ -630,6 +636,13 @@ pub fn create(
                 .map_err(|e| anyhow::anyhow!("{}", e))
         })? {
             Some(pad) => {
+                // Propagate status now — pad has real content after editor,
+                // safe from reconciliation deleting the empty file.
+                let parent_id = pad.metadata.parent_id;
+                state.with_api(|api| {
+                    api.propagate_status(state.scope, parent_id)
+                        .map_err(|e| anyhow::anyhow!("{}", e))
+                })?;
                 // Copy to clipboard
                 copy_content_to_clipboard(&pad.content);
                 // Build result

--- a/crates/padzapp/src/api.rs
+++ b/crates/padzapp/src/api.rs
@@ -358,6 +358,16 @@ impl<S: DataStore> PadzApi<S> {
         self.store.delete_pad(&id, scope, Bucket::Active)
     }
 
+    /// Propagate todo status changes upward from a child's parent.
+    ///
+    /// Called after create/delete/status-change operations to keep ancestor
+    /// statuses consistent. Separated from `create_pad` because propagation
+    /// triggers reconciliation (via `list_pads`), which garbage-collects empty
+    /// files — a problem when the pad hasn't been filled yet (editor flow).
+    pub fn propagate_status(&mut self, scope: Scope, parent_id: Option<uuid::Uuid>) -> Result<()> {
+        crate::todos::propagate_status_change(&mut self.store, scope, parent_id)
+    }
+
     pub fn init(&self, scope: Scope) -> Result<commands::CmdResult> {
         commands::init::run(&self.paths, scope)
     }
@@ -1245,5 +1255,64 @@ mod tests {
             .get_pads(Scope::Project, PadFilter::default(), &[] as &[String])
             .unwrap();
         assert_eq!(list.listed_pads.len(), 0);
+    }
+
+    /// Regression test: simulates the full editor flow for nested pad creation.
+    ///
+    /// The sequence is: create empty pad with parent → (editor fills content)
+    /// → refresh_pad → propagate_status. Before the fix, propagation was called
+    /// inside create, which triggered reconciliation that deleted the empty file
+    /// and its index entry (with parent_id). The pad was then recovered as an
+    /// orphan with parent_id: None.
+    #[test]
+    fn test_editor_flow_preserves_nested_parent() {
+        let mut api = make_api();
+
+        // Create parent pad
+        api.create_pad(Scope::Project, "Parent".into(), "".into(), None)
+            .unwrap();
+
+        // Create child with empty content (simulates `padz create -i 1 -e`)
+        let result = api
+            .create_pad(Scope::Project, "".into(), "".into(), Some("1"))
+            .unwrap();
+        let child_id = result.affected_pads[0].pad.metadata.id;
+        assert!(result.affected_pads[0].pad.metadata.parent_id.is_some());
+
+        // Simulate editor: write content to the pad file
+        api.store
+            .active_store_mut()
+            .backend
+            .write_content(&child_id, Scope::Project, "Editor Content")
+            .unwrap();
+
+        // refresh_pad re-reads content from disk (like after editor closes)
+        let refreshed = api.refresh_pad(Scope::Project, &child_id).unwrap();
+        assert!(refreshed.is_some(), "Pad should exist after refresh");
+        let pad = refreshed.unwrap();
+        assert_eq!(pad.metadata.title, "Editor Content");
+        assert!(
+            pad.metadata.parent_id.is_some(),
+            "Parent ID must be preserved through editor flow"
+        );
+
+        // Now propagate status (caller responsibility after editor)
+        api.propagate_status(Scope::Project, pad.metadata.parent_id)
+            .unwrap();
+
+        // Verify the pad is a child in the tree (children are nested under parents)
+        let all = api
+            .get_pads(Scope::Project, PadFilter::default(), &[] as &[String])
+            .unwrap();
+        assert_eq!(all.listed_pads.len(), 1, "Should have one root pad");
+        let parent_dp = &all.listed_pads[0];
+        assert_eq!(parent_dp.pad.metadata.title, "Parent");
+        assert_eq!(parent_dp.children.len(), 1, "Parent should have one child");
+        let child_dp = &parent_dp.children[0];
+        assert_eq!(child_dp.pad.metadata.id, child_id);
+        assert_eq!(
+            child_dp.pad.metadata.parent_id, pad.metadata.parent_id,
+            "Parent ID must survive the full create→editor→refresh→propagate cycle"
+        );
     }
 }

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -37,8 +37,12 @@ pub fn run<S: DataStore>(
 
     store.save_pad(&pad, scope, Bucket::Active)?;
 
-    // Propagate status change to parent (e.g. adding a "Planned" child might revert parent from "Done")
-    crate::todos::propagate_status_change(store, scope, pad.metadata.parent_id)?;
+    // NOTE: We intentionally do NOT call propagate_status_change here.
+    // Propagation triggers list_pads → reconciliation, which garbage-collects
+    // empty content files. In the editor flow, the pad starts with empty content
+    // (user hasn't typed yet), so reconciliation would delete the file AND its
+    // index entry — destroying the parent_id. The caller is responsible for
+    // calling propagate_status after the pad has real content.
 
     // Get the path for the created pad (for editor integration)
     let pad_path = store.get_pad_path(&pad.metadata.id, scope, Bucket::Active)?;
@@ -61,6 +65,7 @@ pub fn run<S: DataStore>(
 mod tests {
     use super::*;
     use crate::index::{DisplayIndex, PadSelector};
+    use crate::store::backend::StorageBackend;
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
 
@@ -226,6 +231,106 @@ mod tests {
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
         assert!(pads[0].metadata.parent_id.is_none());
+    }
+
+    /// Regression test: creating a nested pad with empty content must not trigger
+    /// reconciliation (which would delete the empty file and lose parent_id).
+    ///
+    /// Before the fix, create::run called propagate_status_change which called
+    /// list_pads → reconcile. Reconciliation garbage-collected the empty content
+    /// file AND its index entry (with parent_id). Now create::run does NOT call
+    /// propagation — the caller handles it after the pad has real content.
+    #[test]
+    fn nested_empty_content_no_propagation_during_create() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+
+        // Create parent
+        run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+
+        // Create child with EMPTY content — simulates `padz create -i 1 -e` (editor flow)
+        let parent_sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "".into(),
+            "".into(),
+            Some(parent_sel),
+        )
+        .unwrap();
+        let child_id = result.affected_pads[0].pad.metadata.id;
+        let parent_id = result.affected_pads[0].pad.metadata.parent_id;
+
+        // The child was created with parent_id set
+        assert!(parent_id.is_some());
+
+        // Crucially: get_pad must find the child (no reconciliation ran to delete it)
+        let child = store
+            .get_pad(&child_id, Scope::Project, Bucket::Active)
+            .expect("Child pad must exist — create should not trigger reconciliation");
+        assert_eq!(child.metadata.parent_id, parent_id);
+    }
+
+    /// Simulates the full editor flow: create empty → editor writes content →
+    /// refresh → propagate. Parent_id must be preserved throughout.
+    #[test]
+    fn nested_editor_flow_preserves_parent_id() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+
+        // Create parent
+        run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+
+        // Create child with empty content (editor hasn't filled it yet)
+        let parent_sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        let result = run(
+            &mut store,
+            Scope::Project,
+            "".into(),
+            "".into(),
+            Some(parent_sel),
+        )
+        .unwrap();
+        let child_id = result.affected_pads[0].pad.metadata.id;
+        let parent_id = result.affected_pads[0].pad.metadata.parent_id;
+        assert!(parent_id.is_some());
+
+        // Simulate editor writing content
+        store
+            .active_store_mut()
+            .backend
+            .write_content(&child_id, Scope::Project, "Editor Content")
+            .unwrap();
+
+        // Simulate refresh_pad: get_pad + update
+        let mut pad = store
+            .get_pad(&child_id, Scope::Project, Bucket::Active)
+            .expect("Pad must exist after editor write");
+        pad.update_from_raw("Editor Content");
+        store
+            .save_pad(&pad, Scope::Project, Bucket::Active)
+            .unwrap();
+
+        // NOW propagate (caller responsibility) — this triggers list_pads → reconcile
+        crate::todos::propagate_status_change(&mut store, Scope::Project, parent_id).unwrap();
+
+        // Verify parent_id survived the full cycle
+        let final_pad = store
+            .get_pad(&child_id, Scope::Project, Bucket::Active)
+            .unwrap();
+        assert_eq!(
+            final_pad.metadata.parent_id, parent_id,
+            "Parent ID must survive create → editor → refresh → propagate cycle"
+        );
+        assert_eq!(final_pad.metadata.title, "Editor Content");
     }
 
     #[test]

--- a/live-tests/tests/editor-flow.bats
+++ b/live-tests/tests/editor-flow.bats
@@ -199,3 +199,61 @@ teardown() {
 
     [[ "${tmp_before}" == "${tmp_after}" ]]
 }
+
+# -----------------------------------------------------------------------------
+# NESTED PAD CREATION VIA PIPED CONTENT (regression: parent_id preservation)
+# -----------------------------------------------------------------------------
+# These tests verify the fix for the bug where creating a nested pad via
+# editor/pipe lost the parent_id. The root cause was that create::run called
+# propagate_status_change (which triggers reconciliation) before the pad had
+# real content, causing reconciliation to delete the empty file + index entry.
+
+@test "piped nested create preserves parent relationship" {
+    # Create parent pad
+    bash -c "printf 'Parent Pad\n\nParent body' | \"${PADZ_BIN}\" -g create" >/dev/null
+
+    # Create child pad with parent reference
+    bash -c "printf 'Child Pad\n\nChild body' | \"${PADZ_BIN}\" -g create -i 1" >/dev/null
+
+    # Verify parent exists
+    assert_pad_exists "Parent Pad" global
+
+    # Child should be nested under parent (not a top-level pad)
+    local json child_parent_id
+    json=$(list_pads global)
+
+    # Only 1 root pad (the parent)
+    local root_count
+    root_count=$(echo "${json}" | jq '.pads | length')
+    [[ "${root_count}" -eq 1 ]]
+
+    # The parent should have the child nested inside
+    child_parent_id=$(echo "${json}" | jq -r '.pads[0].children[0].pad.metadata.parent_id')
+    [[ "${child_parent_id}" != "null" ]]
+
+    local child_title
+    child_title=$(echo "${json}" | jq -r '.pads[0].children[0].pad.metadata.title')
+    [[ "${child_title}" == "Child Pad" ]]
+}
+
+@test "piped nested create shows child in tree listing" {
+    # Create parent
+    bash -c "printf 'Tree Parent\n\nContent' | \"${PADZ_BIN}\" -g create" >/dev/null
+
+    # Create two children
+    bash -c "printf 'Tree Child A\n\nContent A' | \"${PADZ_BIN}\" -g create -i 1" >/dev/null
+    bash -c "printf 'Tree Child B\n\nContent B' | \"${PADZ_BIN}\" -g create -i 1" >/dev/null
+
+    # Both children should be nested under the parent
+    local json children_count
+    json=$(list_pads global)
+    children_count=$(echo "${json}" | jq '.pads[0].children | length')
+    [[ "${children_count}" -eq 2 ]]
+
+    # Newest first
+    local first_child second_child
+    first_child=$(echo "${json}" | jq -r '.pads[0].children[0].pad.metadata.title')
+    second_child=$(echo "${json}" | jq -r '.pads[0].children[1].pad.metadata.title')
+    [[ "${first_child}" == "Tree Child B" ]]
+    [[ "${second_child}" == "Tree Child A" ]]
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `create::run` called `propagate_status_change` immediately after saving the (empty) pad. In the editor flow, the pad starts with empty content. Propagation triggers `list_pads` → reconciliation, which garbage-collects the empty content file AND its index entry — destroying the `parent_id`. The pad was later recovered as an orphan with `parent_id: None`.

- **Fix**: Remove propagation from `create::run`. The CLI handler now calls `propagate_status` at the right time — after the pad has real content (post-editor close for editor path, immediately for quick-create/stdin paths where content is already non-empty).

- **New API method**: `api.propagate_status(scope, parent_id)` — thin wrapper around `propagate_status_change`, available for callers that need explicit control over when propagation happens.

## Test plan

- [x] Unit test: `nested_empty_content_no_propagation_during_create` — verifies `create::run` no longer triggers reconciliation
- [x] Unit test: `nested_editor_flow_preserves_parent_id` — full create→editor→refresh→propagate cycle
- [x] API test: `test_editor_flow_preserves_nested_parent` — end-to-end through the API layer  
- [x] E2E test: `piped nested create preserves parent relationship` — binary-level pipe+nesting test
- [x] E2E test: `piped nested create shows child in tree listing` — multi-child nesting
- [x] All 506 unit tests pass, all 13 editor-flow e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)