### PR TITLE
Fix edit/open commands to support title matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 - **Fixed**
+  - **`edit`/`open` now support title matching** — `padz open On Ids` and `padz edit My Note` now work, matching the behavior of `view`, `copy`, and all other commands. Previously, `split_indexes_and_content` classified non-index args as inline content, leaving no index selector and erroring with "No pad index provided". When no args parse as indexes, they are now treated as a title search term.
   - **`padz init` now uses cwd instead of upward discovery** — Previously, `padz init` used the same `find_project_root()` upward-walk as other commands, which could silently resolve to a parent directory's store instead of creating one in the current directory. Init is a creation operation ("create a store here"), so it now always uses `cwd/.padz` directly. All other commands continue using upward discovery to find existing stores.
   - **Fall back to global scope when no project store is found** — Running `padz` outside any project (no `.padz` found by upward walk) now transparently uses the global store instead of pointing at a nonexistent `cwd/.padz` and showing "No pads yet". The `-g` flag is no longer required outside project directories.
 

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -529,6 +529,12 @@ fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<String>) {
         }
     }
 
+    // If no indexes were found, all args are likely a title search term.
+    // Return them as indexes so parse_selectors can apply its title fallback.
+    if indexes.is_empty() && !content.is_empty() {
+        return (std::mem::take(&mut content), vec![]);
+    }
+
     (indexes, content)
 }
 


### PR DESCRIPTION
## Summary
- `padz open On Ids` and `padz edit My Note` now work, matching the behavior of `view`, `copy`, and all other commands
- Previously, `split_indexes_and_content` classified non-index args as inline content words, leaving `index_args` empty → "No pad index provided" error
- When no args parse as indexes, they are now returned as index args so `parse_selectors` can apply its title fallback logic

## Root cause
`split_indexes_and_content` (handlers.rs:514) is unique to `edit`/`open` — it splits args into pad selectors vs trailing content (for inline edits like `padz edit 1 new text`). It uses `parse_index_or_range` per arg, and anything that fails gets classified as content. For a title search like `padz open On Ids`, nothing parses as an index, so everything becomes "content" and `index_args` is empty.

## Architecture review
The ID resolution system is well centralized — all commands route through `parse_selectors()` → `resolve_selectors()`. The only outlier was `split_indexes_and_content` in the `edit` handler, which pre-filters args before they reach `parse_selectors`.

## Test plan
- [x] `cargo test` — all 196 tests pass
- [ ] Manual: `padz open On Ids` opens the pad in editor
- [ ] Manual: `padz edit 1 new text` still works for inline edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)