### PR TITLE
fix(init): reject linking a project to itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- **Fixed**
+  - **`padz init --link` now rejects linking a project to itself.** Running `padz init --link .` (or pointing `--link` at the current project's own root) inside an already-initialized store would write `.padz/link` containing the project's own path, creating a self-loop. Subsequent `padz` invocations then failed with `Link target '…/.padz' is itself a link. Chained links are not supported.`, because the chain-detection check tripped on the very link file that had just been written. The link command now compares the canonicalized local and target `.padz/` paths up front and refuses with `Cannot link '…' to itself.` before writing anything.
+
 ## [1.8.0] - 2026-04-28
 
 - **Changed**

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -54,6 +54,16 @@ pub fn link(local_padz: &Path, target: &Path) -> Result<CmdResult> {
         target.join(".padz")
     };
 
+    // Reject linking a project to itself
+    if let Ok(local_canonical) = local_padz.canonicalize() {
+        if local_canonical == target_padz {
+            return Err(PadzError::Store(format!(
+                "Cannot link '{}' to itself.",
+                target_padz.display()
+            )));
+        }
+    }
+
     // Validate target has been initialized
     if !target_padz.join("active").exists() {
         return Err(PadzError::Store(format!(
@@ -174,6 +184,25 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("not been initialized"));
+    }
+
+    #[test]
+    fn test_link_rejects_self() {
+        let temp = TempDir::new().unwrap();
+
+        // Project initialized with its own .padz/
+        let project = temp.path().join("project-a");
+        let project_padz = project.join(".padz");
+        init_padz_dir(&project_padz);
+
+        // Linking the project to itself (e.g., `padz init --link .`) must fail
+        // before any link file is written, otherwise it creates a self-loop
+        // that later trips the chain-detection check on every invocation.
+        let result = link(&project_padz, &project);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("itself"));
+        assert!(!project_padz.join("link").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `padz init --link <target>` did not check whether `<target>` resolved to the same `.padz/` it was being run in. Running `padz init --link .` (or `--link <project-root>`) inside an already-initialized store wrote `.padz/link` containing the project's own path — a self-loop.
- Every subsequent `padz` invocation then failed with `Link target '…/.padz' is itself a link. Chained links are not supported.`, because `resolve_link()` saw the same `link` file at the resolved target and bailed via the chain-detection guard. The store became unusable until the user manually deleted `.padz/link`.
- `commands::init::link()` now canonicalizes the local `.padz/` and compares it to `target_padz` before any validation or write. If they match, it returns `Cannot link '…' to itself.` and writes nothing. New `test_link_rejects_self` covers the case alongside the existing chain-rejection test.

The chain check at `crates/padzapp/src/commands/init.rs:66` was passing for the self-loop case because no `link` file existed *yet* at write time — the file the chain-check would later trip on is the one this very call was about to write. Catching self-targets up front avoids creating it in the first place.

## Test plan

- [x] `cargo test -p padzapp --lib commands::init` — 7 passed including new `test_link_rejects_self`
- [x] `cargo test -p padzapp --lib` — full padzapp suite, 505 passed
- [x] Pre-commit hook (fmt + clippy + check + tests) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)