### PR TITLE
ci: bump release reusable workflows to @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
     with:
       binary-name: padz
       bats: true

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v2
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v1.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
 # Bug fixes and improvements to the release pipeline come in via a
 # bump of the @v1 floating ref, no changes here.
 
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
     with:
       version: ${{ inputs.version }}
       crates: padzapp,padz


### PR DESCRIPTION
Moves onto release/'s v2 major line (v2.0.0 = strict lint gate). Reusable workflows unchanged v1→v2; behavior-neutral. Admin-merged without the review loop per maintainer direction.