### PR TITLE
chore: lint cleanup for strict shell-quality gate

### DIFF
--- a/PADZ.md
+++ b/PADZ.md
@@ -1,4 +1,4 @@
-[] PADZ - Command-Line Note Taking
+# PADZ - Command-Line Note Taking
 
 PADZ is a fast, context-aware command-line note-taking tool designed for developers who want quick pad notes without leaving their terminal.
 
@@ -21,6 +21,7 @@ PADZ helps you quickly create, manage, and find pad notes (called "pad") directl
 ### pad
 
 A "pad" is a single note with:
+
 - A **title**: Short description of the note
 - **Content**: The actual note content
 - **Metadata**: Creation time, update time, project association
@@ -53,6 +54,7 @@ PADZ uses two separate discovery algorithms:
 ### Indexing
 
 pad are indexed by their display order (1, 2, 3, ...). The index changes as you create, delete, or pin notes:
+
 - **Pinned notes** appear first with prefix `p1`, `p2`, etc.
 - **Regular notes** follow, numbered sequentially
 - **Deleted notes** (when shown) appear with prefix `d1`, `d2`, etc.
@@ -107,10 +109,12 @@ Aliases: `new`, `n`, `c`
 Create a new pad. If no content is piped, opens `$EDITOR`.
 
 **Flags:**
+
 - `-g, --global`: Create in global scope
 - `-t, --title`: Specify title explicitly
 
 **Examples:**
+
 ```bash
 padz create                              # Opens editor, prompts for title
 padz create "Shopping list"              # Opens editor with title set
@@ -121,6 +125,7 @@ padz create --global "Global note"       # Create in global scope
 ```
 
 **Shortcuts:**
+
 - Just `padz "Some text"` creates a new pad
 - Anything that isn't a recognized command is treated as a create
 
@@ -133,6 +138,7 @@ Aliases: `ls`
 List all pad in current scope.
 
 **Flags:**
+
 - `-g, --global`: Show only global pad
 - `-s, --search <term>`: Search for pad containing term
 - `--deleted`: Show only soft-deleted pad
@@ -140,7 +146,8 @@ List all pad in current scope.
 - `--all`: Show all pad (active, archived, and deleted) grouped with section headers
 
 **Output Format:**
-```
+
+```text
 p1  📌 10 minutes ago  Important note (pinned)
 p2  📌 1 hour ago      Another pinned note
 1   2 hours ago       Regular note
@@ -149,6 +156,7 @@ p2  📌 1 hour ago      Another pinned note
 
 **Search Ranking:**
 When using `-s` or `--search`, results are ranked by:
+
 1. Exact title matches
 2. Partial title matches
 3. Content matches
@@ -156,6 +164,7 @@ When using `-s` or `--search`, results are ranked by:
 5. Original creation order
 
 **Examples:**
+
 ```bash
 padz list                    # List project pad
 padz ls                      # Same (alias)
@@ -174,10 +183,12 @@ Aliases: `v`
 View the content of a pad in your terminal.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 - `--pager`: Use system pager (like `less`)
 
 **Examples:**
+
 ```bash
 padz view 1      # View pad #1
 padz v 1         # Same (alias)
@@ -193,10 +204,12 @@ padz view d1     # View deleted pad #1 (if using --deleted flag)
 Show first and last few lines of a pad.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 - `-n, --lines <int>`: Number of lines from start/end (default: 3)
 
 **Examples:**
+
 ```bash
 padz peek 1       # Show first/last 3 lines
 padz peek 1 -n 5  # Show first/last 5 lines
@@ -211,10 +224,12 @@ Aliases: `o`, `e`
 Open a pad in `$EDITOR`.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 - `--lazy`: Launch editor and exit immediately (non-blocking)
 
 **Examples:**
+
 ```bash
 padz open 1       # Edit pad #1
 padz o 1          # Same (alias)
@@ -232,9 +247,11 @@ Aliases: `rm`, `d`, `del`
 Soft-delete a pad. It can be restored later.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 
 **Examples:**
+
 ```bash
 padz delete 1     # Soft-delete pad #1
 padz rm 1         # Same (alias)
@@ -242,6 +259,7 @@ padz d 1          # Same (alias)
 ```
 
 **Note:** Soft-deleted pad are:
