### PR TITLE
refactor: use canonical bats-harness for e2e runner

### DIFF
--- a/lib/bats-harness.bash
+++ b/lib/bats-harness.bash
@@ -1,1 +1,140 @@
-/Users/adebert/h/release/templates/components/bats/lib/bats-harness.bash
+#!/usr/bin/env bash
+# bats-harness.bash — Reusable lifecycle for BATS e2e test suites.
+# Synced to consumers via release-sync from arthur-debert/release.
+#
+# Source this in your test runner, then call lifecycle functions in
+# order. Each function does one thing; combine them to match your
+# project's needs.
+#
+# SUITE-LEVEL ISOLATION (padz pattern)
+# -------------------------------------
+#   source lib/bats-harness.bash
+#   harness_require_bats
+#   harness_set_root "$SCRIPT_DIR/.."
+#   harness_build "cargo build --bin myapp"
+#   harness_create_workspace
+#   harness_mkdir "data" "projects/a"
+#   harness_git_init "projects/a"
+#   export MY_BIN="$HARNESS_ROOT/target/debug/myapp"
+#   export MY_DATA="$HARNESS_WORKSPACE/data"
+#   harness_bats "$SCRIPT_DIR/tests" "$@"
+#
+# PER-TEST ISOLATION (helper.bash pattern)
+# -----------------------------------------
+#   source lib/bats-harness.bash
+#   harness_set_root "$BATS_TEST_DIRNAME/../.."
+#   setup()    { harness_create_workspace_notrap; cd "$HARNESS_WORKSPACE"; }
+#   teardown() { cd /; harness_cleanup; }
+#
+# SPLIT PHASES (server-in-the-middle)
+# ------------------------------------
+#   harness_build "go build ./cmd/myapp"
+#   harness_create_workspace
+#   start_my_server          # consumer-specific
+#   wait_for_health          # consumer-specific
+#   harness_bats "$DIR" "$@"
+#
+# EXPORTED VARIABLES
+# -------------------
+#   HARNESS_ROOT       — project root directory
+#   HARNESS_WORKSPACE  — isolated workspace (mktemp -d)
+
+# --- State ----------------------------------------------------------------
+
+HARNESS_ROOT=""
+HARNESS_WORKSPACE=""
+
+# --- Output ---------------------------------------------------------------
+
+if [[ -t 2 ]]; then
+  _harness_gray=$'\033[38;5;245m'
+  _harness_red=$'\033[0;31m'
+  _harness_nc=$'\033[0m'
+else
+  _harness_gray=""
+  _harness_red=""
+  _harness_nc=""
+fi
+
+_harness_status() {
+  printf '%s%s%s\n' "$_harness_gray" "$1" "$_harness_nc" >&2
+}
+
+_harness_error() {
+  printf '%s%s%s\n' "$_harness_red" "$1" "$_harness_nc" >&2
+}
+
+# --- Lifecycle functions --------------------------------------------------
+
+harness_require_bats() {
+  if ! command -v bats &>/dev/null; then
+    _harness_error "bats not found. Install with: brew install bats-core"
+    exit 1
+  fi
+}
+
+harness_set_root() {
+  HARNESS_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  export HARNESS_ROOT
+}
+
+harness_build() {
+  _harness_status "Building..."
+  if ! ( cd "$HARNESS_ROOT" && eval "$1" ); then
+    _harness_error "Build failed"
+    exit 1
+  fi
+}
+
+harness_create_workspace() {
+  HARNESS_WORKSPACE="$(mktemp -d)"
+  export HARNESS_WORKSPACE
+  _harness_status "Workspace: $HARNESS_WORKSPACE"
+  trap '_harness_exit_cleanup' EXIT INT TERM
+}
+
+_harness_exit_cleanup() {
+  local rc=$?
+  [[ -n "${HARNESS_WORKSPACE:-}" ]] && rm -rf "$HARNESS_WORKSPACE"
+  exit $rc
+}
+
+harness_create_workspace_notrap() {
+  HARNESS_WORKSPACE="$(mktemp -d)"
+  export HARNESS_WORKSPACE
+}
+
+harness_cleanup() {
+  if [[ -n "${HARNESS_WORKSPACE:-}" ]]; then
+    rm -rf "$HARNESS_WORKSPACE"
+    HARNESS_WORKSPACE=""
+  fi
+}
+
+harness_mkdir() {
+  for dir in "$@"; do
+    mkdir -p "$HARNESS_WORKSPACE/$dir"
+  done
+}
+
+harness_git_init() {
+  for dir in "$@"; do
+    ( cd "$HARNESS_WORKSPACE/$dir" && git init --quiet )
+  done
+}
+
+harness_bats() {
+  local tests_dir="$1"
+  shift
+  _harness_status "Running tests..."
+  echo >&2
+  if [[ $# -eq 0 ]]; then
+    bats "$tests_dir"
+  elif [[ -f "$tests_dir/$1" ]]; then
+    local first="$tests_dir/$1"
+    shift
+    bats "$first" "$@"
+  else
+    bats "$@"
+  fi
+}

--- a/lib/bats-harness.bash
+++ b/lib/bats-harness.bash
@@ -1,0 +1,1 @@
+/Users/adebert/h/release/templates/components/bats/lib/bats-harness.bash

--- a/live-tests/run-tests
+++ b/live-tests/run-tests
@@ -1,121 +1,51 @@
 #!/usr/bin/env bash
-# =============================================================================
 # PADZ BATS TEST RUNNER
-# =============================================================================
 #
-# PURPOSE
-# -------
-# Runs the Bats test suite in an isolated live-test environment. This ensures
-# tests run against the real padz binary with proper fixtures, without touching
-# user data.
+# Runs the Bats test suite in an isolated live-test environment.
+# Uses the canonical bats-harness from release/.
 #
-# HOW IT WORKS
-# ------------
-# 1. Builds a fresh padz binary
-# 2. Creates an isolated workspace (OS temp dir)
-# 3. Sets up the directory structure (global-data/, projects/project-a/)
-# 4. Runs the base fixture to populate test data
-# 5. Exports environment variables for tests
-# 6. Runs bats with forwarded arguments
-# 7. Cleans up on exit
-#
-# USAGE
-# -----
+# Usage:
 #   live-tests/run-tests              # Run all tests
 #   live-tests/run-tests smoke.bats   # Run specific test file
 #   live-tests/run-tests -t "search"  # Run tests matching pattern
 #   live-tests/run-tests --tap        # TAP output format
 #   live-tests/run-tests -j 4         # Parallel execution
 #
-# ENVIRONMENT VARIABLES (available in tests)
-# ------------------------------------------
-#   PADZ_BIN          - Path to the built padz binary
-#   WORKSPACE         - Root of the test workspace
-#   PADZ_GLOBAL_DATA  - Where global pads are stored
-#   PROJECT_A         - Path to project-a directory (git repo)
-#
-# =============================================================================
+# Environment variables available in tests:
+#   PADZ_BIN          — path to the built padz binary
+#   WORKSPACE         — root of the test workspace
+#   PADZ_GLOBAL_DATA  — where global pads are stored
+#   PROJECT_A         — path to project-a directory (git repo)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-TESTS_DIR="${SCRIPT_DIR}/tests"
+source "$SCRIPT_DIR/../lib/bats-harness.bash"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-GRAY='\033[38;5;245m'
-NC='\033[0m'
+harness_require_bats
+harness_set_root "$SCRIPT_DIR/.."
 
-# Check for bats
-if ! command -v bats &>/dev/null; then
-    echo -e "${RED}Error: bats not found. Install with: brew install bats-core${NC}" >&2
-    exit 1
-fi
+harness_build 'cargo build --bin padz 2>&1 | grep -E "Compiling|Finished|error" || true'
 
-# Build fresh binary
-PADZ_BIN="${PROJECT_ROOT}/target/debug/padz"
-echo -e "${GRAY}Building padz...${NC}"
-if ! (cd "${PROJECT_ROOT}" && cargo build --bin padz 2>&1 | grep -E "Compiling|Finished|error" || true); then
-    echo -e "${RED}Build failed${NC}" >&2
-    exit 1
-fi
-[[ ! -x "${PADZ_BIN}" ]] && { echo -e "${RED}Binary not found${NC}" >&2; exit 1; }
+PADZ_BIN="$HARNESS_ROOT/target/debug/padz"
+[[ -x "$PADZ_BIN" ]] || { _harness_error "Binary not found: $PADZ_BIN"; exit 1; }
 
-# Create workspace in OS temp directory
-WORKSPACE="$(mktemp -d)"
-echo -e "${GRAY}Workspace: ${WORKSPACE}${NC}"
+harness_create_workspace
+harness_mkdir "projects/project-a" "global-data"
+harness_git_init "projects/project-a"
 
-cleanup() {
-    local exit_code=$?
-    rm -rf "${WORKSPACE}"
-    exit $exit_code
-}
-trap cleanup EXIT INT TERM
-
-# Set up directory structure
-mkdir -p "${WORKSPACE}/projects/project-a"
-mkdir -p "${WORKSPACE}/global-data"
-
-# Initialize git in project-a
-(cd "${WORKSPACE}/projects/project-a" && git init --quiet)
-
-# Export environment for tests
 export PADZ_BIN
-export WORKSPACE
-export PADZ_GLOBAL_DATA="${WORKSPACE}/global-data"
-export PROJECT_A="${WORKSPACE}/projects/project-a"
+export WORKSPACE="$HARNESS_WORKSPACE"
+export PADZ_GLOBAL_DATA="$HARNESS_WORKSPACE/global-data"
+export PROJECT_A="$HARNESS_WORKSPACE/projects/project-a"
 export EDITOR=true
-export BATS_LIB_PATH="${SCRIPT_DIR}/lib"
+export BATS_LIB_PATH="$SCRIPT_DIR/lib"
 
-# Run base fixture silently to populate test data
-echo -e "${GRAY}Setting up fixtures...${NC}"
+_harness_status "Setting up fixtures..."
 (
-    cd "${WORKSPACE}"
-
-    # Define padz function for fixture
-    padz() { "${PADZ_BIN}" "$@"; }
-
-    # Source the fixture script directly (it's designed to be sourced)
-    # Redirect all output to /dev/null for clean test output
-    source "${SCRIPT_DIR}/base-fixture.sh" >/dev/null 2>&1
+    cd "$HARNESS_WORKSPACE"
+    padz() { "$PADZ_BIN" "$@"; }
+    source "$SCRIPT_DIR/base-fixture.sh" >/dev/null 2>&1
 )
 
-# Run bats
-echo -e "${GRAY}Running tests...${NC}\n"
-
-# Default to running all tests in the tests directory
-if [[ $# -eq 0 ]]; then
-    bats "${TESTS_DIR}"
-else
-    # Check if first arg is a file in tests dir
-    if [[ -f "${TESTS_DIR}/$1" ]]; then
-        first_arg="${TESTS_DIR}/$1"
-        shift
-        bats "$first_arg" "$@"
-    else
-        bats "$@"
-    fi
-fi
+harness_bats "$SCRIPT_DIR/tests" "$@"


### PR DESCRIPTION
## Summary

- Replaces 96 lines of ad-hoc build/isolate/fixture/cleanup shell in `run-tests` with 27 lines sourcing the shared `bats-harness.bash` from `release/`
- Zero changes to `.bats` files or test helpers — same env contract (`PADZ_BIN`, `WORKSPACE`, `PADZ_GLOBAL_DATA`, `PROJECT_A`, `EDITOR`)
- `lib/bats-harness.bash` is a symlink to `release/` during dev; release-sync replaces it later

Refs arthur-debert/release#251

## Test plan

- [x] `live-tests/run-tests` — all 136 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)