### PR TITLE
feat: add canonical bin/build shim (take-iii)

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Canonical rust-cli build entry point. Same script local + CI.
+#
+# Runs `cargo build --release` for the current host target. Produces
+# binaries under `target/release/`. Matches what rust-cli.yml's
+# release-time build job does per matrix target (the workflow adds
+# `--target <T>` for cross-builds; locally you typically want the host
+# target, which cargo picks up by default).
+#
+# Usage:
+#   bin/build                      # cargo build --release (host target)
+#   bin/build --target <triple>    # cross-build to a specific target
+#   bin/build -p mypackage         # workspace member by name
+#   bin/build --features foo,bar   # build with specific features
+#   bin/build -- <extra cargo args>    # pass-through after `--`
+#
+# All args forward to `cargo build` verbatim; cargo handles its own
+# arg parsing (target, package, features, etc.).
+#
+# `bin/build` is the canonical release-build entry point — `--release`
+# is hardcoded. For a local debug build, invoke `cargo build` directly.
+#
+# CWD: respects the caller's working directory. Cargo resolves the
+# nearest Cargo.toml from CWD upward, matching cargo's own behavior.
+#
+# Source of truth: arthur-debert/release templates/rust/bin/build.
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "bin/build: cargo not found on \$PATH" >&2
+    echo "  install: https://rustup.rs (or your package manager)" >&2
+    exit 1
+fi
+
+exec cargo build --release "$@"


### PR DESCRIPTION
## Summary

Adds `bin/build` so this repo satisfies the strict pilot-running criterion per release/'s state contract.

## Why

`bin/done-check` (arthur-debert/release#178 / [PR #193](https://github.com/arthur-debert/release/pull/193)) reports this repo as *implemented* not *pilot-running* because `bin/build` was missing. The shim is the canonical take-iii rust-cli build entry point (`templates/rust/bin/build` in release/) — identical content to what `arthur-debert/simple-gal` ships today (the one rust-cli consumer that currently passes done-check strict).

## What

Single new file: `bin/build` (+x), 40-line shim that `exec`s `cargo build --release "$@"` after a cargo-present preflight. All cargo args pass through verbatim (`--target`, `-p`, `--features`, etc.). Matches what `rust-cli.yml@v1` does in CI's release-time build job; same script local + CI.

## Test plan

- [x] `bin/build --help` → cargo's own --help (preflight passes through)
- [ ] CI green
- [ ] After merge: `done-check --repo <this-repo>` flips to *pilot-running*

Refs arthur-debert/release#107 (take-iii / `bin/<verb>` canonicalization), arthur-debert/release#178 (done-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)