+
 - Hidden from normal listings
 - Visible with `padz ls --deleted` or `padz ls --all`
 - Auto-cleaned after 7 days by default
@@ -257,12 +275,14 @@ Aliases: `undelete`, `recover`
 Restore soft-deleted pad back to active state.
 
 **Flags:**
+
 - `-g, --global`: Restore from global scope
 - `-p, --project <name>`: Restore from specific project
 - `-a, --all`: Restore from all projects
 - `--newer-than <duration>`: Only restore items deleted less than duration ago (e.g., `1h`, `30m`)
 
 **Examples:**
+
 ```bash
 padz restore d1                # Restore specific deleted pad
 padz restore d1 d2 d3          # Restore multiple pad
@@ -277,12 +297,14 @@ Aliases: `purge`
 Permanently delete soft-deleted pad from disk.
 
 **Flags:**
+
 - `-g, --global`: Flush from global scope
 - `-p, --project <name>`: Flush from specific project
 - `-a, --all`: Flush from all projects
 - `--older-than <duration>`: Only flush items deleted more than duration ago (e.g., `7d`, `24h`)
 
 **Examples:**
+
 ```bash
 padz flush                      # Flush all deleted pad (current scope)
 padz flush d1                   # Flush specific pad
@@ -301,12 +323,14 @@ padz flush --all                # Flush from all projects
 Search through pad titles and content using regular expressions.
 
 **Flags:**
+
 - `-g, --global`: Search only global pad
 - `--deleted`: Search only soft-deleted pad
 - `--archived`: Search only archived pad
 - `--all`: Search across all pad (active, archived, and deleted) grouped with section headers
 
 **Examples:**
+
 ```bash
 padz search "my term"           # Search for "my term"
 padz search my term             # Same (spaces automatically joined)
@@ -328,14 +352,17 @@ Aliases: `p`
 Pin one or more pad to the top of the list.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 
 **Limits:**
+
 - Maximum 5 pad can be pinned at once
 - Pinned pad appear with `p1`, `p2`, `p3`, `p4`, `p5` prefixes
 - Pinned pad always appear first in listings
 
 **Examples:**
+
 ```bash
 padz pin 1         # Pin pad #1
 padz pin 1 3 5     # Pin multiple pad
@@ -349,9 +376,11 @@ Aliases: `u`
 Unpin pad.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 
 **Examples:**
+
 ```bash
 padz unpin p1      # Unpin pinned pad #1
 padz unpin p1 p2   # Unpin multiple pinned pad
@@ -367,9 +396,11 @@ Aliases: `clean`
 Cleanup pad older than specified number of days.
 
 **Flags:**
+
 - `-d, --days <int>`: Delete pad older than this many days (default: 30)
 
 **Examples:**
+
 ```bash
 padz cleanup           # Delete pad older than 30 days
 padz cleanup -d 90     # Delete pad older than 90 days
@@ -383,6 +414,7 @@ padz clean -d 7        # Delete pad older than 7 days
 Delete all pad in the current scope.
 
 **Examples:**
+
 ```bash
 padz nuke              # Delete all pad in current project (with confirmation)
 padz nuke --global     # Delete all global pad (with confirmation)
@@ -399,9 +431,11 @@ Aliases: `cp`
 Copy pad content to system clipboard.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 
 **Examples:**
+
 ```bash
 padz copy 1        # Copy pad #1 to clipboard
 padz cp 1          # Same (alias)
@@ -413,9 +447,11 @@ padz copy p1       # Copy pinned pad #1
 Get the full filesystem path to a pad file.
 
 **Flags:**
+
 - `-g, --global`: Operate on global pad
 
 **Examples:**
+
 ```bash
 padz path 1        # Get path to pad #1
 padz path p1       # Get path to pinned pad #1
@@ -430,14 +466,17 @@ cat $(padz path 1) | grep TODO
 Export pad to files in a directory.
 
 **Flags:**
+
 - `-g, --global`: Export global pad
 - `--format <string>`: Export format - `txt` or `markdown` (default: `txt`)
 
 **Output:**
+
 - Creates directory: `padz-export-YYYY-MM-DD-HH-mm/`
 - Filename format: `<index>-<title>.<extension>`
 
 **Examples:**
+
 ```bash
 padz export                     # Export all pad as .txt
 padz export --format markdown   # Export all as .md
