### PR TITLE
feat(ci): adopt rust-ci.yml reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,48 +1,30 @@
 name: CI
 
+# Thin caller for the canonical reusable Rust CI workflow at
+# arthur-debert/release. Replaces the previously hand-rolled
+# rust-toolchain + cargo cache + cargo test + bats install +
+# live-tests/run-tests sequence.
+#
+# See docs/per-stack/rust-ci.md in arthur-debert/release for the
+# full input reference. dodot is the reference adopter.
+#
+# `binary-name: padz` causes the check job to build and upload
+# `padz-linux`; `bats: true` adds an e2e job that downloads it,
+# installs bats-core, and runs `bin/check-e2e` with PADZ_BIN
+# pointing at the workspace-relative binary path — matching what
+# live-tests/run-tests and the live-tests/*.bats suites expect.
+
 on:
   push:
-    branches:
-      - '**'
+    branches: ['**']
   pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Run tests
-        run: cargo test --all --locked
-
-      - name: Install bats
-        uses: bats-core/bats-action@4.0.0
-        with:
-          support-install: false
-          assert-install: false
-          detik-install: false
-          file-install: false
-
-      - name: Run live integration tests
-        # Route through the canonical bin/check-e2e runner (synced from
-        # arthur-debert/release `bats` Component). Discovery picks
-        # live-tests/run-tests automatically — see
-        # docs/per-component/bats.md in the release/ repo.
-        run: bin/check-e2e
+  ci:
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii
+    with:
+      binary-name: padz
+      bats: true


### PR DESCRIPTION
## Summary
- Replace hand-rolled ci.yml with a thin caller to `arthur-debert/release/.github/workflows/rust-ci.yml@take-iii`.
- Inputs: `binary-name: padz`, `bats: true` — the e2e job downloads `padz-linux` and exposes `PADZ_BIN` to the bats live-tests suite.
- dodot is the reference adopter; see release/'s `docs/per-stack/rust-ci.md`.

## Required-checks rename
Job names change from `test` to `ci / check` + `ci / e2e`. The ruleset is updated in the same sweep via `apply-ruleset --checks "ci / check,ci / e2e"`.

## Test plan
- [ ] `ci / check` (fmt + lint + tests + release build) goes green
- [ ] `ci / e2e` (bats live-tests via `bin/check-e2e`) goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)