### PR TITLE
Add --all flag to list/search and shard flags to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **`--all` flag for `list` and `search`** — Shows all three shards (active, archived, deleted) in a single view, grouped with section headers. Each shard keeps its own index namespace (`1`, `ar1`, `d1`).
+  - **`--deleted` and `--archived` flags on `search`** — Search can now target specific shards, matching `list` parity. Previously `search` was hardcoded to active pads only.
+
 ## [1.0.2] - 2026-04-14
 
 ## [1.0.2] - 2026-04-14

--- a/PADZ.md
+++ b/PADZ.md
@@ -131,7 +131,8 @@ List all pad in current scope.
 - `-g, --global`: Show only global pad
 - `-s, --search <term>`: Search for pad containing term
 - `--deleted`: Show only soft-deleted pad
-- `--include-deleted`: Include deleted pad in listing
+- `--archived`: Show only archived pad
+- `--all`: Show all pad (active, archived, and deleted) grouped with section headers
 
 **Output Format:**
 ```
@@ -157,7 +158,8 @@ padz                         # Same (default command)
 padz ls -g                   # List global pad
 padz ls -s "TODO"            # Search for "TODO"
 padz ls --deleted            # Show only deleted pad
-padz ls --include-deleted    # Show active + deleted pad
+padz ls --archived           # Show only archived pad
+padz ls --all                # Show active, archived, and deleted pad
 ```
 
 #### `padz view <index> [flags]`
@@ -236,7 +238,7 @@ padz d 1          # Same (alias)
 
 **Note:** Soft-deleted pad are:
 - Hidden from normal listings
-- Visible with `padz ls --deleted` or `padz ls --include-deleted`
+- Visible with `padz ls --deleted` or `padz ls --all`
 - Auto-cleaned after 7 days by default
 - Can be restored with `padz restore`
 - Can be permanently deleted with `padz flush`
@@ -295,7 +297,9 @@ Search through pad titles and content using regular expressions.
 
 **Flags:**
 - `-g, --global`: Search only global pad
-- `-p, --project <name>`: Limit search to specific project
+- `--deleted`: Search only soft-deleted pad
+- `--archived`: Search only archived pad
+- `--all`: Search across all pad (active, archived, and deleted) grouped with section headers
 
 **Examples:**
 ```bash
@@ -304,6 +308,8 @@ padz search my term             # Same (spaces automatically joined)
 padz search "TODO|FIXME"        # Search using regex
 padz search "func.*main"        # Regex pattern
 padz search -g "global notes"   # Search only global pad
+padz search "TODO" --all        # Search across all shards
+padz search "old" --archived    # Search only archived pad
 ```
 
 **Note:** The search command is separate from `padz ls -s`. Both perform search, but `search` is a dedicated command with additional options.
@@ -692,5 +698,5 @@ Indexes are divided into three stable "buckets":
     *   The standard list of active notes.
     *   Numbered sequentially based on creation time (or configured sort order).
 3.  **Deleted (`d1`, `d2`...)**:
-    *   Soft-deleted items, only visible when using flags like `--deleted`.
+    *   Soft-deleted items, only visible when using flags like `--deleted` or `--all`.
     *   They form a separate list with its own sequence, ensuring they don't shift the indexes of active notes.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -303,6 +303,7 @@ impl<'a> ScopedApi<'a> {
         filter: PadFilter,
         peek: bool,
         show_deleted_help: bool,
