### PR TITLE
Fix search line numbers mistaken for pad indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Fixed**
+  - **Search match line numbers looked like pad indexes** — `padz search` displayed content line numbers (e.g., `19`) that users mistook for child pad indexes (e.g., `9.19`), leading to confusing "not found" errors on `padz view 9.19`. Line numbers now render as `19L` in italic, visually distinguishing them from pad indexes. Context ellipsis also changed from `...` (3 chars) to `…` (1 char).
+
 ## [1.0.1] - 2026-04-08
 
 - **Fixed**

--- a/crates/padz/src/cli/templates/_match_lines.jinja
+++ b/crates/padz/src/cli/templates/_match_lines.jinja
@@ -1,7 +1,7 @@
 {#- Search match lines for a pad -#}
 {#- Expects: pad.left_pad, pad.matches (list of {line_number, segments}), pad.more_matches_count -#}
 {%- for match in pad.matches -%}
-    {{ pad.left_pad }}    [line-number]{{ match.line_number }}[/line-number] {% for seg in match.segments %}{{ seg.text | style_as(seg.style) }}{% endfor %}{{ "" | nl }}
+    {{ pad.left_pad }}    [line-number]{{ match.line_number }}L[/line-number] {% for seg in match.segments %}{{ seg.text | style_as(seg.style) }}{% endfor %}{{ "" | nl }}
 {%- endfor -%}
 {%- if pad.more_matches_count > 0 -%}
     {{ pad.left_pad }}    [truncation]And {{ pad.more_matches_count }} more results[/truncation]{{ "" | nl }}

--- a/crates/padz/src/styles/default.yaml
+++ b/crates/padz/src/styles/default.yaml
@@ -167,5 +167,10 @@ section-header: _secondary
 empty-message: _secondary
 preview: _tertiary
 truncation: _secondary
-line-number: _secondary
+line-number:
+  italic: true
+  light:
+    fg: [115, 115, 115]
+  dark:
+    fg: [138, 138, 138]
 separator: _tertiary

--- a/crates/padzapp/src/commands/get.rs
+++ b/crates/padzapp/src/commands/get.rs
@@ -453,9 +453,9 @@ fn highlight_matches(text: &str, term_lower: &str) -> Vec<MatchSegment> {
 }
 
 /// Extracts context around the first occurrence of `term` in `line`.
-/// Returns segments with "..." if truncated.
+/// Returns segments with "…" if truncated.
 /// Extracts context around the first occurrence of `term` in `line`.
-/// Returns segments with "..." if truncated.
+/// Returns segments with "…" if truncated.
 fn extract_context(line: &str, term_lower: &str, context_words: usize) -> Vec<MatchSegment> {
     let line_lower = line.to_lowercase();
     let start_idx = match line_lower.find(term_lower) {
@@ -522,7 +522,7 @@ fn extract_context(line: &str, term_lower: &str, context_words: usize) -> Vec<Ma
     let mut segments = Vec::new();
 
     if start_context_idx > 0 {
-        segments.push(MatchSegment::Plain("...".to_string()));
+        segments.push(MatchSegment::Plain("…".to_string()));
     }
 
     // Now highlighting inside the window [start_context_idx, end_context_idx]
@@ -545,7 +545,7 @@ fn extract_context(line: &str, term_lower: &str, context_words: usize) -> Vec<Ma
     }
 
     if end_context_idx < line.len() {
-        segments.push(MatchSegment::Plain("...".to_string()));
+        segments.push(MatchSegment::Plain("…".to_string()));
     }
 
     segments


### PR DESCRIPTION
## Summary

- Search results displayed bare line numbers (e.g. `19`) that users read as child-pad indexes (`9.19`), causing confusing "not found" errors on `padz view 9.19`
- Line numbers now render as italic with an `L` suffix (`19L`), visually distinguishing them from pad indexes
- Context ellipsis changed from `...` (3 chars) to `…` (single Unicode char)

## Test plan

- [ ] Run `padz search <term>` and verify line numbers show as `19L` not `19`
- [ ] Verify line number text is italic and dimmer than pad indexes
- [ ] Verify ellipsis renders as single `…` character
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)