### PR TITLE
Add --show-status flag and force status on complete/reopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **`--show-status` flag for `list`** — Displays status icons (planned/in-progress/done) even in notes mode.
+  - **Status icons on `complete`/`reopen` feedback** — When completing or reopening pads, the confirmation output now always shows status icons regardless of mode.
+
 ## [1.1.1] - 2026-04-14
 
 ## [1.1.1] - 2026-04-14

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -118,11 +118,13 @@ impl<'a> ScopedApi<'a> {
             .with_api(|api| f(api, self.state.scope).map_err(|e| anyhow::anyhow!("{}", e)))
     }
 
-    /// Wrap a CmdResult (modification) into rendered output
+    /// Wrap a CmdResult (modification) into rendered output.
+    /// When `force_show_status` is true, status icons are shown regardless of mode.
     fn modification(
         &self,
         action: &str,
         result: CmdResult,
+        force_show_status: bool,
     ) -> Result<Output<Value>, anyhow::Error> {
         Ok(Output::Render(build_modification_result_value(
             action,
@@ -130,6 +132,7 @@ impl<'a> ScopedApi<'a> {
             &result.messages,
             self.state.output_mode,
             self.state.mode,
+            force_show_status,
         )))
     }
 
@@ -144,17 +147,17 @@ impl<'a> ScopedApi<'a> {
 
     pub fn pin_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.pin_pads(scope, indexes))?;
-        self.modification("Pinned", result)
+        self.modification("Pinned", result, false)
     }
 
     pub fn unpin_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.unpin_pads(scope, indexes))?;
-        self.modification("Unpinned", result)
+        self.modification("Unpinned", result, false)
     }
 
     pub fn delete_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_pads(scope, indexes))?;
-        self.modification("Deleted", result)
+        self.modification("Deleted", result, false)
     }
 
     pub fn delete_completed_pads(&self) -> Result<Output<Value>, anyhow::Error> {
@@ -168,32 +171,32 @@ impl<'a> ScopedApi<'a> {
             })));
         }
 
-        self.modification("Deleted", result)
+        self.modification("Deleted", result, false)
     }
 
     pub fn restore_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.restore_pads(scope, indexes))?;
-        self.modification("Restored", result)
+        self.modification("Restored", result, false)
     }
 
     pub fn archive_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.archive_pads(scope, indexes))?;
-        self.modification("Archived", result)
+        self.modification("Archived", result, false)
     }
 
     pub fn unarchive_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.unarchive_pads(scope, indexes))?;
-        self.modification("Unarchived", result)
+        self.modification("Unarchived", result, false)
     }
 
     pub fn complete_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.complete_pads(scope, indexes))?;
-        self.modification("Completed", result)
+        self.modification("Completed", result, true)
     }
 
     pub fn reopen_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
         let result = self.call(|api, scope| api.reopen_pads(scope, indexes))?;
-        self.modification("Reopened", result)
+        self.modification("Reopened", result, true)
     }
 
     pub fn move_pads(
@@ -212,7 +215,7 @@ impl<'a> ScopedApi<'a> {
             let (sources, dest) = indexes.split_at(indexes.len() - 1);
             self.call(|api, scope| api.move_pads(scope, sources, Some(dest[0].as_str())))?
         };
-        self.modification("Moved", result)
+        self.modification("Moved", result, false)
     }
 
     // --- Message-only operations ---
@@ -298,6 +301,7 @@ impl<'a> ScopedApi<'a> {
 
     // --- List operations ---
 
+    #[allow(clippy::too_many_arguments)]
     pub fn list_pads(
         &self,
         filter: PadFilter,
@@ -306,6 +310,7 @@ impl<'a> ScopedApi<'a> {
         show_all_sections: bool,
         ids: &[String],
         show_uuid: bool,
+        show_status: bool,
     ) -> Result<Output<Value>, anyhow::Error> {
         let filtered = filter.search_term.is_some()
             || filter.todo_status.is_some()
@@ -323,6 +328,7 @@ impl<'a> ScopedApi<'a> {
                 mode: self.state.mode,
                 show_uuid,
                 filtered,
+                show_status,
             },
         )))
     }
