### PR TITLE
Split scope discovery into read and write modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Changed**
+  - **Scope discovery split into read and write modes** — Previously, a directory was only treated as a project root if it contained both `.git` and `.padz`. That silently broke `.padz` directories in non-git parents: `padz init` succeeded but every subsequent command still used global because the detection step missed the new `.padz`. Discovery is now two independent algorithms. **Reads** (list, view, search, …) walk up looking for `.padz` alone — `.git` is irrelevant. **Writes** (create, import) use the same read discovery first; if no `.padz` is found upward, they walk up looking for `.git` and auto-create `.padz` at the git root so new pads land inside their enclosing project instead of silently going global. `padz init` continues to create `.padz` at cwd unconditionally — it is user intent and is never blocked.
+
 ## [1.2.0] - 2026-04-16
 
 ## [1.2.0] - 2026-04-16

--- a/PADZ.md
+++ b/PADZ.md
@@ -46,7 +46,7 @@ The scope only changes the path to the data store, nothing else.
 PADZ uses two separate discovery algorithms:
 
 - **Reads** (list, view, search, …): walk up the directory tree looking for `.padz/`. The first match is the project root. If nothing is found before `$HOME`/`/`, fall back to global.
-- **Writes** (create, import): same walk, but if no `.padz/` is found upward, walk up again looking for `.git/`. If a git repo is found, auto-create `.padz/` at the git root and use it — so a new pad lands inside its project instead of silently going global. If neither `.padz/` nor `.git/` is found, use global.
+- **Writes** (create, import): same walk, but if no `.padz/` is found upward, walk up again looking for a `.git` entry — either a directory or a regular file (git worktrees and submodules leave a `.git` file pointing at the real gitdir). If a git repo is found, auto-create `.padz/` at the git root and use it — so a new pad lands inside its project instead of silently going global. If neither `.padz/` nor a `.git` entry is found, use global.
 
 `padz init` is always explicit: it creates `.padz/` at the current directory regardless of git status or any surrounding project.
 

--- a/PADZ.md
+++ b/PADZ.md
@@ -29,21 +29,26 @@ A "pad" is a single note with:
 
 PADZ operates in two scopes:
 
-1. **Project Scope** (default): Notes associated with the current Git project
-   - When you run `padz` inside a Git repository, notes are scoped to that project
+1. **Project Scope** (default when a `.padz/` is found): Notes associated with a specific directory's store
+   - When you run `padz` inside (or under) a directory that contains `.padz/`, notes are scoped to that store
    - Different projects have separate note lists
    - Useful for project-specific TODOs, ideas, snippets
 
-2. **Global Scope** (via `-g` flag): Notes not tied to any project
+2. **Global Scope** (via `-g` flag, or fallback): Notes not tied to any project
    - Available from anywhere
    - Use for personal notes, general snippets, cross-project information
    - Access with `--global` or `-g` flag
 
-Now, the scope only changes the path to the data store , nothing else.
+The scope only changes the path to the data store, nothing else.
 
 ### Project Detection
 
-PADZ determines the current project by walking up the directory tree looking for a `.git` directory. If found, the project name is the basename of that directory. If no `.git` is found, you're in "global" scope.
+PADZ uses two separate discovery algorithms:
+
+- **Reads** (list, view, search, …): walk up the directory tree looking for `.padz/`. The first match is the project root. If nothing is found before `$HOME`/`/`, fall back to global.
+- **Writes** (create, import): same walk, but if no `.padz/` is found upward, walk up again looking for `.git/`. If a git repo is found, auto-create `.padz/` at the git root and use it — so a new pad lands inside its project instead of silently going global. If neither `.padz/` nor `.git/` is found, use global.
+
+`padz init` is always explicit: it creates `.padz/` at the current directory regardless of git status or any surrounding project.
 
 ### Indexing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A terminal app for creating and managing scratch notes that is a good Unix citiz
 
 Designed for maximum ergonomics with a clever ID system for less typing, advanced completion for IDs and titles, batch editing, import/export, nested notes, soft delete, search, tags, and file type (txt, markdown) support.
 
-Context-aware: automatically separates global pads (in your data dir) from project pads (in Git repos), providing sensible project-related and general notes.
+Context-aware: automatically separates global pads (in your data dir) from project pads (in any directory with a `.padz/`, auto-created at the git root on first write), so project-related and general notes stay distinct.
 
 Sports a smart-looking UI with dark/light mode awareness.
 
@@ -75,7 +75,7 @@ Completions include:
 ## Features
 
 - **Unix-friendly**: uses your `$EDITOR`, stores data as plain text files
-- **Context-aware**: project pads (in Git repos) and global pads (in data dir)
+- **Context-aware**: project pads (any directory with `.padz/`; auto-created at the git root on first write) and global pads (in data dir)
 - **Ergonomic**: clever ID system, advanced completion for IDs and titles
 - **Organized**: tags, pinning, nested notes, soft delete
 - **Powerful**: full-text search, batch editing, import/export

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A terminal app for creating and managing scratch notes that is a good Unix citiz
 
 Designed for maximum ergonomics with a clever ID system for less typing, advanced completion for IDs and titles, batch editing, import/export, nested notes, soft delete, search, tags, and file type (txt, markdown) support.
 
-Context-aware: automatically separates global pads (in your data dir) from project pads (in any directory with a `.padz/`, auto-created at the git root on first write), so project-related and general notes stay distinct.
+Context-aware: automatically separates global pads (in your data dir) from project pads (in any directory with a `.padz/`, auto-created at the git root on the first `create`/`import`), so project-related and general notes stay distinct.
 
 Sports a smart-looking UI with dark/light mode awareness.
 
@@ -75,7 +75,7 @@ Completions include:
 ## Features
 
 - **Unix-friendly**: uses your `$EDITOR`, stores data as plain text files
-- **Context-aware**: project pads (any directory with `.padz/`; auto-created at the git root on first write) and global pads (in data dir)
+- **Context-aware**: project pads (any directory with `.padz/`; auto-created at the git root on the first `create`/`import`) and global pads (in data dir)
 - **Ergonomic**: clever ID system, advanced completion for IDs and titles
 - **Organized**: tags, pinning, nested notes, soft delete
 - **Powerful**: full-text search, batch editing, import/export

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -153,7 +153,7 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
             .unwrap_or_else(|| cwd.join(".padz")),
     };
 
