### PR TITLE
Add .deb packages and install.sh one-liner installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,9 +276,12 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
+          # Recursive glob for .deb so this works whether upload-artifact
+          # flattened paths (v4+ default with a pattern ending in *.deb)
+          # or preserved the nested target/<triple>/debian/ structure.
           files: |
             ${{ env.BIN_NAME }}-*.tar.gz
-            *.deb
+            **/*.deb
           draft: false
 
   homebrew-formula:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ env:
   HOMEBREW_TAP: arthur-debert/homebrew-tools
   # Formula filename (without `.rb`). Usually equals BIN_NAME.
   HOMEBREW_FORMULA: padz
+  # ─── Debian/Ubuntu packages (optional) ───────────────────────────────
+  # Build .deb packages for the linux targets and attach them to the
+  # GitHub Release. Set to "false" (or delete) to skip. Requires
+  # `[package.metadata.deb]` in the crate's Cargo.toml.
+  ENABLE_DEB: "true"
 
 jobs:
   prepare:
@@ -166,18 +171,22 @@ jobs:
             os: macos-latest
             artifact_suffix: aarch64-apple-darwin
             cross: false
+            deb_arch: ""
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact_suffix: x86_64-apple-darwin
             cross: false
+            deb_arch: ""
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_suffix: x86_64-linux-gnu
             cross: false
+            deb_arch: amd64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             artifact_suffix: aarch64-linux-gnu
             cross: true
+            deb_arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -229,6 +238,28 @@ jobs:
           name: ${{ env.BIN_NAME }}-${{ matrix.artifact_suffix }}
           path: ${{ env.BIN_NAME }}-${{ matrix.artifact_suffix }}.tar.gz
 
+      # ─── Debian package (linux targets only, gated on ENABLE_DEB) ──────
+      - name: Install cargo-deb
+        if: matrix.deb_arch != '' && env.ENABLE_DEB == 'true'
+        run: cargo install cargo-deb --locked
+
+      - name: Build .deb package
+        if: matrix.deb_arch != '' && env.ENABLE_DEB == 'true'
+        run: |
+          # --no-build reuses the release binary built above. cargo-deb
+          # reads [package.metadata.deb] from Cargo.toml and embeds the
+          # postinst/prerm maintainer scripts from debian/.
+          cargo deb -p "$CRATE_NAME" \
+            --target "${{ matrix.target }}" \
+            --no-build \
+            --no-strip
+
+      - uses: actions/upload-artifact@v5
+        if: matrix.deb_arch != '' && env.ENABLE_DEB == 'true'
+        with:
+          name: ${{ env.BIN_NAME }}-${{ matrix.deb_arch }}-deb
+          path: target/${{ matrix.target }}/debian/*.deb
+
   finalize:
     needs: [prepare, release, build-binaries, publish]
     runs-on: ubuntu-latest
@@ -245,7 +276,9 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
-          files: ${{ env.BIN_NAME }}-*.tar.gz
+          files: |
+            ${{ env.BIN_NAME }}-*.tar.gz
+            *.deb
           draft: false
 
   homebrew-formula:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Added**
+  - **Debian/Ubuntu packages** — every release now produces `.deb` packages for `amd64` and `arm64` and attaches them to the GitHub Release. Install with `sudo dpkg -i padz_<version>-1_<arch>.deb` (or via `apt install ./padz_<version>-1_<arch>.deb` for dependency resolution). The package's postinst script generates bash/zsh/fish completion scripts from the installed binary into `/usr/share/bash-completion/completions/`, `/usr/share/zsh/site-functions/`, and `/usr/share/fish/vendor_completions.d/`, so completions work system-wide for all users with no extra setup.
+  - **`install.sh` one-liner installer** — `curl -fsSL https://raw.githubusercontent.com/arthur-debert/padz/main/install.sh | sh` detects macOS/Linux + arm/x86, downloads the matching release tarball, installs `padz` into `~/.local/bin/`, and runs `padz completion install` automatically. Honors `VERSION=vX.Y.Z` and `PREFIX=/usr/local` overrides for pinned/system installs.
+
 ## [1.4.1] - 2026-04-23
 
 ## [1.4.1] - 2026-04-23

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Sports a smart-looking UI with dark/light mode awareness.
 
 ## Installation
 
+**Homebrew** (macOS, Linux):
+
+```bash
+brew install arthur-debert/tools/padz
+```
+
+**One-line installer** (macOS, Linux — downloads the latest release tarball to `~/.local/bin/`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/arthur-debert/padz/main/install.sh | sh
+```
+
+**Debian / Ubuntu**: grab the `.deb` for your architecture from the [latest release](https://github.com/arthur-debert/padz/releases/latest) and install with `sudo apt install ./padz_<version>-1_<arch>.deb`.
+
+**Cargo**:
+
 ```bash
 cargo install padz
 ```

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -59,6 +59,9 @@ section = "utility"
 priority = "optional"
 depends = "$auto"
 assets = [
+    # cargo-deb rewrites `target/release/` to `target/<triple>/release/`
+    # automatically when `--target` is passed (as CI does), so this path
+    # works for both native and cross-compiled builds.
     ["target/release/padz", "usr/bin/", "755"],
     ["../../README.md", "usr/share/doc/padz/README.md", "644"],
     ["../../CHANGELOG.md", "usr/share/doc/padz/CHANGELOG.md", "644"],

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -37,3 +37,36 @@ anyhow = "1.0"
 assert_cmd = "2.0.16"
 predicates = "3.1.2"
 tempfile = "3.10.1"
+
+# cargo-deb configuration. Driven by `cargo deb -p padz` in CI.
+# Completions are generated at install time by the postinst maintainer
+# script (it invokes `padz completion --shell X print`) rather than
+# shipped as static assets, because clap_complete bakes the absolute
+# binary path into the script and we can't know /usr/bin/padz at build
+# time for a cross-compiled artifact.
+[package.metadata.deb]
+maintainer = "Arthur Debert <debert@gmail.com>"
+copyright = "2025-2026, Arthur Debert <debert@gmail.com>"
+license-file = ["../../LICENSE", "0"]
+extended-description = """
+padz is a scratch-pad / note-taking CLI that adapts to its context.
+Notes are scoped to the current project (via .padz/) or globally, with
+automatic discovery, todo tracking, tags, archive/restore, and import/
+export. Designed as a good Unix citizen: predictable output, pipes
+cleanly, and composes with standard tooling.
+"""
+section = "utility"
+priority = "optional"
+depends = "$auto"
+assets = [
+    ["target/release/padz", "usr/bin/", "755"],
+    ["../../README.md", "usr/share/doc/padz/README.md", "644"],
+    ["../../CHANGELOG.md", "usr/share/doc/padz/CHANGELOG.md", "644"],
+]
+maintainer-scripts = "debian/"
+
+# CI builds each architecture separately with --target, so cargo-deb
+# picks up the binary from target/<triple>/release/. The workspace
+# rewrite pattern handles the asset path override.
+[package.metadata.deb.variants.amd64]
+[package.metadata.deb.variants.arm64]

--- a/crates/padz/debian/postinst
+++ b/crates/padz/debian/postinst
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Generate shell completion scripts into system-wide paths after install.
+#
+# We invoke the freshly-installed `padz completion --shell X print` rather
+# than shipping static scripts because clap_complete embeds the absolute
+# binary path into the completion registration — the right path (/usr/bin/padz
+# in this package) is only known at install time.
+set -e
+
+if [ "$1" != "configure" ]; then
+    exit 0
+fi
+
+PADZ=/usr/bin/padz
+[ -x "$PADZ" ] || exit 0
+
+install_completion() {
+    shell="$1"
+    dest="$2"
+    dir=$(dirname "$dest")
+    mkdir -p "$dir"
+    if ! "$PADZ" completion --shell "$shell" print > "$dest" 2>/dev/null; then
+        rm -f "$dest"
+    fi
+}
+
+install_completion bash /usr/share/bash-completion/completions/padz
+install_completion zsh  /usr/share/zsh/site-functions/_padz
+install_completion fish /usr/share/fish/vendor_completions.d/padz.fish
+
+exit 0

--- a/crates/padz/debian/prerm
+++ b/crates/padz/debian/prerm
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Remove the completion scripts installed by postinst. Runs on `apt remove`
+# and upgrade-replace scenarios.
+set -e
+
+case "$1" in
+    remove|upgrade|deconfigure)
+        rm -f /usr/share/bash-completion/completions/padz
+        rm -f /usr/share/zsh/site-functions/_padz
+        rm -f /usr/share/fish/vendor_completions.d/padz.fish
+        ;;
+esac
+
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# Install padz — a curl-piped installer for the padz CLI.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/arthur-debert/padz/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/arthur-debert/padz/main/install.sh | VERSION=v1.4.1 sh
+#   curl -fsSL https://raw.githubusercontent.com/arthur-debert/padz/main/install.sh | PREFIX=/usr/local sh
+#
+# The script is reusable across cargo projects — change the four ─── REUSE ───
+# values below and it works for any crate whose release workflow follows the
+# same `<bin>-<target>.tar.gz` naming convention.
+
+set -eu
+
+# ─── REUSE: values to edit when adopting this script for another project ───
+BIN_NAME=${BIN_NAME:-padz}
+REPO=${REPO:-arthur-debert/padz}
+# Prefix where the binary goes. "$HOME/.local" needs no sudo; "/usr/local"
+# gets you a system-wide install if you pipe with sudo.
+PREFIX=${PREFIX:-$HOME/.local}
+# Pinned version, or "latest" to resolve from the GitHub API.
+VERSION=${VERSION:-latest}
+# ────────────────────────────────────────────────────────────────────────────
+
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m==>\033[0m %s\n' "$*" >&2; }
+fatal() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || fatal "required command not found: $1"
+}
+
+need uname
+need tar
+need mkdir
+# curl OR wget is fine — checked in download().
+
+detect_target() {
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64|aarch64) echo "aarch64-apple-darwin" ;;
+                x86_64)        echo "x86_64-apple-darwin" ;;
+                *) fatal "unsupported macOS architecture: $arch" ;;
+            esac
+            ;;
+        Linux)
+            case "$arch" in
+                x86_64|amd64)  echo "x86_64-linux-gnu" ;;
+                aarch64|arm64) echo "aarch64-linux-gnu" ;;
+                *) fatal "unsupported Linux architecture: $arch" ;;
+            esac
+            ;;
+        *)
+            fatal "unsupported OS: $os (this installer supports macOS and Linux)"
+            ;;
+    esac
+}
+
+download() {
+    url="$1"
+    dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$dest" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$dest" "$url"
+    else
+        fatal "need either curl or wget"
+    fi
+}
+
+resolve_version() {
+    if [ "$VERSION" != "latest" ]; then
+        echo "$VERSION"
+        return
+    fi
+    # GitHub's /releases/latest 302-redirects to the newest published (non-draft)
+    # release. Following the redirect without downloading tells us the tag.
+    need_curl=
+    command -v curl >/dev/null 2>&1 || need_curl="1"
+    if [ -n "$need_curl" ]; then
+        # Fallback: parse the API JSON. jq would be cleaner but we avoid it
+        # to keep the installer's dependency set minimal.
+        download "https://api.github.com/repos/${REPO}/releases/latest" /tmp/padz-latest.json
+        tag=$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' /tmp/padz-latest.json | head -1)
+        rm -f /tmp/padz-latest.json
+    else
+        tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+            "https://github.com/${REPO}/releases/latest" \
+            | sed 's|.*/tag/||')
+    fi
+    [ -n "$tag" ] || fatal "could not resolve latest release tag"
+    echo "$tag"
+}
+
+main() {
+    target=$(detect_target)
+    tag=$(resolve_version)
+    info "installing $BIN_NAME $tag for $target"
+
+    archive="${BIN_NAME}-${target}.tar.gz"
+    url="https://github.com/${REPO}/releases/download/${tag}/${archive}"
+
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    info "downloading $url"
+    download "$url" "${tmp}/${archive}"
+
+    info "extracting"
+    ( cd "$tmp" && tar -xzf "$archive" )
+
+    # The release tarball contains a single top-level directory with the
+    # binary inside: $BIN_NAME-$target/$BIN_NAME. Locate it either way.
+    bin_src=""
+    if [ -x "${tmp}/${BIN_NAME}" ]; then
+        bin_src="${tmp}/${BIN_NAME}"
+    else
+        bin_src=$(find "$tmp" -maxdepth 3 -type f -name "$BIN_NAME" -perm -u+x | head -1)
+    fi
+    [ -n "$bin_src" ] || fatal "did not find $BIN_NAME binary inside $archive"
+
+    bin_dir="${PREFIX}/bin"
+    mkdir -p "$bin_dir"
+    install -m 0755 "$bin_src" "${bin_dir}/${BIN_NAME}"
+    info "installed ${bin_dir}/${BIN_NAME}"
+
+    # Install shell completions if the binary supports it. padz's CLI is
+    # `<bin> completion install`; for other projects this may need tweaking
+    # or can simply be removed.
+    if "${bin_dir}/${BIN_NAME}" completion install 2>/dev/null; then
+        :  # success message already printed by padz
+    else
+        warn "could not auto-install shell completions; run \`${BIN_NAME} completion install\` manually if desired"
+    fi
+
+    # PATH hint if the install dir isn't already on $PATH.
+    case ":$PATH:" in
+        *":$bin_dir:"*) ;;
+        *)
+            warn "$bin_dir is not on your \$PATH. Add this to your shell profile:"
+            # shellcheck disable=SC2016  # literal $PATH is intended — user pastes this line into rc file
+            printf '\n    export PATH="%s:$PATH"\n\n' "$bin_dir" >&2
+            ;;
+    esac
+
+    info "done. try: $BIN_NAME --version"
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -76,22 +76,25 @@ resolve_version() {
         echo "$VERSION"
         return
     fi
-    # GitHub's /releases/latest 302-redirects to the newest published (non-draft)
-    # release. Following the redirect without downloading tells us the tag.
-    need_curl=
-    command -v curl >/dev/null 2>&1 || need_curl="1"
-    if [ -n "$need_curl" ]; then
-        # Fallback: parse the API JSON. jq would be cleaner but we avoid it
-        # to keep the installer's dependency set minimal.
-        download "https://api.github.com/repos/${REPO}/releases/latest" /tmp/padz-latest.json
-        tag=$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' /tmp/padz-latest.json | head -1)
-        rm -f /tmp/padz-latest.json
-    else
-        tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
-            "https://github.com/${REPO}/releases/latest" \
+    # GitHub's /releases/latest 302-redirects to /releases/tag/<tag>. We
+    # extract the tag from the redirect — no GitHub API calls (avoids
+    # unauthenticated rate limits).
+    url="https://github.com/${REPO}/releases/latest"
+    tag=""
+    if command -v curl >/dev/null 2>&1; then
+        tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$url" \
             | sed 's|.*/tag/||')
+    elif command -v wget >/dev/null 2>&1; then
+        # --max-redirect=0 makes wget print the Location header and exit
+        # non-zero (hence `|| true`); --server-response sends headers to
+        # stderr, which we capture.
+        tag=$(wget --max-redirect=0 --server-response --quiet -O /dev/null "$url" 2>&1 \
+            | awk 'tolower($1) == "location:" { print $2 }' \
+            | sed 's|.*/tag/||' \
+            | tr -d '\r' \
+            | head -1) || true
     fi
-    [ -n "$tag" ] || fatal "could not resolve latest release tag"
+    [ -n "$tag" ] || fatal "could not resolve latest release tag from $url"
     echo "$tag"
 }
 