@@ -682,6 +688,7 @@ pub fn create(
         &result.messages,
         state.output_mode,
         state.mode,
+        false,
     );
     Ok(Output::Render(data))
 }
@@ -704,6 +711,7 @@ pub fn list(
     #[flag(name = "in_progress")] in_progress: bool,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
+    #[flag(name = "show_status")] show_status: bool,
 ) -> Result<Output<Value>, anyhow::Error> {
     let todo_status = if planned {
         Some(TodoStatus::Planned)
@@ -730,7 +738,15 @@ pub fn list(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, peek, deleted || archived, all, &ids, uuid)
+    api(ctx).list_pads(
+        filter,
+        peek,
+        deleted || archived,
+        all,
+        &ids,
+        uuid,
+        show_status,
+    )
 }
 
 #[handler]
@@ -746,7 +762,7 @@ pub fn peek(
         todo_status: None,
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
-    api(ctx).list_pads(filter, true, false, false, &ids, uuid)
+    api(ctx).list_pads(filter, true, false, false, &ids, uuid, false)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -780,7 +796,7 @@ pub fn search(
         tags: if tags.is_empty() { None } else { Some(tags) },
     };
 
-    api(ctx).list_pads(filter, false, deleted || archived, all, &[], uuid)
+    api(ctx).list_pads(filter, false, deleted || archived, all, &[], uuid, false)
 }
 
 // =============================================================================
@@ -856,6 +872,7 @@ pub fn edit(
             &result.messages,
             state.output_mode,
             state.mode,
+            false,
         );
         return Ok(Output::Render(data));
     }
@@ -878,6 +895,7 @@ pub fn edit(
             &result.messages,
             state.output_mode,
             state.mode,
+            false,
         );
         return Ok(Output::Render(data));
     }
@@ -931,6 +949,7 @@ pub fn edit(
                 &result.messages,
                 state.output_mode,
                 state.mode,
+                false,
             );
             Ok(Output::Render(data))
         }
@@ -1171,6 +1190,7 @@ pub mod tag {
             &result.messages,
             state.output_mode,
             state.mode,
+            false,
         )))
     }
 
@@ -1191,6 +1211,7 @@ pub mod tag {
             &result.messages,
             state.output_mode,
             state.mode,
+            false,
         )))
     }
 

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -82,6 +82,7 @@ pub fn build_modification_result_value(
     trailing_messages: &[CmdMessage],
     output_mode: OutputMode,
     mode: PadzMode,
+    force_show_status: bool,
 ) -> serde_json::Value {
     use serde_json::json;
 
@@ -94,7 +95,7 @@ pub fn build_modification_result_value(
         });
     }
 
-    let show_status = mode == PadzMode::Todos;
+    let show_status = force_show_status || mode == PadzMode::Todos;
     let col_status = if show_status { COL_STATUS } else { 0 };
     let width = line_width();
 
@@ -186,6 +187,7 @@ pub struct ListOptions {
     pub mode: PadzMode,
     pub show_uuid: bool,
     pub filtered: bool,
+    pub show_status: bool,
 }
 
 /// Builds list result data as serde_json::Value for Dispatch handlers.
@@ -210,7 +212,7 @@ pub fn build_list_result_value(
         });
     }
 
-    let show_status = opts.mode == PadzMode::Todos;
+    let show_status = opts.show_status || opts.mode == PadzMode::Todos;
     let col_status = if show_status { COL_STATUS } else { 0 };
     let width = line_width();
 
@@ -587,6 +589,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
         assert!(data.get("empty").and_then(|v| v.as_bool()).unwrap_or(false));
