### PR TITLE
docs: add CLAUDE.md tooling adherence note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+## Tooling
+
+This repo follows the canonical tooling described in [`~/h/repo-all/tooling.lex`](../repo-all/tooling.lex). Short summary:
+
+- **Branch protection**: `main` is gated by the `main-branch-protection` ruleset — PRs are required and status checks must be green to merge.
+- **Copilot review**: `.github/workflows/copilot-review.yml` auto-triggers Copilot on every PR via the reusable workflow at [`arthur-debert/gh-dagentic`](https://github.com/arthur-debert/gh-dagentic). Do NOT pin the reusable to a SHA — same-owner reusables follow "fix once, propagate".
+- **Policy files** (`CODEOWNERS`, `dependabot.yml`, `copilot-instructions.md`, `pull_request_template.md`) are synced from `~/h/dotfiles/gh/templates/rust/`. Edit the source-of-truth template first when changes should propagate.
+- **Releases run in CI**: `scripts/release` triggers `.github/workflows/release.yml`. Local `cargo publish` is not the path. Crate publishes use `scripts/ci-publish-crate.sh` for tolerant retry behavior (handles re-runs of older rcs and post-partial-publish recovery).


### PR DESCRIPTION
## Summary

Adds a short `## Tooling` section to `CLAUDE.md` pointing at the canonical tooling doc (`~/h/repo-all/tooling.lex`) so any contributor or agent can immediately see what shape this repo follows: branch protection ruleset, Copilot review via gh-dagentic, policy-file source of truth, and CI-only release flow.

Same content landing simultaneously in dodot, padz, burgertocow, clapfig, standout — the canonical rust repos that previously lacked a CLAUDE.md.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — docs-only, no behavior change
- [x] Project umbrella check passes locally — N/A (docs only)
- [x] Tests added or updated for behavior changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)