### PR TITLE
Fall back to global scope when no project store is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Fixed**
+  - **`padz init` now uses cwd instead of upward discovery** — Previously, `padz init` used the same `find_project_root()` upward-walk as other commands, which could silently resolve to a parent directory's store instead of creating one in the current directory. Init is a creation operation ("create a store here"), so it now always uses `cwd/.padz` directly. All other commands continue using upward discovery to find existing stores.
+
 ## [0.28.0] - 2026-04-03
 
 ## [0.28.0] - 2026-04-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Fixed**
   - **`padz init` now uses cwd instead of upward discovery** — Previously, `padz init` used the same `find_project_root()` upward-walk as other commands, which could silently resolve to a parent directory's store instead of creating one in the current directory. Init is a creation operation ("create a store here"), so it now always uses `cwd/.padz` directly. All other commands continue using upward discovery to find existing stores.
+  - **Fall back to global scope when no project store is found** — Running `padz` outside any project (no `.padz` found by upward walk) now transparently uses the global store instead of pointing at a nonexistent `cwd/.padz` and showing "No pads yet". The `-g` flag is no longer required outside project directories.
 
 ## [0.28.0] - 2026-04-03
 

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -113,6 +113,22 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     let data_override = cli.data.as_ref().map(std::path::PathBuf::from);
 