+        show_all_sections: bool,
         ids: &[String],
         show_uuid: bool,
     ) -> Result<Output<Value>, anyhow::Error> {
@@ -317,6 +318,7 @@ impl<'a> ScopedApi<'a> {
             ListOptions {
                 peek,
                 show_deleted_help,
+                show_all_sections,
                 output_mode: self.state.output_mode,
                 mode: self.state.mode,
                 show_uuid,
@@ -695,6 +697,7 @@ pub fn list(
     #[arg] search: Option<String>,
     #[flag] deleted: bool,
     #[flag] archived: bool,
+    #[flag] all: bool,
     #[flag] peek: bool,
     #[flag] planned: bool,
     #[flag] completed: bool,
@@ -713,7 +716,9 @@ pub fn list(
     };
 
     let filter = PadFilter {
-        status: if deleted {
+        status: if all {
+            PadStatusFilter::All
+        } else if deleted {
             PadStatusFilter::Deleted
         } else if archived {
             PadStatusFilter::Archived
@@ -725,7 +730,7 @@ pub fn list(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, peek, deleted || archived, &ids, uuid)
+    api(ctx).list_pads(filter, peek, deleted || archived, all, &ids, uuid)
 }
 
 #[handler]
@@ -741,19 +746,31 @@ pub fn peek(
         todo_status: None,
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
-    api(ctx).list_pads(filter, true, false, &ids, uuid)
+    api(ctx).list_pads(filter, true, false, false, &ids, uuid)
 }
 
+#[allow(clippy::too_many_arguments)]
 #[handler]
 pub fn search(
     #[ctx] ctx: &CommandContext,
     #[arg] term: String,
+    #[flag] deleted: bool,
+    #[flag] archived: bool,
+    #[flag] all: bool,
     #[flag] completed: bool,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
     let filter = PadFilter {
-        status: PadStatusFilter::Active,
+        status: if all {
+            PadStatusFilter::All
+        } else if deleted {
+            PadStatusFilter::Deleted
+        } else if archived {
+            PadStatusFilter::Archived
+        } else {
+            PadStatusFilter::Active
+        },
         search_term: Some(term),
         todo_status: if completed {
             Some(TodoStatus::Done)
@@ -763,7 +780,7 @@ pub fn search(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, false, false, &[], uuid)
+    api(ctx).list_pads(filter, false, deleted || archived, all, &[], uuid)
 }
 
 // =============================================================================

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -181,6 +181,7 @@ pub fn build_modification_result_value(
 pub struct ListOptions {
     pub peek: bool,
     pub show_deleted_help: bool,
+    pub show_all_sections: bool,
     pub output_mode: OutputMode,
     pub mode: PadzMode,
     pub show_uuid: bool,
@@ -376,8 +377,12 @@ pub fn build_list_result_value(
         }
     }
 
+    let mut entered_archived = false;
+    let mut entered_deleted = false;
+
     for dp in pads {
         let is_pinned_section = matches!(dp.index, DisplayIndex::Pinned(_));
+        let is_archived_section = matches!(dp.index, DisplayIndex::Archived(_));
         let is_deleted_section = matches!(dp.index, DisplayIndex::Deleted(_));
 
         // Separator between pinned and regular roots
@@ -395,12 +400,29 @@ pub fn build_list_result_value(
                 "is_pinned_section": false,
                 "is_deleted": false,
                 "is_separator": true,
+                "is_section_header": false,
                 "matches": [],
                 "more_matches_count": 0,
                 "peek": serde_json::Value::Null,
             }));
         }
         last_was_pinned = is_pinned_section;
+
+        // Section headers for --all mode
+        if opts.show_all_sections {
+            if is_archived_section && !entered_archived {
+                entered_archived = true;
+                pad_lines
+                    .push(serde_json::json!({ "is_separator": true, "is_section_header": false }));
+                pad_lines.push(serde_json::json!({ "is_section_header": true, "section_title": "Archived Pads" }));
+            }
+            if is_deleted_section && !entered_deleted {
+                entered_deleted = true;
+                pad_lines
+                    .push(serde_json::json!({ "is_separator": true, "is_section_header": false }));
+                pad_lines.push(serde_json::json!({ "is_section_header": true, "section_title": "Deleted Pads" }));
+            }
+        }
 
         process_pad_to_json(
             dp,
@@ -560,6 +582,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -585,6 +608,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -618,6 +642,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -650,6 +675,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: true,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -687,6 +713,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -719,6 +746,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -747,6 +775,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -780,6 +809,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Json,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -855,6 +885,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Notes,
                 show_uuid: false,
@@ -881,6 +912,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -911,6 +943,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Notes,
                 show_uuid: false,
@@ -923,6 +956,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -965,6 +999,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Notes,
                 show_uuid: false,
@@ -988,6 +1023,7 @@ mod tests {
             ListOptions {
                 peek: false,
                 show_deleted_help: false,
+                show_all_sections: false,
                 output_mode: OutputMode::Text,
                 mode: PadzMode::Todos,
                 show_uuid: false,
@@ -1023,6 +1059,7 @@ mod tests {
         ListOptions {
             peek: false,
             show_deleted_help: false,
+            show_all_sections: false,
             output_mode: OutputMode::Text,
             mode: PadzMode::Todos,
             show_uuid: false,

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -330,12 +330,16 @@ pub enum Commands {
         search: Option<String>,
 
         /// Show deleted pads
-        #[arg(long)]
+        #[arg(long, conflicts_with = "all")]
         deleted: bool,
 
         /// Show archived pads
-        #[arg(long)]
+        #[arg(long, conflicts_with = "all")]
         archived: bool,
+
+        /// Show all pads (active, archived, and deleted)
+        #[arg(long)]
+        all: bool,
 
         /// Peek at pad content
         #[arg(long)]
@@ -368,6 +372,18 @@ pub enum Commands {
     Search {
         /// Search term
         term: String,
+
+        /// Show deleted pads
+        #[arg(long, conflicts_with = "all")]
+        deleted: bool,
+
+        /// Show archived pads
+        #[arg(long, conflicts_with = "all")]
+        archived: bool,
+
+        /// Show all pads (active, archived, and deleted)
+        #[arg(long)]
+        all: bool,
 
         /// Show only completed pads
         #[arg(long)]

--- a/crates/padz/src/cli/templates/list.jinja
+++ b/crates/padz/src/cli/templates/list.jinja
@@ -5,7 +5,9 @@
 {{ help_text }}
 {%- else -%}
 {%- for pad in pads -%}
-{%- if pad.is_separator -%}
+{%- if pad.is_section_header -%}
+[section-header]{{ pad.section_title }}[/section-header]{{ "" | nl }}
+{%- elif pad.is_separator -%}
 {{- "" | nl -}}
 {%- else -%}
 {%- include "_pad_line.jinja" -%}


### PR DESCRIPTION
## Summary

- `list` and `search` now support `--all` to show active, archived, and deleted pads in a single grouped view with section headers ("Archived Pads", "Deleted Pads")
- `search` gains `--deleted` and `--archived` flags for parity with `list` (previously hardcoded to active-only)
- Each shard keeps its own index namespace (`1`, `ar1`, `d1`) — no index merging
- Updated PADZ.md docs to reflect new flags

## Test plan

- [ ] `padz list --all` — shows active, archived, deleted sections with headers
- [ ] `padz list --deleted` — unchanged behavior
- [ ] `padz search <term> --all` — searches across all shards, grouped output
- [ ] `padz search <term> --deleted` — searches only deleted pads
- [ ] `padz list --all --deleted` — errors (conflicting flags)
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)