-    let padz_ctx = initialize(&cwd, cli.global, data_override, auto_init_for_write);
+    let padz_ctx = initialize(&cwd, cli.global, data_override, auto_init_for_write)?;
 
     Ok(AppState::new(
         padz_ctx.api,

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -115,7 +115,7 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
 
     // `padz init` (plain, non-global) is a creation operation: "create a store HERE".
     // It should use cwd directly, not walk up to find an existing store.
-    // All other commands use find_project_root() for discovery, which is correct.
+    // All other commands use find_padz_root() for discovery, which is correct.
     let is_plain_init = matches!(
         cli.command,
         Some(Commands::Init {
@@ -129,6 +129,16 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
         data_override
     };
 
+    // Commands that create new pads opt into auto-init: if no `.padz` is found
+    // upward, a fresh store is materialized at the enclosing git root (if any)
+    // so the new pad is project-scoped rather than silently dropped into global.
+    // Every other command operates on existing pads and reads fall back to global
+    // cleanly; they pass `false`.
+    let auto_init_for_write = matches!(
+        cli.command,
+        Some(Commands::Create { .. }) | Some(Commands::Import { .. })
+    );
+
     // Compute the local .padz dir BEFORE link resolution (used by link/unlink commands)
     let local_padz_dir = match &data_override {
         Some(path) => {
@@ -138,12 +148,12 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
                 path.join(".padz")
             }
         }
-        None => padzapp::init::find_project_root(&cwd)
+        None => padzapp::init::find_padz_root(&cwd)
             .map(|root| root.join(".padz"))
             .unwrap_or_else(|| cwd.join(".padz")),
     };
 
-    let padz_ctx = initialize(&cwd, cli.global, data_override);
+    let padz_ctx = initialize(&cwd, cli.global, data_override, auto_init_for_write);
 
     Ok(AppState::new(
         padz_ctx.api,
@@ -168,7 +178,7 @@ fn handle_config(cli: &Cli, subcommand: &Option<ConfigSubcommand>) -> Result<()>
                 path.join(".padz")
             }
         }
-        None => padzapp::init::find_project_root(&cwd)
+        None => padzapp::init::find_padz_root(&cwd)
             .map(|root| root.join(".padz"))
             .unwrap_or_else(|| cwd.join(".padz")),
     };

--- a/crates/padz/src/cli/complete.rs
+++ b/crates/padz/src/cli/complete.rs
@@ -21,7 +21,9 @@ fn get_pad_candidates(include_deleted: bool) -> Vec<CompletionCandidate> {
 
     // Initialize context (completions don't support --data override)
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let ctx = initialize(&cwd, is_global, None, false);
+    let Ok(ctx) = initialize(&cwd, is_global, None, false) else {
+        return vec![];
+    };
     let api: PadzApi<FileStore> = ctx.api;
 
     // Query pads
@@ -84,7 +86,9 @@ pub fn archived_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let ctx = initialize(&cwd, is_global, None, false);
+        let Ok(ctx) = initialize(&cwd, is_global, None, false) else {
+            return vec![];
+        };
         let api: PadzApi<FileStore> = ctx.api;
 
         let filter = PadFilter {
@@ -118,7 +122,9 @@ pub fn deleted_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let ctx = initialize(&cwd, is_global, None, false);
+        let Ok(ctx) = initialize(&cwd, is_global, None, false) else {
+            return vec![];
+        };
         let api: PadzApi<FileStore> = ctx.api;
 
         let filter = PadFilter {

--- a/crates/padz/src/cli/complete.rs
+++ b/crates/padz/src/cli/complete.rs
@@ -21,7 +21,7 @@ fn get_pad_candidates(include_deleted: bool) -> Vec<CompletionCandidate> {
 
     // Initialize context (completions don't support --data override)
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let ctx = initialize(&cwd, is_global, None);
+    let ctx = initialize(&cwd, is_global, None, false);
     let api: PadzApi<FileStore> = ctx.api;
 
     // Query pads
@@ -84,7 +84,7 @@ pub fn archived_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let ctx = initialize(&cwd, is_global, None);
+        let ctx = initialize(&cwd, is_global, None, false);
         let api: PadzApi<FileStore> = ctx.api;
 
         let filter = PadFilter {
@@ -118,7 +118,7 @@ pub fn deleted_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let ctx = initialize(&cwd, is_global, None);
+        let ctx = initialize(&cwd, is_global, None, false);
         let api: PadzApi<FileStore> = ctx.api;
 
         let filter = PadFilter {

--- a/crates/padz/src/cli/topics/scopes.txt
+++ b/crates/padz/src/cli/topics/scopes.txt
@@ -1,15 +1,16 @@
 Projects and Global Notes
 
-Padz stores notes in two scopes: Project (local to a repo) or Global (user-wide).
+Padz stores notes in two scopes: Project (a specific .padz/ directory) or
+Global (user-wide).
 
 THE TWO SCOPES
 --------------
 
-Project Scope (default):
-  Data stored in: <repo_root>/.padz/
+Project Scope (default when a .padz is found):
+  Data stored in: <project_root>/.padz/
   Use case: Project-specific notes, TODOs, code snippets
 
-Global Scope (-g flag):
+Global Scope (-g flag, or fallback):
   Data stored in: OS data directory
     - macOS:   ~/Library/Application Support/com.padz.padz/
     - Linux:   ~/.local/share/padz/
@@ -17,43 +18,59 @@ Global Scope (-g flag):
   Use case: Cross-project notes, personal reminders, grocery lists
 
 
-HOW PADZ FINDS YOUR PROJECT
----------------------------
+HOW PADZ FINDS YOUR STORE
+-------------------------
 
-When you run padz (without -g), it searches for your project root:
+Padz uses two separate discovery algorithms depending on what the command does.
 
-1. Start at your current directory
-2. Look for a directory with BOTH .git AND .padz
-3. If found: use that as project root
-4. If not found: check parent directory
-5. Stop at home directory or filesystem root
+Read commands (list, view, search, etc.):
+  1. Start at your current directory.
+  2. If the directory contains a .padz/, use it.
+  3. Otherwise, move up one directory.
+  4. Stop at $HOME or the filesystem root.
+  5. If nothing is found, use the global store.
 
-Why require BOTH .git AND .padz?
-  - .git alone isn't enough: avoids accidentally using parent repos in monorepos
-  - .padz alone isn't enough: maintains semantic binding to "project" concept
+Write commands (create, import):
+  Same as above, but with one extra step before falling back to global:
+  if no .padz was found upward, padz walks up again looking for a .git/
+  directory. If one is found, padz auto-creates .padz/ at that git root
+  and puts the new pad there. This keeps new pads scoped to their enclosing
+  git project instead of silently dropping them into global.
 
-This means you must run `padz init` in a repo to opt-in to project scope.
+Summary of the write fallback chain:
+  .padz found upward  → use it
+  else .git upward    → auto-init .padz at the git root, use it
+  else                → global
+
+
+EXPLICIT padz init
+------------------
+
+`padz init` is an explicit user intent and is never blocked. It creates
+.padz/ in the current directory regardless of whether it is a git repo or
+already sits inside another project's store. Use it any time you want a
+store in a specific location; the auto-init behavior above is a convenience
+only for write commands that would otherwise land in global.
 
 
 NESTED REPOSITORIES
 -------------------
 
-In monorepos or nested git structures:
+The innermost .padz (closest to cwd) wins. Subprojects inherit the parent's
+store unless they run `padz init` themselves:
 
-  parent-repo/        (.git + .padz)
-    child-repo/       (.git only)
+  parent-repo/        (.padz)
+    child-repo/       (.git, no .padz)
       your-code/
 
-Running padz from child-repo/ will use parent-repo/.padz/ (walks up until
-it finds both .git and .padz together).
-
-To give child-repo its own notes: run `padz init` inside child-repo.
+Running padz from child-repo/ uses parent-repo/.padz/. To give child-repo
+its own notes: run `padz init` inside child-repo.
 
 
 USING THE GLOBAL FLAG
 ---------------------
 
-Add -g to any command to use global scope:
+Add -g to any command to force global scope, even inside a project:
 
   padz -g list          # List global notes
   padz -g create        # Create global note
@@ -66,7 +83,8 @@ SWITCHING BETWEEN SCOPES
 ------------------------
 
 Project and global notes are completely separate. Use -g to access global
-notes from any directory. Without -g, you're always in project scope.
+notes from any directory. Without -g, padz uses whichever scope discovery
+resolves to.
 
 Example workflow:
   cd ~/projects/myapp
@@ -79,7 +97,7 @@ Example workflow:
 INITIALIZING PROJECT SCOPE
 --------------------------
 
-To enable project-scope notes in a git repository:
+To create a project store in a specific directory:
 
   cd /path/to/your/repo
   padz init

--- a/crates/padz/src/cli/topics/scopes.txt
+++ b/crates/padz/src/cli/topics/scopes.txt
@@ -32,8 +32,10 @@ Read commands (list, view, search, etc.):
 
 Write commands (create, import):
   Same as above, but with one extra step before falling back to global:
-  if no .padz was found upward, padz walks up again looking for a .git/
-  directory. If one is found, padz auto-creates .padz/ at that git root
+  if no .padz was found upward, padz walks up again looking for a .git
+  entry — either a directory (normal repo) or a regular file (git
+  worktrees and submodules leave a `.git` file pointing at the real
+  gitdir). If one is found, padz auto-creates .padz/ at that git root
   and puts the new pad there. This keeps new pads scoped to their enclosing
   git project instead of silently dropping them into global.
 

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -1,5 +1,6 @@
 use crate::commands::{CmdMessage, CmdResult, PadzPaths};
 use crate::error::{PadzError, Result};
+use crate::init::create_bucket_layout;
 use crate::model::Scope;
 use std::fs;
 use std::path::Path;
@@ -7,10 +8,7 @@ use std::path::Path;
 pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
     let dir = paths.scope_dir(scope)?;
 
-    // Create scope root and bucket subdirectories
-    fs::create_dir_all(dir.join("active"))?;
-    fs::create_dir_all(dir.join("archived"))?;
-    fs::create_dir_all(dir.join("deleted"))?;
+    create_bucket_layout(&dir)?;
 
     let mut result = CmdResult::default();
     result.add_message(CmdMessage::success(format!(

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -89,35 +89,53 @@ pub struct PadzContext {
     pub config: PadzConfig,
 }
 
-/// Walk upward from `cwd` looking for a directory that contains `.padz/`.
+/// Materialize the padz store layout (`active/`, `archived/`, `deleted/`) at
+/// `padz_dir`. Idempotent — safe to call on an existing store. Shared between
+/// explicit `padz init` (in `commands::init`) and the auto-init-on-write path
+/// in [`initialize`]; callers decide how to react to failure.
+pub fn create_bucket_layout(padz_dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(padz_dir.join("active"))?;
+    std::fs::create_dir_all(padz_dir.join("archived"))?;
+    std::fs::create_dir_all(padz_dir.join("deleted"))?;
+    Ok(())
+}
+
+/// Walk upward from `cwd` looking for a directory that contains a `.padz/`
+/// subdirectory.
 ///
 /// This is the **read** discovery function: every command uses it to locate an
 /// existing store, regardless of whether the enclosing directory is a git repo.
+/// `.padz` must be a directory; a stray regular file with that name is ignored
+/// so it cannot masquerade as a store and trip later I/O.
 /// Stops at `$HOME` or the filesystem root and returns `None`.
 pub fn find_padz_root(cwd: &Path) -> Option<PathBuf> {
-    walk_up_for(cwd, ".padz")
+    walk_up_matching(cwd, |dir| dir.join(".padz").is_dir())
 }
 
-/// Walk upward from `cwd` looking for a directory that contains `.git/`.
+/// Walk upward from `cwd` looking for a directory that contains a `.git` entry
+/// (directory or file).
 ///
 /// This is the **auto-init** discovery function: used by write commands to decide
-/// where to create a new `.padz/` when none is found upward. When a pad is being
-/// created and there is no existing store, we want it scoped to the enclosing git
-/// project rather than dropped into global.
+/// where to create a new `.padz/` when none is found upward. Accepts `.git` as
+/// either a directory (normal repo) or a regular file (git worktrees and
+/// submodules store the real gitdir elsewhere and leave a `.git` file pointer).
 /// Stops at `$HOME` or the filesystem root and returns `None`.
 pub fn find_git_root(cwd: &Path) -> Option<PathBuf> {
-    walk_up_for(cwd, ".git")
+    walk_up_matching(cwd, |dir| dir.join(".git").exists())
 }
 
 /// Shared upward-walk helper. Returns the first ancestor (including `cwd`
-/// itself) that contains a child entry named `marker`. Stops at `$HOME` or
-/// the filesystem root.
-fn walk_up_for(cwd: &Path, marker: &str) -> Option<PathBuf> {
+/// itself) for which `matches` returns true. Stops at `$HOME` or the
+/// filesystem root.
+fn walk_up_matching<F>(cwd: &Path, matches: F) -> Option<PathBuf>
+where
+    F: Fn(&Path) -> bool,
+{
     let home_dir = BaseDirs::new().map(|bd| bd.home_dir().to_path_buf());
     let mut current = cwd.to_path_buf();
 
     loop {
-        if current.join(marker).exists() {
+        if matches(&current) {
             return Some(current);
         }
 
@@ -281,21 +299,31 @@ pub fn initialize(
                     (Some(resolved), Scope::Project)
                 }
                 None => {
-                    if auto_init_for_write {
-                        if let Some(git_root) = find_git_root(cwd) {
-                            let new_padz = git_root.join(".padz");
-                            // Best-effort create of the bucket layout. If this
-                            // fails (e.g. read-only FS), downstream writes will
-                            // surface the actual I/O error.
-                            let _ = std::fs::create_dir_all(new_padz.join("active"));
-                            let _ = std::fs::create_dir_all(new_padz.join("archived"));
-                            let _ = std::fs::create_dir_all(new_padz.join("deleted"));
-                            (Some(new_padz), Scope::Project)
-                        } else {
-                            (None, Scope::Global)
-                        }
-                    } else {
-                        (None, Scope::Global)
+                    // Write path: try to auto-init a project store at the
+                    // enclosing git root. If either no git root exists or the
+                    // directory creation itself fails (e.g. read-only FS,
+                    // permissions), fall back to Global rather than returning
+                    // a Project scope backed by an unusable path.
+                    let auto_init = auto_init_for_write
+                        .then(|| find_git_root(cwd))
+                        .flatten()
+                        .map(|git_root| git_root.join(".padz"))
+                        .filter(|new_padz| {
+                            if let Err(err) = create_bucket_layout(new_padz) {
+                                eprintln!(
+                                    "Warning: could not auto-init padz store at {}: {}. Falling back to global.",
+                                    new_padz.display(),
+                                    err
+                                );
+                                false
+                            } else {
+                                true
+                            }
+                        });
+
+                    match auto_init {
+                        Some(new_padz) => (Some(new_padz), Scope::Project),
+                        None => (None, Scope::Global),
                     }
                 }
             },
@@ -576,6 +604,56 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
 
         assert_eq!(find_git_root(&dir), None);
+    }
+
+    #[test]
+    fn test_find_padz_root_ignores_file_marker() {
+        // A regular file named `.padz` must not count as a store. Otherwise an
+        // accidental same-named file would mis-detect a project root and blow
+        // up when later code tried to create bucket subdirectories under a
+        // non-directory path.
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        fs::write(root.join(".padz"), "not a store").unwrap();
+
+        assert_eq!(find_padz_root(root), None);
+    }
+
+    #[test]
+    fn test_find_git_root_accepts_file_marker() {
+        // Git worktrees and submodules use a regular `.git` *file* that points
+        // at the real gitdir. `find_git_root` must accept this so auto-init
+        // still scopes new pads to the worktree's root.
+        let temp = TempDir::new().unwrap();
+        let worktree = temp.path().join("worktree");
+        fs::create_dir_all(&worktree).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            "gitdir: /elsewhere/.git/worktrees/x\n",
+        )
+        .unwrap();
+
+        assert_eq!(find_git_root(&worktree), Some(worktree));
+    }
+
+    #[test]
+    fn test_initialize_write_auto_init_failure_falls_back_to_global() {
+        // If auto-init cannot materialize the layout (here: there's already a
+        // *file* at the target .padz path so create_dir_all fails), we must
+        // not return a Project scope pointing at an unusable path. Fall back
+        // to Global instead.
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
+        fs::write(repo.join(".padz"), "blocking file").unwrap();
+        let sub = repo.join("src");
+        fs::create_dir_all(&sub).unwrap();
+
+        let ctx = initialize(&sub, false, None, true);
+
+        assert_eq!(ctx.scope, Scope::Global);
+        assert_eq!(ctx.api.paths().project, None);
     }
 
     #[test]

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -233,30 +233,45 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 /// * `PADZ_GLOBAL_DATA` - If set, overrides the default global data directory.
 ///   This is primarily used for testing to isolate global state.
 ///
+/// # Errors
+///
+/// Returns `Err` when the user's intent is clearly project-scoped but the
+/// project store is unusable:
+/// - A `.padz/link` file exists but resolves to a broken, uninitialized, or
+///   chained target. Silently falling back to the local `.padz` would send
+///   writes to a different store than the user configured.
+/// - Auto-init was requested (`auto_init_for_write = true`) and a git root
+///   was found, but creating `.padz/` at that root failed. Silently going
+///   to Global would drop the new pad somewhere the user almost certainly
+///   did not mean; making the caller abort is the safer default.
+///
+/// All other paths (no `.padz` upward on a read, no `.git` on a write, etc.)
+/// fall back to `Scope::Global` successfully.
+///
 /// # Examples
 ///
 /// ```ignore
 /// // Read path: discover .padz upward, else global
-/// let ctx = initialize(&cwd, false, None, false);
+/// let ctx = initialize(&cwd, false, None, false)?;
 ///
 /// // Write path: discover .padz upward; if none, auto-init at git root; else global
-/// let ctx = initialize(&cwd, false, None, true);
+/// let ctx = initialize(&cwd, false, None, true)?;
 ///
 /// // Force global scope
-/// let ctx = initialize(&cwd, true, None, false);
+/// let ctx = initialize(&cwd, true, None, false)?;
 ///
 /// // Use explicit data directory - path ends with .padz, used directly
-/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project/.padz")), false);
+/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project/.padz")), false)?;
 ///
 /// // Use explicit project directory - .padz is appended
-/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project")), false);
+/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project")), false)?;
 /// ```
 pub fn initialize(
     cwd: &Path,
     use_global: bool,
     data_override: Option<PathBuf>,
     auto_init_for_write: bool,
-) -> PadzContext {
+) -> crate::error::Result<PadzContext> {
     // Determine global data directory:
     // 1. Check PADZ_GLOBAL_DATA environment variable (primarily for testing)
     // 2. Fall back to OS-appropriate data directory via directories crate
@@ -272,9 +287,11 @@ pub fn initialize(
     // Determine project data directory and scope:
     // 1. If use_global → Global scope, no project dir
     // 2. If data_override provided → Project scope with explicit path
-    // 3. find_padz_root found something → Project scope (follow link if present)
+    // 3. find_padz_root found something → Project scope (follow link if present,
+    //    propagate link-resolution errors rather than silently using the local path)
     // 4. Else if auto_init_for_write and find_git_root found something → create
-    //    .padz at that git root and use it (Project scope)
+    //    .padz at that git root and use it (Project scope), propagating bucket-
+    //    creation errors rather than silently dropping the pad into global
     // 5. Else → fall back to Global scope
     let (project_padz_dir, scope) = if use_global {
         (None, Scope::Global)
@@ -291,41 +308,41 @@ pub fn initialize(
             None => match find_padz_root(cwd) {
                 Some(root) => {
                     let detected = root.join(".padz");
-                    // Follow .padz/link if present
-                    let resolved = match resolve_link(&detected) {
-                        Ok(Some(linked)) => linked,
-                        _ => detected,
+                    // Follow .padz/link if present. A broken/uninitialized/
+                    // chained link is the user's declared intent going wrong;
+                    // bubble the error up so it is visible instead of silently
+                    // operating on the local (unlinked) directory, which might
+                    // be a different store.
+                    let resolved = match resolve_link(&detected)? {
+                        Some(linked) => linked,
+                        None => detected,
                     };
                     (Some(resolved), Scope::Project)
                 }
-                None => {
+                None if auto_init_for_write => {
                     // Write path: try to auto-init a project store at the
-                    // enclosing git root. If either no git root exists or the
-                    // directory creation itself fails (e.g. read-only FS,
-                    // permissions), fall back to Global rather than returning
-                    // a Project scope backed by an unusable path.
-                    let auto_init = auto_init_for_write
-                        .then(|| find_git_root(cwd))
-                        .flatten()
-                        .map(|git_root| git_root.join(".padz"))
-                        .filter(|new_padz| {
-                            if let Err(err) = create_bucket_layout(new_padz) {
-                                eprintln!(
-                                    "Warning: could not auto-init padz store at {}: {}. Falling back to global.",
+                    // enclosing git root. If no git root is found, fall back
+                    // to Global (the user isn't clearly inside a project). If
+                    // a git root IS found but layout creation fails, surface
+                    // the error — the write would otherwise silently land in
+                    // Global despite the user sitting in a git repo.
+                    match find_git_root(cwd) {
+                        Some(git_root) => {
+                            let new_padz = git_root.join(".padz");
+                            create_bucket_layout(&new_padz).map_err(|err| {
+                                PadzError::Store(format!(
+                                    "could not auto-init padz store at {}: {}. \
+                                     Run `padz init` there (or `-g` to force global) to proceed.",
                                     new_padz.display(),
                                     err
-                                );
-                                false
-                            } else {
-                                true
-                            }
-                        });
-
-                    match auto_init {
-                        Some(new_padz) => (Some(new_padz), Scope::Project),
+                                ))
+                            })?;
+                            (Some(new_padz), Scope::Project)
+                        }
                         None => (None, Scope::Global),
                     }
                 }
+                None => (None, Scope::Global),
             },
         }
     };
@@ -362,7 +379,7 @@ pub fn initialize(
     };
     let api = PadzApi::new(store, paths);
 
-    PadzContext { api, scope, config }
+    Ok(PadzContext { api, scope, config })
 }
 
 /// Migrates a legacy flat `.padz/` layout to the bucketed layout.
@@ -637,11 +654,11 @@ mod tests {
     }
 
     #[test]
-    fn test_initialize_write_auto_init_failure_falls_back_to_global() {
+    fn test_initialize_write_auto_init_failure_errors() {
         // If auto-init cannot materialize the layout (here: there's already a
         // *file* at the target .padz path so create_dir_all fails), we must
-        // not return a Project scope pointing at an unusable path. Fall back
-        // to Global instead.
+        // error out rather than silently sending the new pad to Global — the
+        // user is clearly inside a git repo and expects project scope.
         let temp = TempDir::new().unwrap();
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).unwrap();
@@ -650,10 +667,41 @@ mod tests {
         let sub = repo.join("src");
         fs::create_dir_all(&sub).unwrap();
 
-        let ctx = initialize(&sub, false, None, true);
+        let msg = match initialize(&sub, false, None, true) {
+            Ok(_) => panic!("expected auto-init failure, got Ok"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("could not auto-init"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("padz init"),
+            "error should hint at `padz init`: {msg}"
+        );
+    }
 
-        assert_eq!(ctx.scope, Scope::Global);
-        assert_eq!(ctx.api.paths().project, None);
+    #[test]
+    fn test_initialize_surfaces_broken_link_error() {
+        // A `.padz` with a link pointing at a non-existent target used to be
+        // swallowed — `initialize` silently fell back to the local (unlinked)
+        // directory, which may be a completely different store than the user
+        // configured. That is now a hard error on every command so the broken
+        // link surfaces instead of misrouting writes.
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        fs::create_dir_all(project.join(".padz")).unwrap();
+        fs::write(
+            project.join(".padz").join("link"),
+            "/definitely/not/a/real/path",
+        )
+        .unwrap();
+
+        let msg = match initialize(&project, false, None, false) {
+            Ok(_) => panic!("expected broken-link error, got Ok"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("does not exist"), "unexpected error: {msg}");
     }
 
     #[test]
@@ -692,7 +740,7 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override ending in .padz - should use it directly
-        let ctx = initialize(repo, false, Some(override_dir.clone()), false);
+        let ctx = initialize(repo, false, Some(override_dir.clone()), false).unwrap();
 
         // Verify the override path is used directly (no .padz appended)
         assert_eq!(ctx.api.paths().project, Some(override_dir));
@@ -712,7 +760,7 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override - should append .padz
-        let ctx = initialize(repo, false, Some(override_dir.clone()), false);
+        let ctx = initialize(repo, false, Some(override_dir.clone()), false).unwrap();
 
         // Verify .padz was appended
         assert_eq!(ctx.api.paths().project, Some(override_dir.join(".padz")));
@@ -728,7 +776,7 @@ mod tests {
         fs::create_dir(repo.join(".padz")).unwrap();
 
         // Initialize without override - should use detected .padz
-        let ctx = initialize(repo, false, None, false);
+        let ctx = initialize(repo, false, None, false).unwrap();
 
         // Verify the detected path is used
         assert_eq!(ctx.api.paths().project, Some(repo.join(".padz")));
@@ -750,7 +798,7 @@ mod tests {
         // Initialize with override AND global flag
         // Global flag wins: scope is Global, project path is None
         // Note: CLI prevents this combination (--data conflicts with -g)
-        let ctx = initialize(repo, true, Some(override_dir), false);
+        let ctx = initialize(repo, true, Some(override_dir), false).unwrap();
 
         assert_eq!(ctx.api.paths().project, None);
         assert_eq!(ctx.scope, crate::model::Scope::Global);
@@ -771,7 +819,7 @@ mod tests {
         fs::create_dir_all(&workdir).unwrap();
 
         // Initialize from workdir, pointing to project's .padz
-        let ctx = initialize(&workdir, false, Some(project.join(".padz")), false);
+        let ctx = initialize(&workdir, false, Some(project.join(".padz")), false).unwrap();
 
         // Should use project's .padz path
         assert_eq!(ctx.api.paths().project, Some(project.join(".padz")));
@@ -789,7 +837,7 @@ mod tests {
         fs::create_dir_all(project.join(".padz").join("active")).unwrap();
         // No .git on purpose.
 
-        let ctx = initialize(&project, false, None, false);
+        let ctx = initialize(&project, false, None, false).unwrap();
 
         assert_eq!(ctx.api.paths().project, Some(project.join(".padz")));
         assert_eq!(ctx.scope, Scope::Project);
@@ -807,7 +855,7 @@ mod tests {
         fs::create_dir_all(&sub).unwrap();
         fs::create_dir(repo.join(".git")).unwrap();
 
-        let ctx = initialize(&sub, false, None, true);
+        let ctx = initialize(&sub, false, None, true).unwrap();
 
         assert_eq!(ctx.api.paths().project, Some(repo.join(".padz")));
         assert_eq!(ctx.scope, Scope::Project);
@@ -827,7 +875,7 @@ mod tests {
         fs::create_dir_all(&sub).unwrap();
         fs::create_dir(repo.join(".git")).unwrap();
 
-        let ctx = initialize(&sub, false, None, false);
+        let ctx = initialize(&sub, false, None, false).unwrap();
 
         assert_eq!(ctx.scope, Scope::Global);
         assert_eq!(ctx.api.paths().project, None);
@@ -841,7 +889,7 @@ mod tests {
         let dir = temp.path().join("loose").join("dir");
         fs::create_dir_all(&dir).unwrap();
 
-        let ctx = initialize(&dir, false, None, true);
+        let ctx = initialize(&dir, false, None, true).unwrap();
 
         assert_eq!(ctx.scope, Scope::Global);
         assert_eq!(ctx.api.paths().project, None);
@@ -859,7 +907,7 @@ mod tests {
         fs::create_dir(parent.join(".padz")).unwrap();
         fs::create_dir(child.join(".git")).unwrap();
 
-        let ctx = initialize(&child, false, None, true);
+        let ctx = initialize(&child, false, None, true).unwrap();
 
         assert_eq!(ctx.api.paths().project, Some(parent.join(".padz")));
         // Child must not have had a .padz created under it.
@@ -1145,7 +1193,7 @@ mod tests {
         .unwrap();
 
         // Initialize from project-b — should follow link to project-a
-        let ctx = initialize(&project_b, false, None, false);
+        let ctx = initialize(&project_b, false, None, false).unwrap();
         assert_eq!(
             ctx.api.paths().project,
             Some(project_a.canonicalize().unwrap().join(".padz"))

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -10,53 +10,54 @@
 //!
 //! ## The Scopes
 //!
-//! - **Project**: Bound to a specific code repository. Data lives in `<repo_root>/.padz/`.
+//! - **Project**: Bound to a specific `.padz/` directory. Data lives in `<project_root>/.padz/`.
 //! - **Global**: Bound to the user. Data lives in the OS-appropriate data directory
 //!   (via the `directories` crate).
 //!
-//! ## Scope Detection Algorithm
+//! ## Two Discovery Modes
 //!
-//! [`find_project_root`] implements git-aware scope detection:
+//! Padz uses **two different discovery algorithms** depending on what the command does:
 //!
-//! 1. Start at `CWD` (Current Working Directory).
-//! 2. Check: Does this directory have BOTH `.git` AND `.padz`?
-//! 3. **Match**: If yes, this is the Project Root.
-//! 4. **No Match**: Move to parent directory.
-//! 5. **Stop**: If we reach `HOME` or filesystem root, return `None`.
+//! ### Read discovery — used by every command
 //!
-//! **Why require both `.git` AND `.padz`?**
-//! - If we only checked `.git`: We might accidentally use a parent repo in monorepos.
-//! - If we only checked `.padz`: We lose the semantic binding to the "Project" concept.
+//! [`find_padz_root`] walks up from cwd looking for `.padz` alone:
 //!
-//! This means you must explicitly `padz init` in a repo to opt-in to project scope.
+//! 1. Start at `CWD`.
+//! 2. If `current/.padz` exists → this is the project root.
+//! 3. Otherwise move to the parent directory.
+//! 4. Stop at `$HOME` or the filesystem root; return `None`.
+//!
+//! If a `.padz` is found, it is used (resolving any `link` file). Otherwise the read
+//! falls back to the global store.
+//!
+//! ### Auto-init discovery — used only by write commands (create, import)
+//!
+//! If read discovery finds nothing and the command is creating a new pad, padz tries
+//! to place that pad inside a project rather than silently dropping it into global.
+//! It runs [`find_git_root`] — the same upward walk, but looking for `.git` — and, if
+//! a git repo is found, creates a fresh `.padz/` at the git root and uses it.
+//!
+//! **Summary of the fallback chain for writes:**
+//!
+//! 1. `.padz` found upward → use it.
+//! 2. Else `.git` found upward → auto-init `.padz` at the git root, use it.
+//! 3. Else → global.
+//!
+//! Reads never auto-init; they simply fall through to step 3 if step 1 misses.
+//!
+//! ## Explicit `padz init`
+//!
+//! `padz init` is user intent and is never blocked: it always creates `.padz/` at
+//! cwd, regardless of whether the directory is a git repo, already inside another
+//! project, or anywhere else. The CLI layer handles this by forcing `cwd` as the
+//! data override for plain-init, bypassing the discovery logic entirely.
 //!
 //! ## Nested Repositories
 //!
-//! When working in nested repos (e.g., `parent-repo/child-repo`):
-//! - If only `parent-repo` has `.padz`, starting from `child-repo` will find and use `parent-repo`
-//! - If both have `.padz`, the innermost one (closest to cwd) wins
-//! - If neither has `.padz`, falls back to global scope
-//!
-//! ## Scope Resolution Flow
-//!
-//! The scope is resolved during [`initialize`]:
-//! 1. If `-g` flag is present → Force `Scope::Global`.
-//! 2. If `data_override` is provided → Use that path directly as project data directory (`Scope::Project`).
-//! 3. Otherwise → Run [`find_project_root`].
-//!    - Found → `Scope::Project`.
-//!    - Not Found → `Scope::Global` (fall back to global store).
-//!
-//! This means that outside any project, commands transparently use the global store.
-//! Users don't need `-g` unless they want to explicitly access global pads while
-//! inside a project directory.
-//!
-//! **Note:** The CLI layer overrides this for `padz init` (plain, non-global): init is a
-//! creation operation ("create a store HERE"), so it always uses `cwd/.padz` directly,
-//! bypassing upward discovery. All other commands use [`find_project_root`] for discovery.
-//!
-//! **Note:** The CLI layer overrides this for `padz init` (plain, non-global): init is a
-//! creation operation ("create a store HERE"), so it always uses `cwd/.padz` directly,
-//! bypassing upward discovery. All other commands use [`find_project_root`] for discovery.
+//! With the `.padz`-only read rule, nested behavior is straightforward:
+//! - The innermost `.padz` (closest to cwd on the upward walk) wins.
+//! - Subprojects inherit their parent's store unless they run `padz init` themselves.
+//! - A `.padz/link` file transparently redirects to another project's store.
 //!
 //! ## Data Path Override
 //!
@@ -69,7 +70,7 @@
 //! When `data_override` is provided:
 //! - If the path ends with `.padz`, it's used directly as the data directory
 //! - Otherwise, `.padz` is appended to the path (e.g., `/path/to/project` becomes `/path/to/project/.padz`)
-//! - Scope detection via [`find_project_root`] is skipped
+//! - Both discovery algorithms are skipped
 //! - The scope defaults to `Scope::Project` (unless `-g` forces global)
 
 use crate::api::{PadzApi, PadzPaths};
@@ -88,39 +89,49 @@ pub struct PadzContext {
     pub config: PadzConfig,
 }
 
-/// Find the project root by walking up from cwd looking for a directory
-/// that has both .git and .padz. If a directory has .git but no .padz,
-/// continue searching upward (to support nested repos where parent has padz).
-/// Returns None if no matching directory is found before reaching home or root.
-pub fn find_project_root(cwd: &Path) -> Option<PathBuf> {
+/// Walk upward from `cwd` looking for a directory that contains `.padz/`.
+///
+/// This is the **read** discovery function: every command uses it to locate an
+/// existing store, regardless of whether the enclosing directory is a git repo.
+/// Stops at `$HOME` or the filesystem root and returns `None`.
+pub fn find_padz_root(cwd: &Path) -> Option<PathBuf> {
+    walk_up_for(cwd, ".padz")
+}
+
+/// Walk upward from `cwd` looking for a directory that contains `.git/`.
+///
+/// This is the **auto-init** discovery function: used by write commands to decide
+/// where to create a new `.padz/` when none is found upward. When a pad is being
+/// created and there is no existing store, we want it scoped to the enclosing git
+/// project rather than dropped into global.
+/// Stops at `$HOME` or the filesystem root and returns `None`.
+pub fn find_git_root(cwd: &Path) -> Option<PathBuf> {
+    walk_up_for(cwd, ".git")
+}
+
+/// Shared upward-walk helper. Returns the first ancestor (including `cwd`
+/// itself) that contains a child entry named `marker`. Stops at `$HOME` or
+/// the filesystem root.
+fn walk_up_for(cwd: &Path, marker: &str) -> Option<PathBuf> {
     let home_dir = BaseDirs::new().map(|bd| bd.home_dir().to_path_buf());
     let mut current = cwd.to_path_buf();
 
     loop {
-        let git_dir = current.join(".git");
-        let padz_dir = current.join(".padz");
-
-        // Found a repo with padz - use it
-        if git_dir.exists() && padz_dir.exists() {
+        if current.join(marker).exists() {
             return Some(current);
         }
 
-        // Check stop conditions: reached home dir or volume root
         if let Some(ref home) = home_dir {
             if &current == home {
                 return None;
             }
         }
 
-        // Try to move up to parent
         match current.parent() {
             Some(parent) if parent != current => {
                 current = parent.to_path_buf();
             }
-            _ => {
-                // Reached filesystem root
-                return None;
-            }
+            _ => return None,
         }
     }
 }
@@ -194,6 +205,10 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 ///   When provided, bypasses automatic scope detection.
 ///   - If path ends with `.padz`, it's used as the data directory directly
 ///   - Otherwise, `.padz` is appended to the path
+/// * `auto_init_for_write` - If true and read discovery finds no `.padz`, fall
+///   through to `find_git_root` and create `.padz/` at the git root before
+///   returning `Scope::Project`. Only write commands (`create`, `import`) should
+///   pass `true`; reads pass `false` and fall back to global cleanly.
 ///
 /// # Environment Variables
 ///
@@ -203,19 +218,27 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 /// # Examples
 ///
 /// ```ignore
-/// // Normal initialization with automatic scope detection
-/// let ctx = initialize(&cwd, false, None);
+/// // Read path: discover .padz upward, else global
+/// let ctx = initialize(&cwd, false, None, false);
+///
+/// // Write path: discover .padz upward; if none, auto-init at git root; else global
+/// let ctx = initialize(&cwd, false, None, true);
 ///
 /// // Force global scope
-/// let ctx = initialize(&cwd, true, None);
+/// let ctx = initialize(&cwd, true, None, false);
 ///
 /// // Use explicit data directory - path ends with .padz, used directly
-/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project/.padz")));
+/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project/.padz")), false);
 ///
 /// // Use explicit project directory - .padz is appended
-/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project")));
+/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project")), false);
 /// ```
-pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) -> PadzContext {
+pub fn initialize(
+    cwd: &Path,
+    use_global: bool,
+    data_override: Option<PathBuf>,
+    auto_init_for_write: bool,
+) -> PadzContext {
     // Determine global data directory:
     // 1. Check PADZ_GLOBAL_DATA environment variable (primarily for testing)
     // 2. Fall back to OS-appropriate data directory via directories crate
@@ -231,8 +254,10 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
     // Determine project data directory and scope:
     // 1. If use_global → Global scope, no project dir
     // 2. If data_override provided → Project scope with explicit path
-    // 3. find_project_root found something → Project scope
-    // 4. No project found → fall back to Global scope
+    // 3. find_padz_root found something → Project scope (follow link if present)
+    // 4. Else if auto_init_for_write and find_git_root found something → create
+    //    .padz at that git root and use it (Project scope)
+    // 5. Else → fall back to Global scope
     let (project_padz_dir, scope) = if use_global {
         (None, Scope::Global)
     } else {
@@ -245,7 +270,7 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
                 };
                 (Some(dir), Scope::Project)
             }
-            None => match find_project_root(cwd) {
+            None => match find_padz_root(cwd) {
                 Some(root) => {
                     let detected = root.join(".padz");
                     // Follow .padz/link if present
@@ -255,7 +280,24 @@ pub fn initialize(cwd: &Path, use_global: bool, data_override: Option<PathBuf>) 
                     };
                     (Some(resolved), Scope::Project)
                 }
-                None => (None, Scope::Global),
+                None => {
+                    if auto_init_for_write {
+                        if let Some(git_root) = find_git_root(cwd) {
+                            let new_padz = git_root.join(".padz");
+                            // Best-effort create of the bucket layout. If this
+                            // fails (e.g. read-only FS), downstream writes will
+                            // surface the actual I/O error.
+                            let _ = std::fs::create_dir_all(new_padz.join("active"));
+                            let _ = std::fs::create_dir_all(new_padz.join("archived"));
+                            let _ = std::fs::create_dir_all(new_padz.join("deleted"));
+                            (Some(new_padz), Scope::Project)
+                        } else {
+                            (None, Scope::Global)
+                        }
+                    } else {
+                        (None, Scope::Global)
+                    }
+                }
             },
         }
     };
@@ -444,116 +486,117 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    // --- find_padz_root tests ---
+
     #[test]
-    fn test_find_project_root_with_git_and_padz() {
-        // Setup: single repo with both .git and .padz
+    fn test_find_padz_root_at_cwd() {
+        // `.padz` in the current directory is found immediately, no `.git` needed.
+        // Regression: previously find_project_root required both and would skip this.
         let temp = TempDir::new().unwrap();
         let root = temp.path();
-        fs::create_dir(root.join(".git")).unwrap();
         fs::create_dir(root.join(".padz")).unwrap();
 
-        let result = find_project_root(root);
+        let result = find_padz_root(root);
         assert_eq!(result, Some(root.to_path_buf()));
     }
 
     #[test]
-    fn test_find_project_root_git_only_continues_up() {
-        // Setup: child repo with .git only, parent with both .git and .padz
+    fn test_find_padz_root_walks_up() {
         let temp = TempDir::new().unwrap();
         let parent = temp.path();
-        let child = parent.join("child-repo");
-
-        fs::create_dir(&child).unwrap();
-        fs::create_dir(parent.join(".git")).unwrap();
-        fs::create_dir(parent.join(".padz")).unwrap();
-        fs::create_dir(child.join(".git")).unwrap();
-        // child has NO .padz
-
-        let result = find_project_root(&child);
-        assert_eq!(result, Some(parent.to_path_buf()));
-    }
-
-    #[test]
-    fn test_find_project_root_nested_repos_child_has_padz() {
-        // Setup: child repo with both .git and .padz should be used
-        let temp = TempDir::new().unwrap();
-        let parent = temp.path();
-        let child = parent.join("child-repo");
-
-        fs::create_dir(&child).unwrap();
-        fs::create_dir(parent.join(".git")).unwrap();
-        fs::create_dir(parent.join(".padz")).unwrap();
-        fs::create_dir(child.join(".git")).unwrap();
-        fs::create_dir(child.join(".padz")).unwrap();
-
-        let result = find_project_root(&child);
-        assert_eq!(result, Some(child.clone()));
-    }
-
-    #[test]
-    fn test_find_project_root_deep_nested() {
-        // Setup: deeply nested path finds grandparent with .git and .padz
-        let temp = TempDir::new().unwrap();
-        let grandparent = temp.path();
-        let parent = grandparent.join("parent");
         let child = parent.join("child");
-
         fs::create_dir_all(&child).unwrap();
-        fs::create_dir(grandparent.join(".git")).unwrap();
-        fs::create_dir(grandparent.join(".padz")).unwrap();
-        // parent and child have no .git or .padz
+        fs::create_dir(parent.join(".padz")).unwrap();
 
-        let result = find_project_root(&child);
-        assert_eq!(result, Some(grandparent.to_path_buf()));
+        assert_eq!(find_padz_root(&child), Some(parent.to_path_buf()));
     }
 
     #[test]
-    fn test_find_project_root_no_git_no_padz() {
-        // Setup: no .git or .padz anywhere in temp dir
+    fn test_find_padz_root_inner_wins() {
+        // Innermost .padz (closest to cwd) is picked over an outer one.
         let temp = TempDir::new().unwrap();
-        let dir = temp.path().join("some").join("deep").join("path");
+        let outer = temp.path();
+        let inner = outer.join("inner");
+        fs::create_dir_all(&inner).unwrap();
+        fs::create_dir(outer.join(".padz")).unwrap();
+        fs::create_dir(inner.join(".padz")).unwrap();
+
+        assert_eq!(find_padz_root(&inner), Some(inner));
+    }
+
+    #[test]
+    fn test_find_padz_root_no_match() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("a").join("b");
         fs::create_dir_all(&dir).unwrap();
 
-        let result = find_project_root(&dir);
-        assert_eq!(result, None);
+        assert_eq!(find_padz_root(&dir), None);
     }
 
+    // --- find_git_root tests ---
+
     #[test]
-    fn test_find_project_root_padz_only_no_git() {
-        // Setup: .padz without .git should not match
+    fn test_find_git_root_at_cwd() {
         let temp = TempDir::new().unwrap();
         let root = temp.path();
-        fs::create_dir(root.join(".padz")).unwrap();
-        // No .git
+        fs::create_dir(root.join(".git")).unwrap();
 
-        let result = find_project_root(root);
-        assert_eq!(result, None);
+        assert_eq!(find_git_root(root), Some(root.to_path_buf()));
     }
 
     #[test]
-    fn test_find_project_root_multiple_nested_git_only_repos() {
-        // Setup: multiple nested repos, only topmost has .padz
-        // grandparent-repo/ (.git + .padz)
-        //   parent-repo/ (.git only)
-        //     child-repo/ (.git only)
+    fn test_find_git_root_walks_up() {
+        // Subdir of a git repo resolves to the repo root.
         let temp = TempDir::new().unwrap();
-        let grandparent = temp.path();
-        let parent = grandparent.join("parent-repo");
-        let child = parent.join("child-repo");
+        let repo = temp.path();
+        let sub = repo.join("src").join("cli");
+        fs::create_dir_all(&sub).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
 
-        fs::create_dir_all(&child).unwrap();
-        fs::create_dir(grandparent.join(".git")).unwrap();
-        fs::create_dir(grandparent.join(".padz")).unwrap();
-        fs::create_dir(parent.join(".git")).unwrap();
-        fs::create_dir(child.join(".git")).unwrap();
+        assert_eq!(find_git_root(&sub), Some(repo.to_path_buf()));
+    }
 
-        // From child, should find grandparent
-        let result = find_project_root(&child);
-        assert_eq!(result, Some(grandparent.to_path_buf()));
+    #[test]
+    fn test_find_git_root_innermost_wins() {
+        // Nested repos: innermost .git is used, not the parent.
+        let temp = TempDir::new().unwrap();
+        let outer = temp.path();
+        let inner = outer.join("submodule");
+        fs::create_dir_all(&inner).unwrap();
+        fs::create_dir(outer.join(".git")).unwrap();
+        fs::create_dir(inner.join(".git")).unwrap();
 
-        // From parent, should also find grandparent
-        let result = find_project_root(&parent);
-        assert_eq!(result, Some(grandparent.to_path_buf()));
+        assert_eq!(find_git_root(&inner), Some(inner));
+    }
+
+    #[test]
+    fn test_find_git_root_no_match() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("a");
+        fs::create_dir_all(&dir).unwrap();
+
+        assert_eq!(find_git_root(&dir), None);
+    }
+
+    #[test]
+    fn test_discovery_independent() {
+        // The two discovery algorithms are independent: a dir with only `.padz`
+        // and no `.git` is found by find_padz_root; a dir with only `.git` and
+        // no `.padz` is found by find_git_root. This is the core of the split —
+        // the old find_project_root required both at the same location.
+        let temp = TempDir::new().unwrap();
+        let padz_only = temp.path().join("padz-only");
+        let git_only = temp.path().join("git-only");
+        fs::create_dir_all(&padz_only).unwrap();
+        fs::create_dir_all(&git_only).unwrap();
+        fs::create_dir(padz_only.join(".padz")).unwrap();
+        fs::create_dir(git_only.join(".git")).unwrap();
+
+        assert_eq!(find_padz_root(&padz_only), Some(padz_only.clone()));
+        assert_eq!(find_git_root(&padz_only), None);
+
+        assert_eq!(find_git_root(&git_only), Some(git_only.clone()));
+        assert_eq!(find_padz_root(&git_only), None);
     }
 
     // --- initialize() with data_override tests ---
@@ -571,7 +614,7 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override ending in .padz - should use it directly
-        let ctx = initialize(repo, false, Some(override_dir.clone()));
+        let ctx = initialize(repo, false, Some(override_dir.clone()), false);
 
         // Verify the override path is used directly (no .padz appended)
         assert_eq!(ctx.api.paths().project, Some(override_dir));
@@ -591,7 +634,7 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override - should append .padz
-        let ctx = initialize(repo, false, Some(override_dir.clone()));
+        let ctx = initialize(repo, false, Some(override_dir.clone()), false);
 
         // Verify .padz was appended
         assert_eq!(ctx.api.paths().project, Some(override_dir.join(".padz")));
@@ -607,7 +650,7 @@ mod tests {
         fs::create_dir(repo.join(".padz")).unwrap();
 
         // Initialize without override - should use detected .padz
-        let ctx = initialize(repo, false, None);
+        let ctx = initialize(repo, false, None, false);
 
         // Verify the detected path is used
         assert_eq!(ctx.api.paths().project, Some(repo.join(".padz")));
@@ -629,7 +672,7 @@ mod tests {
         // Initialize with override AND global flag
         // Global flag wins: scope is Global, project path is None
         // Note: CLI prevents this combination (--data conflicts with -g)
-        let ctx = initialize(repo, true, Some(override_dir));
+        let ctx = initialize(repo, true, Some(override_dir), false);
 
         assert_eq!(ctx.api.paths().project, None);
         assert_eq!(ctx.scope, crate::model::Scope::Global);
@@ -650,10 +693,99 @@ mod tests {
         fs::create_dir_all(&workdir).unwrap();
 
         // Initialize from workdir, pointing to project's .padz
-        let ctx = initialize(&workdir, false, Some(project.join(".padz")));
+        let ctx = initialize(&workdir, false, Some(project.join(".padz")), false);
 
         // Should use project's .padz path
         assert_eq!(ctx.api.paths().project, Some(project.join(".padz")));
+    }
+
+    // --- Read-path discovery: .padz alone is enough ---
+
+    #[test]
+    fn test_initialize_finds_padz_without_git() {
+        // Regression for the bug that motivated the split: a directory with
+        // `.padz` but no `.git` used to fall through to global. With the new
+        // read-path rules, find_padz_root picks it up.
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        fs::create_dir_all(project.join(".padz").join("active")).unwrap();
+        // No .git on purpose.
+
+        let ctx = initialize(&project, false, None, false);
+
+        assert_eq!(ctx.api.paths().project, Some(project.join(".padz")));
+        assert_eq!(ctx.scope, Scope::Project);
+    }
+
+    // --- Auto-init-on-write discovery ---
+
+    #[test]
+    fn test_initialize_auto_inits_at_git_root_on_write() {
+        // Write op in a git repo with no `.padz` anywhere should materialize
+        // `.padz/` at the git root and return Project scope.
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        let sub = repo.join("src");
+        fs::create_dir_all(&sub).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
+
+        let ctx = initialize(&sub, false, None, true);
+
+        assert_eq!(ctx.api.paths().project, Some(repo.join(".padz")));
+        assert_eq!(ctx.scope, Scope::Project);
+        // Auto-init must have created the bucket layout on disk.
+        assert!(repo.join(".padz").join("active").is_dir());
+        assert!(repo.join(".padz").join("archived").is_dir());
+        assert!(repo.join(".padz").join("deleted").is_dir());
+    }
+
+    #[test]
+    fn test_initialize_read_never_auto_inits() {
+        // Same setup as the auto-init test, but `auto_init_for_write = false`.
+        // Should fall back to Global and leave the filesystem untouched.
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        let sub = repo.join("src");
+        fs::create_dir_all(&sub).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
+
+        let ctx = initialize(&sub, false, None, false);
+
+        assert_eq!(ctx.scope, Scope::Global);
+        assert_eq!(ctx.api.paths().project, None);
+        assert!(!repo.join(".padz").exists());
+    }
+
+    #[test]
+    fn test_initialize_write_outside_git_goes_global() {
+        // No `.padz`, no `.git` → global, even on a write op.
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("loose").join("dir");
+        fs::create_dir_all(&dir).unwrap();
+
+        let ctx = initialize(&dir, false, None, true);
+
+        assert_eq!(ctx.scope, Scope::Global);
+        assert_eq!(ctx.api.paths().project, None);
+    }
+
+    #[test]
+    fn test_initialize_write_prefers_existing_padz_over_git() {
+        // Parent has `.padz`, child has `.git` with no `.padz`. The write should
+        // use the parent's existing store, not auto-init a new one at the child.
+        // (The read discovery matches first and short-circuits.)
+        let temp = TempDir::new().unwrap();
+        let parent = temp.path().join("parent");
+        let child = parent.join("child");
+        fs::create_dir_all(&child).unwrap();
+        fs::create_dir(parent.join(".padz")).unwrap();
+        fs::create_dir(child.join(".git")).unwrap();
+
+        let ctx = initialize(&child, false, None, true);
+
+        assert_eq!(ctx.api.paths().project, Some(parent.join(".padz")));
+        // Child must not have had a .padz created under it.
+        assert!(!child.join(".padz").exists());
     }
 
     // --- Migration tests ---
@@ -935,7 +1067,7 @@ mod tests {
         .unwrap();
 
         // Initialize from project-b — should follow link to project-a
-        let ctx = initialize(&project_b, false, None);
+        let ctx = initialize(&project_b, false, None, false);
         assert_eq!(
             ctx.api.paths().project,
             Some(project_a.canonicalize().unwrap().join(".padz"))

--- a/docs/scopes.txt
+++ b/docs/scopes.txt
@@ -8,51 +8,73 @@ Command line tools typically operate in one of two modes:
 
 For a developer-focused note tool, neither is sufficient. You want context-aware notes ("TODOs for *this* project") but occasionally need global notes ("Grocery list") without leaving your terminal. Furthermore, in nested repository structures (monorepos), "Local" is ambiguous.
 
-## The Solution: Heuristic Scope Detection
+## The Solution: Two Discovery Modes
 
-Padz implements a git-aware scope detection algorithm to robustly identify the "Project Root".
+Padz uses **two separate discovery algorithms**, applied depending on whether the command is reading or writing.
 
 ### 1. The Scopes
--   **Project**: Bound to a specific code repository. Data lives in `<repo_root>/.padz/`.
+
+-   **Project**: Bound to a specific `.padz/` directory. Data lives in `<project_root>/.padz/`.
 -   **Global**: Bound to the user. Data lives in the OS-appropriate data directory (via `directories` crate).
 
-### 2. Detection Logic
+### 2. Read Discovery (`find_padz_root`)
 
--   **Location**: `src/padz/init.rs` — function `find_project_root`
+Used by every command to locate an existing store.
+
+-   **Location**: `crates/padzapp/src/init.rs` — function `find_padz_root`
 -   **Algorithm**:
-    1.  Start at `CWD` (Current Working Directory).
-    2.  Check for **Evidence**: Does this directory have BOTH `.git` AND `.padz`?
-    3.  **Match**: If yes, this is the Project Root.
-    4.  **No Match**: Move to parent directory.
-    5.  **Stop**: If we reach `HOME` or filesystem root, return `None`.
+    1.  Start at `CWD`.
+    2.  If the directory contains `.padz/`, that's the project root.
+    3.  Otherwise, move up one directory.
+    4.  Stop at `$HOME` or the filesystem root.
 
-**Why require both `.git` AND `.padz`?**
-This dual-check is the strictness filter:
--   If we only checked `.git`: We might accidentally use a parent repo (e.g., when working in a sub-repo inside a monorepo).
--   If we only checked `.padz`: We lose the semantic binding to the "Project" concept.
+If a `.padz` is found, padz uses it (resolving a `link` file if present). If not, padz falls back to global. `.git` is irrelevant here.
 
-The result is that you must explicitly `padz init` in a repo to opt-in to project scope. This prevents accidental pollution of parent directories.
+### 3. Auto-Init Discovery (`find_git_root`)
 
-### 3. Scope Resolution Flow
+Used **only** by write commands (`create`, `import`) when read discovery found nothing.
 
-The scope is resolved during `padz::init::initialize`:
-1.  If `-g` flag is present → Force `Scope::Global`.
-2.  If `--data <PATH>` is provided → Use that path directly as project data directory.
-3.  Otherwise → Run `find_project_root(cwd)`.
+-   **Location**: `crates/padzapp/src/init.rs` — function `find_git_root`
+-   **Algorithm**: Same walk, but looking for `.git/` instead of `.padz/`.
+-   **Effect**: If a git root is found, padz creates a fresh `.padz/` at that location and uses it for the new pad. This prevents a new pad from being silently dropped into global when the user is clearly inside a project.
+
+### 4. Write Fallback Chain
+
+For `create` and `import`:
+
+1.  `.padz` found upward → use it.
+2.  Else `.git` found upward → auto-init `.padz` at the git root, use it.
+3.  Else → global.
+
+Read commands skip step 2 — they never auto-init.
+
+### 5. Scope Resolution Flow
+
+The scope is resolved during `padzapp::init::initialize`:
+
+1.  If `-g` flag is present → force `Scope::Global`.
+2.  If `--data <PATH>` is provided → use that path directly; `Scope::Project`.
+3.  Otherwise → run `find_padz_root(cwd)`.
     -   Found → `Scope::Project`.
-    -   Not Found → `Scope::Project` with `cwd/.padz` as path (may need `init`).
+    -   Not found, and write op → run `find_git_root(cwd)`.
+        -   Found → create `.padz` there; `Scope::Project`.
+        -   Not found → `Scope::Global`.
+    -   Not found, and read op → `Scope::Global`.
 
-### 3.1 Data Path Override (--data option)
+### 6. Explicit `padz init`
 
-The `--data <PATH>` option allows explicitly specifying the data directory,
-bypassing automatic scope detection. This is useful when:
--   Working in a git worktree that should share data with the main repo
--   Working in a temp directory for a project located elsewhere
--   Explicitly pointing to a specific data store location
+`padz init` is user intent and is never blocked. It always creates `.padz/` at the current directory, regardless of git status or any ancestor `.padz`. The CLI layer short-circuits discovery for plain-init by passing `cwd` as the data override.
+
+### 7. Data Path Override (--data option)
+
+The `--data <PATH>` option allows explicitly specifying the data directory, bypassing both discovery algorithms. Useful when:
+-   Working in a git worktree that should share data with the main repo.
+-   Working in a temp directory for a project located elsewhere.
+-   Explicitly pointing to a specific data store location.
 
 **Path handling:**
--   If the path ends with `.padz`, it's used directly as the data directory
--   Otherwise, `.padz` is appended to the path
+-   If the path ends with `.padz`, it's used directly as the data directory.
+-   Otherwise, `.padz` is appended to the path.
 
 Example usage:
 ```bash
@@ -64,18 +86,20 @@ padz --data ~/projects/myproject list
 padz --data ~/projects/myproject/.padz list
 # Uses: ~/projects/myproject/.padz
 
-# Create a pad from temp directory, saved to project
+# Create a pad from a temp directory, saved to the project
 padz --data /home/user/myproject create "temp notes"
 ```
 
 When `--data` is provided:
--   Scope detection via `find_project_root` is skipped
--   The scope defaults to `Scope::Project`
--   Note: `--data` and `-g` are mutually exclusive
+-   Both discovery algorithms are skipped.
+-   The scope defaults to `Scope::Project`.
+-   `--data` and `-g` are mutually exclusive.
 
-### 4. Nested Repositories
+### 8. Nested Repositories
 
-When working in nested repos (e.g., `parent-repo/child-repo`):
-- If only `parent-repo` has `.padz`, starting from `child-repo` will find and use `parent-repo`
-- If both have `.padz`, the innermost one (closest to cwd) wins
-- If neither has `.padz`, scope resolution returns `None` and uses `cwd/.padz` as default
+With the split rules, nested behavior is straightforward:
+
+-   The innermost `.padz` (closest to cwd on the upward walk) wins.
+-   A subdirectory without its own `.padz` inherits the enclosing project's store.
+-   A `.padz/link` file transparently redirects to another project's store.
+-   On writes, if no ancestor has `.padz` but the current dir is inside a git repo, auto-init places a new `.padz` at the git root — never deeper, never shallower.

--- a/docs/scopes.txt
+++ b/docs/scopes.txt
@@ -35,7 +35,7 @@ If a `.padz` is found, padz uses it (resolving a `link` file if present). If not
 Used **only** by write commands (`create`, `import`) when read discovery found nothing.
 
 -   **Location**: `crates/padzapp/src/init.rs` — function `find_git_root`
--   **Algorithm**: Same walk, but looking for `.git/` instead of `.padz/`.
+-   **Algorithm**: Same walk, but matches a `.git` entry — either a directory (normal repo) or a regular file (git worktrees and submodules leave a `.git` file pointing at the real gitdir). Using `exists()` rather than `is_dir()` here is deliberate so worktrees auto-init correctly. Contrast with `find_padz_root`, which requires `.padz` to be a directory so a stray same-named file can't masquerade as a store.
 -   **Effect**: If a git root is found, padz creates a fresh `.padz/` at that location and uses it for the new pad. This prevents a new pad from being silently dropped into global when the user is clearly inside a project.
 
 ### 4. Write Fallback Chain


### PR DESCRIPTION
## Summary

- Splits padz's project-root discovery into two independent algorithms so `.padz` directories without a sibling `.git` are no longer invisible. Read commands walk up for `.padz` alone; write commands (`create`, `import`) additionally auto-init `.padz/` at the enclosing git root when no store is found upward.
- `padz init` stays the same — always creates `.padz/` at cwd regardless of git status or any enclosing project.
- Docs (module-level rustdoc, `padz --help scopes` topic, `docs/scopes.txt`, `README.md`, `PADZ.md`) rewritten to match.

## Motivation

A directory with `.padz` but no `.git` used to fall through to global scope because `find_project_root` required both markers at the same location. So running `padz init` in such a directory appeared to do nothing: the `.padz/` was created, but the very next `padz list` walked past it and hit the global store instead. The two new discovery functions remove that coupling while preserving the "don't silently pollute a parent git repo" guarantee via the write-only auto-init path.

## Test plan

- [x] `cargo test --workspace` — 535 tests passing (net +7 from the new discovery coverage)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New unit tests cover: `.padz` without `.git` (the original bug), auto-init at git root on write, read path never auto-inits, write outside any git repo still goes global, existing `.padz` upward wins over an inner `.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)