### PR TITLE
Fix config with stale keys silently falling back to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-08
+
+- **Fixed**
+  - **Config with stale keys silently ignored** — `padz config set format lex` followed by `padz create` would still create `.txt` files. Clapfig's strict mode (the default) rejects unknown keys in config files, and `initialize()` swallowed the error via `unwrap_or_default()`, silently falling back to `format = "txt"`. Config files with stale keys from schema evolution (e.g. `modes` from an older version) triggered this. Fixed by setting `strict(false)` on both config loading paths so unknown keys are tolerated.
+
 ## [1.0.0] - 2026-04-06
 
 ## [1.0.0] - 2026-04-06

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/padzapp", "crates/padz"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/arthur-debert/padz"

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -14,7 +14,7 @@ name = "padz"
 path = "src/main.rs"
 
 [dependencies]
-padzapp = { version = "1.0.0", path = "../padzapp" }
+padzapp = { version = "1.0.1", path = "../padzapp" }
 chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.53", features = ["derive"] }
 clapfig = "0.9.2"

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -219,6 +219,7 @@ fn handle_config(cli: &Cli, subcommand: &Option<ConfigSubcommand>) -> Result<()>
             SearchPath::Path(project_padz_dir.clone()),
         ])
         .search_mode(SearchMode::Merge)
+        .strict(false)
         .persist_scope("local", SearchPath::Path(project_padz_dir))
         .persist_scope("global", SearchPath::Path(global_data_dir))
         .handle_and_print(&action)

--- a/crates/padz/tests/format_e2e.rs
+++ b/crates/padz/tests/format_e2e.rs
@@ -319,3 +319,40 @@ fn test_format_alias_text_creates_txt() {
 
     assert_eq!(txt_count, 1, "\"text\" alias should create .txt file");
 }
+
+#[test]
+fn test_config_with_stale_keys_still_loads_format() {
+    let temp = TempDir::new().unwrap();
+    let (project, global_dir) = setup_project(&temp);
+
+    // Write a config file with stale/unknown keys (simulates schema evolution)
+    let config_path = project.join(".padz").join("padz.toml");
+    fs::write(
+        &config_path,
+        "modes = \"todos\"\nmode = \"todos\"\nformat = \"lex\"\n",
+    )
+    .unwrap();
+
+    // Create a pad — should use "lex" from config despite the stale "modes" key
+    padz_cmd()
+        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
+        .current_dir(&project)
+        .args(["create", "--no-editor", "stale key test"])
+        .assert()
+        .success();
+
+    let active_dir = project.join(".padz").join("active");
+    let lex_count = fs::read_dir(&active_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("pad-") && name.ends_with(".lex")
+        })
+        .count();
+
+    assert_eq!(
+        lex_count, 1,
+        "Config with stale keys should still apply format = lex"
+    );
+}

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -273,6 +273,7 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
         .file_name("padz.toml")
         .search_paths(config_search_paths)
         .search_mode(SearchMode::Merge)
+        .strict(false)
         .load()
         .unwrap_or_default();
     let format_ext = config.format_ext();


### PR DESCRIPTION
## Summary

- **Bug**: `padz config set format lex` → `padz create` still creates `.txt` files
- **Root cause**: Clapfig defaults to `strict: true`, rejecting unknown keys in config files. Config files with stale keys from schema evolution (e.g. `modes` instead of `mode`) caused `load()` to fail, and `unwrap_or_default()` silently fell back to `format = "txt"`
- **Fix**: Set `strict(false)` on both config loading paths so unknown keys are tolerated

## Test plan

- [x] Added `test_config_with_stale_keys_still_loads_format` E2E test
- [x] All existing format E2E tests pass (9/9)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)