@@ -613,6 +616,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -647,6 +651,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -680,6 +685,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -718,6 +724,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -751,6 +758,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -780,6 +788,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -814,6 +823,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -835,6 +845,7 @@ mod tests {
             &[],
             OutputMode::Text,
             PadzMode::Todos,
+            false,
         );
 
         assert_eq!(
@@ -890,6 +901,7 @@ mod tests {
                 mode: PadzMode::Notes,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -917,7 +929,65 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
+        );
+
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            pads[0].get("status_icon").and_then(|v| v.as_str()),
+            Some(STATUS_PLANNED)
+        );
+        assert_eq!(
+            data.get("col_status").and_then(|v| v.as_u64()),
+            Some(COL_STATUS as u64)
+        );
+    }
+
+    #[test]
+    fn test_show_status_flag_overrides_notes_mode() {
+        let pad = make_pad("Test Note", false);
+        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
+
+        let data = build_list_result_value(
+            &[dp],
+            &[],
+            ListOptions {
+                peek: false,
+                show_deleted_help: false,
+                show_all_sections: false,
+                output_mode: OutputMode::Text,
+                mode: PadzMode::Notes,
+                show_uuid: false,
+                filtered: false,
+                show_status: true,
+            },
+        );
+
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            pads[0].get("status_icon").and_then(|v| v.as_str()),
+            Some(STATUS_PLANNED)
+        );
+        assert_eq!(
+            data.get("col_status").and_then(|v| v.as_u64()),
+            Some(COL_STATUS as u64)
+        );
+    }
+
+    #[test]
+    fn test_force_show_status_in_modification_result() {
+        let pad = make_pad("Test Note", false);
+        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
+
+        // Notes mode with force_show_status=true should show status
+        let data = build_modification_result_value(
+            "Completed",
+            &[dp],
+            &[],
+            OutputMode::Text,
+            PadzMode::Notes,
+            true,
         );
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
@@ -948,6 +1018,7 @@ mod tests {
                 mode: PadzMode::Notes,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
         let todos_data = build_list_result_value(
@@ -961,6 +1032,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -1004,6 +1076,7 @@ mod tests {
                 mode: PadzMode::Notes,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -1028,6 +1101,7 @@ mod tests {
                 mode: PadzMode::Todos,
                 show_uuid: false,
                 filtered: false,
+                show_status: false,
             },
         );
 
@@ -1064,6 +1138,7 @@ mod tests {
             mode: PadzMode::Todos,
             show_uuid: false,
             filtered: false,
+            show_status: false,
         }
     }
 
@@ -1193,6 +1268,7 @@ mod tests {
             &[],
             OutputMode::Text,
             PadzMode::Notes,
+            false,
         );
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -364,6 +364,10 @@ pub enum Commands {
         /// Show short UUIDs next to pad titles
         #[arg(long)]
         uuid: bool,
+
+        /// Show status icons (even in notes mode)
+        #[arg(long)]
+        show_status: bool,
     },
 
     /// Search pads (dedicated command)


### PR DESCRIPTION
## Summary
- Adds `--show-status` flag to `list` command, showing status icons (planned/in-progress/done) even in notes mode
- `complete` and `reopen` commands now always show status icons in their feedback output, regardless of mode
- Both changes make status visible when it's contextually relevant, without changing the default notes-mode behavior

## Changes
- **`render.rs`**: `ListOptions` gains `show_status: bool`; `build_modification_result_value` gains `force_show_status: bool`; two new tests
- **`handlers.rs`**: threads `show_status` through list path; `complete_pads`/`reopen_pads` pass `force_show_status: true`
- **`setup.rs`**: `--show-status` flag on `List` command
- **`CHANGELOG.md`**: documented under `[Unreleased]`

## Test plan
- [x] `cargo test` — all 36 render tests + full suite pass
- [x] `cargo build` — clean
- [x] `padz list --help` shows `--show-status` flag
- [ ] Manual: `padz list --show-status` in notes mode shows status icons
- [ ] Manual: `padz complete <id>` in notes mode shows status icon in feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)