@@ -455,6 +494,7 @@ These flags work with all commands:
 - `-v, -vv, -vvv`: Increase verbosity for debugging
 
 **Examples:**
+
 ```bash
 padz list --format json      # Output as JSON
 padz list --format plain     # Plain text output (no colors)
@@ -466,14 +506,16 @@ padz list -vv                # Debug output
 
 ### Data Storage
 
-The data storage is a directory. 
+The data storage is a directory.
 In it, we have each pad in a file,named pad-{UUID}.(txt | md)
 and a data.json file that lists all files and their metadata (uuid, title , created, deletion pinning, etc)
 
 this is the .padz directory. It's either in project's directory or uses the xdg data path for the global (user wide ) scope
+
 ### Auto-Cleanup
 
 PADZ automatically cleans up soft-deleted pad:
+
 - Runs in the background on most commands
 - Permanently deletes pad that have been soft-deleted for > 7 days
 - Non-blocking (won't slow down your commands)
@@ -487,6 +529,7 @@ Commands that modify pad (create, delete, pin, etc.) automatically show the upda
 - `--silent`: Don't show list after command
 
 **Example:**
+
 ```bash
 padz create "Note" --silent   # Create but don't list
 padz delete 1 --verbose       # Delete and show updated list (default)
@@ -497,28 +540,33 @@ padz delete 1 --verbose       # Delete and show updated list (default)
 PADZ has smart command resolution for convenience:
 
 1. **No arguments**: Runs `list`
+
    ```bash
    padz          # Same as: padz list
    ```
 
 2. **Single integer**: Runs `view` (or `open`, configurable)
+
    ```bash
    padz 1        # Same as: padz view 1
    ```
 
 3. **Starts with flag**: Assumed to be for `list`
+
    ```bash
    padz -g       # Same as: padz list -g
    padz -s "foo" # Same as: padz list -s "foo"
    ```
 
 4. **Known command**: Runs that command
+
    ```bash
    padz create
    padz search
    ```
 
 5. **Unknown text**: Assumed to be `create` with title
+
    ```bash
    padz "My note"    # Same as: padz create "My note"
    ```
@@ -528,21 +576,19 @@ This means you rarely need to type `create` or `list` explicitly.
 The key thing about this, called naked mode (no sub command specified) is how to integrate with the cli library.
 we want to avoid haveing to parse as much as possible.
 
-so the right way to do is; 
-execute the command as it. if it has no subcommand , the library will generate an error. 
+so the right way to do is;
+execute the command as it. if it has no subcommand , the library will generate an error.
 intercep the error. if it's a no command given error, now you will figure out what needs to be done.
 use the parsed data from the cli to figure out if you have no args (list), an int(view) and so on.
 
 one you do, inject the right string into the user generated input, then re ran the injected command through the cli library.
-
-
-
 
 ## Output Format
 
 ### Terminal Format (default)
 
 Colorful, human-readable output with:
+
 - Relative timestamps ("10 minutes ago", "3 days ago")
 - Pin indicators (📌 for pinned items)
 - Syntax highlighting for content
@@ -551,10 +597,12 @@ Colorful, human-readable output with:
 ### Plain Format
 
 Plain text without colors or special formatting. Useful for:
+
 - Piping to other commands
 - Logging
 - Scripts
 (detected automatically)
+
 ```bash
 padz list --format plain
 ```
@@ -562,6 +610,7 @@ padz list --format plain
 ### JSON Format
 
 Machine-readable JSON output. Each pad is a JSON object with fields:
+
 - `id`: UUID
 - `project`: Project name
 - `title`: pad title
@@ -584,12 +633,14 @@ padz list --format json | jq '.[0].title'
 PADZ maintains detailed logs for debugging:
 
 **Console Logging:**
+
 - Controlled by `-v` flags
 - `-v`: Info level
 - `-vv`: Debug level
 - `-vvv`: Trace level
 
 **File Logging:**
+
 - Always enabled, logs everything
 - JSON format for structured parsing
 - Location:
@@ -598,6 +649,7 @@ PADZ maintains detailed logs for debugging:
   - **Windows**: `%LOCALAPPDATA%\padz\padz.log`
 
 **Finding the log file:**
