### PR TITLE
chore(ci): migrate release reusable-workflow callers @v2 → @v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v3
     with:
       binary-name: padz
       bats: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Thin caller — the canonical pipeline lives at
-# arthur-debert/release/.github/workflows/rust-cli.yml@v2.
+# arthur-debert/release/.github/workflows/rust-cli.yml@v3.
 # Bug fixes and improvements to the release pipeline come in via a
 # bump of the @v1 floating ref, no changes here.
 
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-cli.yml@v3
     with:
       version: ${{ inputs.version }}
       crates: padzapp,padz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # Thin caller — the canonical pipeline lives at
 # arthur-debert/release/.github/workflows/rust-cli.yml@v3.
 # Bug fixes and improvements to the release pipeline come in via a
-# bump of the @v1 floating ref, no changes here.
+# bump of the @v3 floating ref, no changes here.
 
 on:
   workflow_dispatch:

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,0 +1,1 @@
+ci: migrate release reusable-workflow callers from @v2 to @v3

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,1 +1,1 @@
-ci: migrate release reusable-workflow callers from @v2 to @v3
+- ci: migrate release reusable-workflow callers from @v2 to @v3


### PR DESCRIPTION
Migrates this consumer's `arthur-debert/release` reusable-workflow callers from `@v2` to `@v3` following the release cut of **v3.0.0**.

v3 is a MAJOR only because release removed the deprecated singular `wasm-package` input (#634). No consumer used it, so this is a mechanical re-pin — no behavior change. The `v2` branch is frozen at v2.21.0, so staying on `@v2` freezes this consumer out of future fixes.

## Workflows bumped (@v2 → @v3)
- `.github/workflows/release.yml` — `rust-cli.yml@v2 → @v3` (uses: line + header comment)
- `.github/workflows/ci.yml` — `rust-ci.yml@v2 → @v3` (uses: line)

## Left as-is
- `.github/workflows/copilot-review.yml` — stays at `@v1` (separate concern, out of scope).

The managed tree is intentionally NOT part of this PR — it arrives via the consumer's own wheel pull, not a push.

🤖 Generated with Claude Code