### PR TITLE
chore(dependabot): group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      gh-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `groups: gh-actions: patterns: ["*"]` so Dependabot opens one combined PR per week instead of one per action. Aligns with the canonical template at arthur-debert/release.