+
 ```bash
 padz ls -vv
 # Look for: "Logger initialized with dual output log_file=..."
@@ -608,9 +660,11 @@ padz ls -vv
 ### Quick Capture
 
 Create a pad with content in one line:
+
 ```bash
 echo "TODO: Fix the auth bug" | padz "Auth Bug"
 ```
+
 ### Testing Environment
 
 PADZ includes a testing environment for safe experimentation:
@@ -629,6 +683,7 @@ exit
 ```
 
 The test environment provides:
+
 - Isolated HOME directory
 - Separate XDG directories
 - Fresh padz data store
@@ -638,11 +693,13 @@ The test environment provides:
 ### Index confusion?
 
 Remember that indexes are display-only and change:
+
 - Pinning changes indexes
 - Deleting changes indexes
 - Creating new pad changes indexes
 
 If you need stable references, use:
+
 ```bash
 padz list --format json | jq -r '.[].id'   # Get UUIDs
 ```
@@ -655,7 +712,6 @@ padz list --format json | jq -r '.[].id'   # Get UUIDs
 - **No Encryption**: pad are stored as plain text
 - **Pin Limit**: Maximum 5 pinned pad
 
-
 ## Understanding Indexes
 
 PADZ uses **Display Indexes** (e.g., `1`, `p1`, `d1`) to make commands easy to type. It's much faster to type `padz copy 3` than `padz copy 550e8400-e29b-41d4-a716-446655440000`. However, it is crucial to understand how these indexes are calculated to avoid mistakes.
@@ -666,6 +722,7 @@ A naive approach would be to number items based on the *current view*. If you se
 
 **The Danger:**
 Imagine you have these notes in your main list:
+
 1. `Buy Milk`
 2. `Fix critical bug`
 3. `Call Mom`
@@ -678,17 +735,19 @@ But if `padz` is stateless (which it is), `padz delete 1` would delete the *actu
 To solve this, PADZ indexes are **stable across views**. The index you see in a search result is the same index the item holds in the full, unfiltered list.
 
 **How it works:**
+
 1. PADZ loads **all** active notes for the current scope (the "Default View").
 2. It assigns indexes (`1`, `2`, `3`...) based on this full list.
 3. When you run a search, it filters the list but **preserves the original indexes**.
 
 **Example:**