+    // `padz init` (plain, non-global) is a creation operation: "create a store HERE".
+    // It should use cwd directly, not walk up to find an existing store.
+    // All other commands use find_project_root() for discovery, which is correct.
+    let is_plain_init = matches!(
+        cli.command,
+        Some(Commands::Init {
+            link: None,
+            unlink: false
+        })
+    );
+    let data_override = if is_plain_init && data_override.is_none() && !cli.global {
+        Some(cwd.clone())
+    } else {
+        data_override
+    };
+
     // Compute the local .padz dir BEFORE link resolution (used by link/unlink commands)
     let local_padz_dir = match &data_override {
         Some(path) => {

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -144,15 +144,10 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
     };
 
     let padz_ctx = initialize(&cwd, cli.global, data_override);
-    let scope = if cli.global {
-        padzapp::model::Scope::Global
-    } else {
-        padzapp::model::Scope::Project
-    };
 
     Ok(AppState::new(
         padz_ctx.api,
-        scope,
+        padz_ctx.scope,
         padz_ctx.config.import_extensions(),
         output_mode,
         padz_ctx.config.mode,

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -46,6 +46,10 @@
 //!    - Found → `Scope::Project`.
 //!    - Not Found → `Scope::Project` with `cwd/.padz` as path.
 //!
+//! **Note:** The CLI layer overrides this for `padz init` (plain, non-global): init is a
+//! creation operation ("create a store HERE"), so it always uses `cwd/.padz` directly,
+//! bypassing upward discovery. All other commands use [`find_project_root`] for discovery.
+//!
 //! ## Data Path Override
 //!
 //! The `data_override` parameter allows explicitly specifying the data directory,

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -35,16 +35,20 @@
 //! When working in nested repos (e.g., `parent-repo/child-repo`):
 //! - If only `parent-repo` has `.padz`, starting from `child-repo` will find and use `parent-repo`
 //! - If both have `.padz`, the innermost one (closest to cwd) wins
-//! - If neither has `.padz`, uses `cwd/.padz` as default (may need `init`)
+//! - If neither has `.padz`, falls back to global scope
 //!
 //! ## Scope Resolution Flow
 //!
 //! The scope is resolved during [`initialize`]:
 //! 1. If `-g` flag is present → Force `Scope::Global`.
-//! 2. If `data_override` is provided → Use that path directly as project data directory.
+//! 2. If `data_override` is provided → Use that path directly as project data directory (`Scope::Project`).
 //! 3. Otherwise → Run [`find_project_root`].
 //!    - Found → `Scope::Project`.
-//!    - Not Found → `Scope::Project` with `cwd/.padz` as path.
+//!    - Not Found → `Scope::Global` (fall back to global store).
+//!
+//! This means that outside any project, commands transparently use the global store.
+//! Users don't need `-g` unless they want to explicitly access global pads while
+//! inside a project directory.
 //!
 //! **Note:** The CLI layer overrides this for `padz init` (plain, non-global): init is a
 //! creation operation ("create a store HERE"), so it always uses `cwd/.padz` directly,
@@ -208,32 +212,6 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 /// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project")));
 /// ```
 pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) -> PadzContext {
-    // Determine project data directory:
-    // 1. If data_override provided:
-    //    - If it ends with ".padz", use it directly
-    //    - Otherwise, append ".padz" to it
-    // 2. Otherwise, try to find a project root with both .git and .padz
-    // 3. Fallback to cwd/.padz
-    let project_padz_dir = match data_override {
-        Some(path) => {
-            if path.file_name().is_some_and(|name| name == ".padz") {
-                path
-            } else {
-                path.join(".padz")
-            }
-        }
-        None => {
-            let detected = find_project_root(cwd)
-                .map(|root| root.join(".padz"))
-                .unwrap_or_else(|| cwd.join(".padz"));
-            // Follow .padz/link if present
-            match resolve_link(&detected) {
-                Ok(Some(linked)) => linked,
-                _ => detected,
-            }
-        }
-    };
-
     // Determine global data directory:
     // 1. Check PADZ_GLOBAL_DATA environment variable (primarily for testing)
     // 2. Fall back to OS-appropriate data directory via directories crate
@@ -246,23 +224,45 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
             proj_dirs.data_dir().to_path_buf()
         });
 
-    let scope = if use_global {
-        Scope::Global
+    // Determine project data directory and scope:
+    // 1. If use_global → Global scope, no project dir
+    // 2. If data_override provided → Project scope with explicit path
+    // 3. find_project_root found something → Project scope
+    // 4. No project found → fall back to Global scope
+    let (project_padz_dir, scope) = if use_global {
+        (None, Scope::Global)
     } else {
-        Scope::Project
+        match data_override {
+            Some(path) => {
+                let dir = if path.file_name().is_some_and(|name| name == ".padz") {
+                    path
+                } else {
+                    path.join(".padz")
+                };
+                (Some(dir), Scope::Project)
+            }
+            None => match find_project_root(cwd) {
+                Some(root) => {
+                    let detected = root.join(".padz");
+                    // Follow .padz/link if present
+                    let resolved = match resolve_link(&detected) {
+                        Ok(Some(linked)) => linked,
+                        _ => detected,
+                    };
+                    (Some(resolved), Scope::Project)
+                }
+                None => (None, Scope::Global),
+            },
+        }
     };
 
     // Config search paths depend on scope:
     // - Global: only global dir (project config must not affect global operations)
     // - Project: both dirs merged (global provides defaults, project overrides)
-    let config_search_paths = if use_global {
-        vec![SearchPath::Path(global_data_dir.clone())]
-    } else {
-        vec![
-            SearchPath::Path(global_data_dir.clone()),
-            SearchPath::Path(project_padz_dir.clone()),
-        ]
-    };
+    let mut config_search_paths = vec![SearchPath::Path(global_data_dir.clone())];
+    if let Some(ref project_dir) = project_padz_dir {
+        config_search_paths.push(SearchPath::Path(project_dir.clone()));
+    }
 
     let config: PadzConfig = Clapfig::builder()
         .app_name("padz")
@@ -274,13 +274,15 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
     let format_ext = config.format_ext();
 
     // Migrate legacy flat layout to bucketed layout (if needed)
-    migrate_if_needed(&project_padz_dir);
+    if let Some(ref project_dir) = project_padz_dir {
+        migrate_if_needed(project_dir);
+    }
     migrate_if_needed(&global_data_dir);
 
-    let store = FileStore::new_fs(Some(project_padz_dir.clone()), global_data_dir.clone())
+    let store = FileStore::new_fs(project_padz_dir.clone(), global_data_dir.clone())
         .with_format(&format_ext);
     let paths = PadzPaths {
-        project: Some(project_padz_dir),
+        project: project_padz_dir,
         global: global_data_dir,
     };
     let api = PadzApi::new(store, paths);
@@ -620,11 +622,11 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override AND global flag
-        // The override still sets project path, but scope is Global
-        // Note: CLI prevents this combination, but library allows it
-        let ctx = initialize(repo, true, Some(override_dir.clone()));
+        // Global flag wins: scope is Global, project path is None
+        // Note: CLI prevents this combination (--data conflicts with -g)
+        let ctx = initialize(repo, true, Some(override_dir));
 
-        assert_eq!(ctx.api.paths().project, Some(override_dir));
+        assert_eq!(ctx.api.paths().project, None);
         assert_eq!(ctx.scope, crate::model::Scope::Global);
     }
 

--- a/live-tests/base-fixture.sh
+++ b/live-tests/base-fixture.sh
@@ -62,6 +62,7 @@ padz -g list --deleted
 # Create from inside project-a (git repo = project scope)
 
 cd projects/project-a
+padz init
 
 # Simple project pads
 padz create --no-editor "Project pad: Feature Implementation"


### PR DESCRIPTION
## Summary

- When `find_project_root()` returns `None` (no `.padz` found by upward walk), scope now resolves to `Global` instead of pointing at a nonexistent `cwd/.padz`
- `initialize()` now returns the resolved scope (including fallback logic), and `create_app_state` uses it directly instead of re-deriving from the `-g` flag
- Live test fixture updated to explicitly `padz init` in the project directory (the correct real-world workflow now that implicit creation via fallback-to-cwd is gone)

Includes cherry-pick of #87 (init uses cwd) since the two changes are complementary.

## Before/After

```bash
# Before: outside any project
$ padz | head -1
No pads yet, create one with `padz create`

# After: transparently shows global pads
$ padz | head -1
⚲ p1. Code Review Basics ...
```

Closes #89

## Test plan

- [x] All 524 cargo tests pass (unit + integration + e2e)
- [x] All 114 bats live tests pass
- [ ] Manual: `cd ~` (outside any project), `padz list` shows global pads
- [ ] Manual: `cd` into an initialized project, `padz list` shows project pads (not global)

🤖 Generated with [Claude Code](https://claude.com/claude-code)