### PR TITLE
fix: drop stale shell-quality capability (unblocks release-sync)

### DIFF
--- a/.release-sync.yaml
+++ b/.release-sync.yaml
@@ -1,6 +1,5 @@
 # Consumer override for release-sync. Adds the opt-in `bats` Component
 # on top of the rust Stack defaults.
 capabilities:
-  - shell-quality
   - rust-quality
   - bats


### PR DESCRIPTION
`release-sync` currently fails here:

```
release-sync: declared Capability 'shell-quality' has no templates/components/shell-quality/ tree
```

`shell-quality` was promoted to `templates/commons/` in arthur-debert/release#320 and removed as a Capability — the gate now ships in commons for every consumer. This repo's `.release-sync.yaml` still declares it, so sync errors out.

Fix: drop `shell-quality` (keep `rust-quality`, `bats`). Verified `release-sync` now resolves cleanly.

Surfaced by `release-verify-fleet` during the v2 advance.