-*   **Full List:**
-    *   `1`: Buy Milk
-    *   `2`: Fix critical bug
-    *   `3`: Call Mom
-*   **Search "critical":**
-    *   Result: `2`: Fix critical bug (It retains index #2)
+
+- **Full List:**
+  - `1`: Buy Milk
+  - `2`: Fix critical bug
+  - `3`: Call Mom
+- **Search "critical":**
+  - Result: `2`: Fix critical bug (It retains index #2)
 
 This ensures that `padz delete 2` always acts on "Fix critical bug", regardless of whether you are looking at the full list or a search result.
 
@@ -696,12 +755,12 @@ This ensures that `padz delete 2` always acts on "Fix critical bug", regardless 
 
 Indexes are divided into three stable "buckets":
 
-1.  **Pinned (`p1`, `p2`...)**:
-    *   Pinned items are always processed first.
-    *   They have their own independent numbering sequence.
-2.  **Regular (`1`, `2`...)**:
-    *   The standard list of active notes.
-    *   Numbered sequentially based on creation time (or configured sort order).
-3.  **Deleted (`d1`, `d2`...)**:
-    *   Soft-deleted items, only visible when using flags like `--deleted` or `--all`.
-    *   They form a separate list with its own sequence, ensuring they don't shift the indexes of active notes.
+1. **Pinned (`p1`, `p2`...)**:
+    - Pinned items are always processed first.
+    - They have their own independent numbering sequence.
+2. **Regular (`1`, `2`...)**:
+    - The standard list of active notes.
+    - Numbered sequentially based on creation time (or configured sort order).
+3. **Deleted (`d1`, `d2`...)**:
+    - Soft-deleted items, only visible when using flags like `--deleted` or `--all`.
+    - They form a separate list with its own sequence, ensuring they don't shift the indexes of active notes.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ eval "$(padz completions zsh)"
 ```
 
 Completions include:
+
 - All commands and their aliases (`view`/`v`, `edit`/`e`, etc.)
 - Command options (`--global`, `--deleted`, `--peek`, etc.)
 - Pad indexes (`1`, `2`, `p1`, `d1`, etc.)

--- a/crates/padzapp/README.md
+++ b/crates/padzapp/README.md
@@ -12,6 +12,7 @@ This crate provides the UI-agnostic business logic for padz. It includes:
 ## Architecture
 
 Everything in this crate is UI-agnostic:
+
 - Functions take normal Rust arguments and return normal Rust types
 - No stdout/stderr writes
 - No `std::process::exit` calls

--- a/live-tests/demo_flow.sh
+++ b/live-tests/demo_flow.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
 # Demo Flow: Create, Pin, Delete, List
 
 echo "--- Creating 3 pads ---"
@@ -5,16 +7,16 @@ padz n --no-editor "First Note" "Content of first note"
 padz n --no-editor "Second Note" "Content of second note"
 padz n --no-editor "Third Note" "Content of third note"
 
-echo "\n--- Listing all pads (Creation Order) ---"
+printf '\n--- Listing all pads (Creation Order) ---\n'
 padz ls
 
-echo "\n--- Pinning the Third Note (Index 3) ---"
+printf '\n--- Pinning the Third Note (Index 3) ---\n'
 padz p 3
 
-echo "\n--- Listing pads (Pinned should be first) ---"
+printf '\n--- Listing pads (Pinned should be first) ---\n'
 padz ls
 
-echo "\n--- Deleting the First Note (Index 1) ---"
+printf '\n--- Deleting the First Note (Index 1) ---\n'
 # Note: After pinning 3, the list order might be: p1(Third), 1(First), 2(Second).
 # We need to be careful about indexes.
 # The user uses DISPLAY indexes.
@@ -23,41 +25,41 @@ echo "\n--- Deleting the First Note (Index 1) ---"
 # So I delete 1.
 padz rm 1
 
-echo "\n--- Listing pads (First note gone, Third pinned, Second remains) ---"
+printf '\n--- Listing pads (First note gone, Third pinned, Second remains) ---\n'
 padz ls
 
-echo "\n--- Listing ALL pads (including deleted) ---"
+printf '\n--- Listing ALL pads (including deleted) ---\n'
 padz ls --deleted
 
-echo "\n--- Purging the deleted note ---"
+printf '\n--- Purging the deleted note ---\n'
 echo "Y" | padz purge
 
-echo "\n--- Listing deleted pads (Should be empty) ---"
+printf '\n--- Listing deleted pads (Should be empty) ---\n'
 padz ls --deleted
 
-echo "\n--- Creating a file for Import test ---"
-echo "Imported Title\nImported Content" > import_test.txt
+printf '\n--- Creating a file for Import test ---\n'
+printf 'Imported Title\nImported Content\n' > import_test.txt
 
-echo "\n--- Importing the file ---"
+printf '\n--- Importing the file ---\n'
 padz import import_test.txt
 
-echo "\n--- Listing pads (Should include Imported Title) ---"
+printf '\n--- Listing pads (Should include Imported Title) ---\n'
 padz ls
 
-echo "\n--- Exporting pads ---"
+printf '\n--- Exporting pads ---\n'
 padz export
 
-echo "\n--- Verifying Export ---"
+printf '\n--- Verifying Export ---\n'
 ls -lh padz-*.tar.gz
 # Verify archive content contains the imported pad (filename matches sanitized title)
 tar -tzf padz-*.tar.gz | grep "Imported Title"
 
-echo "\n--- Doctor Test: Creating inconsistency ---"
+printf '\n--- Doctor Test: Creating inconsistency ---\n'
 # Create consistency by writing a file manually that isn't in DB
-echo "Orphan Pad\nOrphan Content" > .padz/pad-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.txt
+printf 'Orphan Pad\nOrphan Content\n' > .padz/pad-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.txt
 
-echo "\n--- Running Doctor ---"
+printf '\n--- Running Doctor ---\n'
 padz doctor
 
-echo "\n--- Listing pads (Should include Orphan Pad) ---"
+printf '\n--- Listing pads (Should include Orphan Pad) ---\n'
 padz ls

--- a/live-tests/list-all-scopes.sh
+++ b/live-tests/list-all-scopes.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
 # List pads from both global and project scopes
 # Run after base-fixture.sh to see the fixture data
 
@@ -6,6 +8,6 @@ padz -g list
 
 echo ""
 echo "=== Project Pads (project-a) ==="
-cd projects/project-a
+cd projects/project-a || exit
 padz list
-cd ../..
+cd ../.. || exit

--- a/live-tests/search_test.sh
+++ b/live-tests/search_test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
 printf "Meeting Notes\n\nDiscussed the roadmap for Q4. Important topics included search UI.\n" > meeting.md
 printf "Todo List\n\n1. Buy milk\n2. Fix search bug\n3. Review PR\n" > todo.md
 printf "Rust Tips\n\nUse Vec::with_capacity for optimization.\nIterators are lazy.\n" > rust.md

--- a/live-tests/smart_create.sh
+++ b/live-tests/smart_create.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env zsh
+# shellcheck shell=bash
 set -e
 
 echo "--- Starting Smart Create Tests ---"
@@ -28,7 +29,8 @@ echo '#!/bin/sh' > ./bin/fake-editor
 chmod +x ./bin/fake-editor
 
 # Add to PATH and set EDITOR
-export PATH="$(pwd)/bin:$PATH"
+PATH="$(pwd)/bin:$PATH"
+export PATH
 export EDITOR="fake-editor"
 
 echo "Running padz create (from clipboard)..."

--- a/live-tests/test_basic.sh
+++ b/live-tests/test_basic.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+# shellcheck shell=bash
 # Basic Padz Verification
 
 # Create a pad

--- a/live-tests/test_nested_repo_detection.sh
+++ b/live-tests/test_nested_repo_detection.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+# shellcheck shell=bash
 # Test nested repo detection: child repo should use parent's .padz
 
 set -e
@@ -33,7 +34,11 @@ echo "Step 3: Verify from child repo we can see parent's pads"
 padz ls
 
 PAD_COUNT=$(padz ls 2>/dev/null | grep -c "Parent Pad" || echo 0)
-[[ "$PAD_COUNT" -eq "1" ]] && echo "SUCCESS: Child repo sees parent's pad" || { echo "FAILURE: Child repo cannot see parent's pad (count=$PAD_COUNT)"; exit 1; }
+if [[ "$PAD_COUNT" -eq "1" ]]; then
+    echo "SUCCESS: Child repo sees parent's pad"
+else
+    echo "FAILURE: Child repo cannot see parent's pad (count=$PAD_COUNT)"; exit 1
+fi
 
 echo ""
 echo "Step 4: Create a pad from child repo (should go to parent's .padz)"
@@ -41,14 +46,26 @@ padz n --no-editor "Child Pad"
 padz ls
 
 PAD_COUNT=$(padz ls 2>/dev/null | grep -c "Pad" || echo 0)
-[[ "$PAD_COUNT" -eq "2" ]] && echo "SUCCESS: Pads created from child go to parent's .padz" || { echo "FAILURE: Expected 2 pads, got $PAD_COUNT"; exit 1; }
+if [[ "$PAD_COUNT" -eq "2" ]]; then
+    echo "SUCCESS: Pads created from child go to parent's .padz"
+else
+    echo "FAILURE: Expected 2 pads, got $PAD_COUNT"; exit 1
+fi
 
 echo ""
 echo "Step 5: Verify pads are stored in parent's .padz, not child"
-[[ ! -d ".padz" ]] && echo "SUCCESS: No .padz in child repo" || { echo "FAILURE: .padz directory was created in child repo"; exit 1; }
+if [[ ! -d ".padz" ]]; then
+    echo "SUCCESS: No .padz in child repo"
+else
+    echo "FAILURE: .padz directory was created in child repo"; exit 1
+fi
 
 cd ..
-[[ -d ".padz" ]] && echo "SUCCESS: .padz exists in parent repo" || { echo "FAILURE: .padz not found in parent repo"; exit 1; }
+if [[ -d ".padz" ]]; then
+    echo "SUCCESS: .padz exists in parent repo"
+else
+    echo "FAILURE: .padz not found in parent repo"; exit 1
+fi
 
 echo ""
 echo "Step 6: Test deeply nested repos"
@@ -59,7 +76,11 @@ echo "Created grandchild-repo with .git"
 
 padz n --no-editor "Grandchild Pad"
 PAD_COUNT=$(padz ls 2>/dev/null | grep -c "Pad" || echo 0)
-[[ "$PAD_COUNT" -eq "3" ]] && echo "SUCCESS: Deeply nested repos also use ancestor's .padz" || { echo "FAILURE: Expected 3 pads from grandchild, got $PAD_COUNT"; exit 1; }
+if [[ "$PAD_COUNT" -eq "3" ]]; then
+    echo "SUCCESS: Deeply nested repos also use ancestor's .padz"
+else
+    echo "FAILURE: Expected 3 pads from grandchild, got $PAD_COUNT"; exit 1
+fi
 
 cd ../..
 
@@ -74,7 +95,11 @@ padz n --no-editor "Independent Pad"
 INDEPENDENT_COUNT=$(padz ls 2>/dev/null | grep -c "Independent Pad" || echo 0)
 TOTAL_COUNT=$(padz ls 2>/dev/null | grep -c "Pad" || echo 0)
 
-[[ "$INDEPENDENT_COUNT" -eq "1" && "$TOTAL_COUNT" -eq "1" ]] && echo "SUCCESS: Child with own .padz is independent" || { echo "FAILURE: Expected only 1 independent pad, got total=$TOTAL_COUNT independent=$INDEPENDENT_COUNT"; exit 1; }
+if [[ "$INDEPENDENT_COUNT" -eq "1" && "$TOTAL_COUNT" -eq "1" ]]; then
+    echo "SUCCESS: Child with own .padz is independent"
+else
+    echo "FAILURE: Expected only 1 independent pad, got total=$TOTAL_COUNT independent=$INDEPENDENT_COUNT"; exit 1
+fi
 
 cd ..
 

--- a/tests/e2e/base-fixture.sh
+++ b/tests/e2e/base-fixture.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # =============================================================================
 # Base Fixture - Creates a diverse set of pads for testing
 # =============================================================================
@@ -61,7 +62,7 @@ padz -g list --deleted
 # -----------------------------------------------------------------------------
 # Create from inside project-a (git repo = project scope)
 
-cd projects/project-a
+cd projects/project-a || exit
 padz init
 
 # Simple project pads
@@ -99,7 +100,7 @@ echo "=== Project Pads (including deleted) ==="
 padz list --deleted
 
 # Return to workspace
-cd ../..
+cd ../.. || exit
 
 echo ""
 echo "=== Fixture Complete ==="

--- a/tests/e2e/bats/helpers/assertions.bash
+++ b/tests/e2e/bats/helpers/assertions.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154  # $status/$output injected by bats run
 # =============================================================================
 # PADZ TEST ASSERTIONS
 # =============================================================================
@@ -139,7 +140,7 @@ assert_pad_has_tag() {
     local scope="${3:-}"
     local tags
     tags=$(get_pad_tags "${index}" "${scope}")
-    if [[ ! " ${tags} " =~ " ${tag} " ]]; then
+    if [[ " ${tags} " != *" ${tag} "* ]]; then
         echo "FAIL: Expected pad ${index} to have tag '${tag}', but tags are: ${tags}" >&2
         return 1
     fi

--- a/tests/e2e/bats/helpers/backdoors.bash
+++ b/tests/e2e/bats/helpers/backdoors.bash
@@ -156,7 +156,14 @@ backdoor_list_content_files() {
     local bucket="${2:-active}"
     local bucket_dir
     bucket_dir=$(_get_bucket_dir "${scope}" "${bucket}")
-    ls "${bucket_dir}"/pad-*.txt 2>/dev/null | xargs -n1 basename | sed 's/^pad-//; s/\.txt$//' || true
+    local f base
+    for f in "${bucket_dir}"/pad-*.txt; do
+        [[ -e "$f" ]] || continue
+        base=$(basename "$f")
+        base="${base#pad-}"
+        base="${base%.txt}"
+        printf '%s\n' "$base"
+    done
 }
 
 # Check if content file exists for UUID

--- a/tests/e2e/bats/helpers/backdoors.bash
+++ b/tests/e2e/bats/helpers/backdoors.bash
@@ -159,7 +159,7 @@ backdoor_list_content_files() {
     local f base
     for f in "${bucket_dir}"/pad-*.txt; do
         [[ -e "$f" ]] || continue
-        base=$(basename "$f")
+        base="${f##*/}"
         base="${base#pad-}"
         base="${base%.txt}"
         printf '%s\n' "$base"

--- a/tests/e2e/bats/helpers/helpers.bash
+++ b/tests/e2e/bats/helpers/helpers.bash
@@ -52,12 +52,11 @@
 # Run padz with optional scope
 # Usage: _padz [scope] <args...>
 _padz() {
-    local scope=""
-    local args=()
+    local flag=()
 
     # Check if first arg is a scope indicator
     if [[ "$1" == "global" ]]; then
-        scope="-g"
+        flag=(-g)
         shift
     elif [[ "$1" == "project" ]]; then
         # Ensure we're in project directory
@@ -65,28 +64,28 @@ _padz() {
         shift
     fi
 
-    "${PADZ_BIN}" ${scope} "$@"
+    "${PADZ_BIN}" "${flag[@]}" "$@"
 }
 
 # Get JSON output for all pads
 # Usage: list_pads [scope]
 list_pads() {
     local scope="${1:-}"
-    _padz ${scope} list --output json 2>/dev/null
+    _padz ${scope:+"$scope"} list --output json 2>/dev/null
 }
 
 # Get JSON output for deleted pads
 # Usage: list_deleted_pads [scope]
 list_deleted_pads() {
     local scope="${1:-}"
-    _padz ${scope} list --deleted --output json 2>/dev/null
+    _padz ${scope:+"$scope"} list --deleted --output json 2>/dev/null
 }
 
 # Get JSON output for archived pads
 # Usage: list_archived_pads [scope]
 list_archived_pads() {
     local scope="${1:-}"
-    _padz ${scope} list --archived --output json 2>/dev/null
+    _padz ${scope:+"$scope"} list --archived --output json 2>/dev/null
 }
 
 # Search pads and return JSON
@@ -94,7 +93,7 @@ list_archived_pads() {
 search_pads() {
     local term="$1"
     local scope="${2:-}"
-    _padz ${scope} search "${term}" --output json 2>/dev/null
+    _padz ${scope:+"$scope"} search "${term}" --output json 2>/dev/null
 }
 
 # Count active pads


### PR DESCRIPTION
## What & why

This is **content-only pre-cleaning** ahead of the `release/` strict-gate
tightening. The `release/`-synced lint gate (shellcheck + markdownlint) was
relaxed during a migration (severity floor + path excludes, tracked in
arthur-debert/release#288). Before that relaxation is reverted, each consumer's
**owned** content must already pass the strict gate so the tightening lands
without breaking anyone. padz is the pilot for fanning this out to ~18 repos.

**No managed config touched.** All `.release/`-synced symlinks (`.shellcheckrc`,
`.markdownlint.json`, `lefthook.yml`, managed `bin/*`) are left untouched — their
debt is fixed upstream in `release/`, not here. Only real, repo-owned files were
edited.

## Proof is local strict lint runs

CI still runs the **relaxed** config (the pre-commit shellcheck hook reports
"no files for inspection" due to the current path excludes), so the proof is
local strict runs:

- `shellcheck --severity=info` on every owned shell file → **0 findings**
- `markdownlint` with `{MD013:false, line-length:false, MD060:false, table-column-style:false}` (MD056 stays on) on owned `.md` files → **0 findings**
- e2e bats suite (`bin/check-e2e`): **136/136 passing** (verifies the bats helper/fixture changes)

## Finding categories fixed

**Shell (shellcheck --severity=info):**
- SC2148 missing shebang — added honest `#!/usr/bin/env zsh` + `# shellcheck shell=bash` to the zsh-harness live-tests; `#!/usr/bin/env bash` to the bats fixture
- SC1071 — added `# shellcheck shell=bash` directive so the bash-compatible subset is linted
- SC2155 — split declare-and-assign for `PATH` export
- SC2164 — `cd … || exit` on bare `cd`
- SC2028 — converted escape-bearing `echo` to `printf`
- SC2015 — converted `A && B || C` test assertions to real `if/else`
- SC2076 — switched literal-substring `=~` test to `==` glob match
- SC2154 — documented `$status`/`$output` are bats-injected
- SC2011 — replaced `ls | xargs` with a glob loop
- SC2034 — removed an unused `local`
- SC2086 — refactored intentional empty-scope expansion to an array flag + `${scope:+…}`

**Markdown:** MD031/MD032/MD030/MD004/MD012/MD007/MD009/MD022 auto-fixed; hand-fixed MD040 (code-fence language), MD041 (H1 first line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)