@@ -124,7 +127,10 @@ main() {
 
     bin_dir="${PREFIX}/bin"
     mkdir -p "$bin_dir"
-    install -m 0755 "$bin_src" "${bin_dir}/${BIN_NAME}"
+    # cp + chmod rather than `install(1)`, which isn't in the base
+    # `need` checks and can be missing on minimal containers.
+    cp "$bin_src" "${bin_dir}/${BIN_NAME}"
+    chmod 0755 "${bin_dir}/${BIN_NAME}"
     info "installed ${bin_dir}/${BIN_NAME}"
 
     # Install shell completions if the binary supports it. padz's CLI is


### PR DESCRIPTION
## Summary

Two new distribution channels, completing the four-channel story (cargo / brew / install.sh / apt):

- **Debian packages** via `cargo-deb`. Every release produces `.deb` files for `amd64` and `arm64` and attaches them to the GitHub Release. `apt install ./padz_<version>-1_<arch>.deb` just works; completions land in `/usr/share/{bash-completion/completions,zsh/site-functions,fish/vendor_completions.d}` system-wide via the postinst maintainer script.
- **`install.sh`** at repo root. `curl -fsSL https://raw.githubusercontent.com/arthur-debert/padz/main/install.sh | sh` → resolves the latest release, detects platform, drops the binary into `~/.local/bin/`, runs `padz completion install`.

README's Installation section now lists all four channels.

## How the .deb build works

- `[package.metadata.deb]` block in `crates/padz/Cargo.toml` describes the package (assets, section, depends, extended description, etc.).
- Maintainer scripts live in `crates/padz/debian/`:
  - `postinst` runs `padz completion --shell X print` into the system completion dirs for each of bash/zsh/fish. We invoke the *installed* binary rather than shipping static scripts because clap_complete embeds the absolute binary path into the completion registration — that path is only known at install time.
  - `prerm` removes them on uninstall/upgrade.
- Build happens inside the existing `build-binaries` matrix for Linux targets — `cargo deb --no-build` reuses the freshly-built release binary instead of rebuilding. Artifacts upload as `padz-<arch>-deb`, and `finalize` attaches both `*.tar.gz` and `*.deb` to the Release.
- Gated behind a new env var `ENABLE_DEB: "true"`. Flip to `"false"` or delete the var when reusing the workflow in a project that doesn't want .debs.

## How install.sh works

POSIX sh. Four env vars at the top (`BIN_NAME`, `REPO`, `PREFIX`, `VERSION`) are the entire project-specific surface — change those and the script works for any crate whose release workflow follows the same `<bin>-<target>.tar.gz` naming. Detects macOS/Linux × arm/x86, resolves `latest` via GitHub's redirect (no `jq` dependency), downloads + extracts, installs, runs `padz completion install`, hints about `$PATH` if the install dir isn't already on it.

## Reusability summary (across this PR + prior two)

Copy to a new cargo project:
- `.github/workflows/release.yml` — edit the top `env:` block (~10 values)
- `.github/homebrew-formula.rb.tmpl`, `.github/render-homebrew-formula.py`
- `crates/<bin>/debian/{postinst,prerm}` (or top-level `debian/` for single-crate projects)
- `[package.metadata.deb]` block in Cargo.toml
- `install.sh` — edit the 4 vars at top

That's the whole template. One `HOMEBREW_TAP_TOKEN` secret per tap (shared across projects).

## Test plan

- [x] `cargo deb -p padz` locally on macOS: produces valid `.deb`, correct filesystem layout (`/usr/bin/padz` + `/usr/share/doc/padz/{README.md,CHANGELOG.md,copyright}`), postinst/prerm scripts embedded intact
- [x] `shellcheck install.sh` — clean
- [x] `install.sh` end-to-end against the real v1.4.1 release in a sandbox `HOME`/`PREFIX`: downloads the correct tarball, installs the binary, runs `padz completion install`, emits the PATH hint when the prefix isn't on PATH
- [x] `actionlint` clean on the updated workflow
- [ ] First real release post-merge — verify `.deb` artifacts appear on the Release, install-and-remove flow on a Linux box (I don't have one handy; happy to run in a Docker ubuntu container if wanted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)