### PR TITLE
release: adopt the shipit release workflow caller (ADP02-WS06)

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -1,0 +1,87 @@
+name: shipit-release
+
+# ADP02-WS06 cutover caller: drives padz through shipit's COMPOSED release
+# pipeline (ADR-0040) — one `uses:` line against the remote wf-release.yml
+# at @v1, the standard-consumer shape (ADR-0010/0053: shipit is public,
+# floating `@v1` is the proven distribution path — never SHA-pinned or
+# vendored). Routing ONLY: the release plan (matrix, live stages,
+# post-RC-guard endpoints, required secrets) is preflight's, computed inside
+# the blocks; nothing is re-derived here.
+#
+# Runs ALONGSIDE the untouched legacy release.yml caller — the cutover canon
+# keeps legacy callers operational until the WS07 proof gate retires them.
+#
+# Secrets — exactly the plan-required set for a real padz release:
+#   RELEASE_TOKEN        prepare's tag+branch push through the ruleset
+#   HOMEBREW_TAP_TOKEN   the brew endpoint's tap push (stable releases only)
+#   CARGO_REGISTRY_TOKEN the crates endpoint — mapped HERE from the repo's
+#                        legacy-named CRATES_IO_KEY secret (NOT renamed:
+#                        legacy release.yml consumes it via
+#                        `secrets: inherit` until WS07 retires it)
+# gh-release rides the workflow's own GITHUB_TOKEN; a -release-rc version
+# drops crates/brew from the plan centrally (the RC guard lives in the
+# publish verb, never here).
+#
+# Per-stage dispatch (owner requirement, 2026-07-12): `stage` selects the
+# full chain (default) or ONE independently re-runnable stage block.
+# Only `prepare` is offered beside `full`: wf-prepare.yml@v1 is
+# self-sufficient from a version input (and idempotent — a re-dispatch
+# re-emits the same tag, ADR-0009). `build` and `publish` stage values are
+# DELIBERATELY absent — a shipit finding (PRD story 49), not an omission:
+# wf-build.yml@v1 requires prepare's plan outputs (`tag`/`matrix`/`stages`,
+# all `required: true`) and wf-publish.yml@v1 additionally downloads the
+# same-run `bundle-*`/`release-notes` artifacts (actions/download-artifact
+# with no run-id reaches only the current run), so neither block can run
+# from a bare version in a fresh dispatch. The fix lands in shipit, never
+# worked around here (re-wiring prepare→build consumer-side is the
+# consumer-owned wiring ADR-0040 rejected). Until then, re-running a failed
+# build/publish is the full-chain re-dispatch, which ADR-0009 makes
+# convergent: prepare resumes onto the same tag, publish clobbers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Version to release: a bare semver (e.g. 1.9.0 or
+          1.9.0-release-rc) or a bump word (major|minor|patch)
+        required: true
+        type: string
+      stage:
+        description: >-
+          What to dispatch: the full composed chain (default) or one
+          independently re-runnable stage block. See the header comment
+          for why build/publish are not offered.
+        required: false
+        type: choice
+        default: full
+        options:
+          - full
+          - prepare
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: inputs.stage == 'full'
+    uses: arthur-debert/shipit/.github/workflows/wf-release.yml@v1
+    with:
+      version: ${{ inputs.version }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+
+  prepare:
+    if: inputs.stage == 'prepare'
+    uses: arthur-debert/shipit/.github/workflows/wf-prepare.yml@v1
+    with:
+      version: ${{ inputs.version }}
+    # Preflight runs inside the block and hard-fails naming any missing
+    # plan-required secret, so the stage dispatch forwards the same set the
+    # full chain does.
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -66,6 +66,39 @@ local = true
 [toolchains]
 "." = "rust"
 
+# [artifacts] — padz's declared Artifact set for the shipit release pipeline
+# (ADP02-WS06, the first real-consumer release cutover; modeled on
+# lex-fmt/lex@shipit-rc's TOL02 map). The legacy surface it replaces is
+# release.yml → rust-cli.yml@v3 (`crates: padzapp,padz`, `bin-name: padz`,
+# defaults: darwin arm64 + linux gnu x86_64/aarch64, brew, apt).
+#   - [artifacts.padz] is the binary-tarball artifact (the brew formula
+#     subject): archive composition over the same three native-runner
+#     platforms the legacy matrix built, distributed to gh-release + crates
+#     (padzapp then padz — shipit derives the workspace topo order itself)
+#     + brew (the tap is shipit's portfolio constant,
+#     arthur-debert/homebrew-tools — same as legacy).
+#   - [artifacts.padz-deb] is the legacy `apt: true` leg: cargo-deb against
+#     the pre-built release binary (the same `cargo deb -p padz --no-build
+#     --no-strip` contract as legacy build-deb), linux platforms only,
+#     gh-release only (legacy attached the .debs to the GH release; there is
+#     no apt repository endpoint).
+# No `sign = true` anywhere (owner decision, 2026-07-12): shipit's mac
+# signer covers the coupled .app/.dmg unit, not raw binaries — the raw
+# binary codesign+notarize leg the legacy darwin lane ran is owned by
+# arthur-debert/shipit#779 and the first real release ships unsigned darwin
+# tarballs, recorded.
+[artifacts.padz]
+build = [{ toolchain = "rust", package = "padz" }]
+platforms = ["darwin-arm64", "linux-x86_64", "linux-arm64"]
+bundle = { composition = "archive" }
+endpoints = ["gh-release", "crates", "brew"]
+
+[artifacts.padz-deb]
+build = [{ toolchain = "rust", package = "padz" }]
+platforms = ["linux-x86_64", "linux-arm64"]
+bundle = { composition = "deb" }
+endpoints = ["gh-release"]
+
 [shipit]
 version = "e0862f81072d35b4da4827cbba7e17c4e89a1d7f"
 


### PR DESCRIPTION
Closes #179 — ADP02-WS06 (epic arthur-debert/shipit#422, workstream arthur-debert/shipit#657).

## Context

**This PR is the CUTOVER ONLY**: it lands padz's `[artifacts]` declarations and the new
`shipit-release.yml` caller, modeled on lex-fmt/lex@shipit-rc (the TOL02 rc-campaign shape).
The rc and real-release dispatches are **coordinator-owned and happen after merge** — nothing
was dispatched from this Run. The legacy `release.yml` is **untouched and operational**
(cutover canon; removal is WS07, post-proof). Do NOT "fix" the legacy caller, rename the
`CRATES_IO_KEY` repo secret (legacy inherits it), pin/vendor the `@v1` refs (ADR-0053), or
add a `sign` declaration (shipit#779 owns the raw-binary sign leg).

### Removed-vs-replaced semantic diff (legacy `release.yml` → `rust-cli.yml@v3`, read line by line)

Legacy surface for padz: `crates: padzapp,padz`, `bin-name: padz`, `secrets: inherit`, all
defaults (darwin `arm64`, linux gnu `x86_64,aarch64`, `brew: true`, `apt: true`,
`publish-crates: true`; musl/windows/wasm/extra-binaries/notify-downstreams empty/off).

**(a) Preserved** (same behavior, new owner):

| Legacy | New path |
| --- | --- |
| prepare-release: version bump, changelog roll, release commit, tag | `wf-prepare` → `shipit release prepare` (tag is the version authority, ADR-0041) |
| GH release + notes (softprops/action-gh-release) | publish verb's gh-release endpoint, notes via the `release-notes` artifact |
| `padz` tarballs: aarch64-apple-darwin, x86_64-linux-gnu, aarch64-linux-gnu (binary + README/CHANGELOG/LICENSE, `<bin>-<target>.tar.gz`) | `[artifacts.padz]`, `archive` composition — same staging-subdir contract, same asset names |
| `.deb` amd64/arm64 via `cargo deb -p padz --target <triple> --no-build --no-strip` | `[artifacts.padz-deb]`, `deb` composition — same cargo-deb argv contract (but see Findings F2–F4) |
| crates.io publish padzapp→padz in topo order (`CRATES_IO_KEY`) | `crates` endpoint — topo order derived from `cargo metadata` (never declared); token mapped in the caller as `CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}` |
| brew formula `padz` → `arthur-debert/homebrew-tools`, stable-only (prerelease skip) | `brew` endpoint — same tap (shipit's portfolio constant `HOMEBREW_TAP`), same stable-only rule, formula metadata from the crate |
| `-release-rc` guard: never publish crates/npm on an rc | central RC guard in the publish verb (plan drops external endpoints — verified in the pasted rc plan) |
| linux-arm64 leg | native `ubuntu-24.04-arm` runner instead of legacy's gcc-aarch64 cross-compile — same shipped binary arch |

**(b) Relocated** (semantics moved, not 1:1): per-job `if:` guards (rc, brew-stable,
publish-crates) → plan facts computed once by `release preflight` and consumed verbatim
(ADR-0040); matrix assembly from arch inputs → the closed `PLATFORM_MATRIX` keyed by declared
`platforms`; secrets `inherit` → explicit plan-required forwarding; sccache/Swatinem build
caching → not carried (build-perf plumbing, not release surface; shipit's blocks pin pixi).

**(c) Deliberately dropped** (each with evidence):

- **mac raw-binary codesign + notarize** (legacy `sign-mac` + notarytool poll on the darwin
  leg). Owner decision 2026-07-12 recorded in #179: the first real release ships unsigned
  darwin tarballs; shipit's signer covers the coupled `.app`/`.dmg` unit only. Sign leg owned
  by **arthur-debert/shipit#779** (must land before WS07 completes legacy cleanup). No
  `sign = true` declared; the plan's sign-matrix is `[]` (see plans below).
- **Legacy opt-in inputs padz never used**: musl/windows archs, `extra-binaries`,
  `wasm-packages`/npm, `notify-downstreams`, `brew-private-repo`, `submodules` — all default
  empty/off in the legacy caller (evidence: `release.yml` passes only `version`, `crates`,
  `bin-name`), so no padz surface is lost.
- **apt endpoint**: legacy "apt" only attached `.deb`s to the GH release (no apt repo);
  `[artifacts.padz-deb] endpoints = ["gh-release"]` is the same distribution.

### The caller

`workflow_dispatch` with `version` (bare semver or `major|minor|patch` — wf-release accepts
bump words) + `stage` choice; `permissions: contents: write`; forwards exactly the
plan-required secrets (`RELEASE_TOKEN`, `HOMEBREW_TAP_TOKEN`,
`CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}` — mapped in the caller, repo secret NOT
renamed).

### Findings (adoption posture: report, never work around — PRD story 49)

**F1 — per-stage dispatch: `build`/`publish` stage blocks are not self-sufficient when
called directly.** The issue's step 3 wanted stage values running exactly one stage block
from a version input, and pre-named this outcome as a shipit finding. Evidence from the `@v1`
block contracts (read, not memory): `wf-build.yml@v1` declares `tag`, `matrix`, `stages` as
`required: true` workflow_call inputs — wf-prepare outputs, underivable from a bare version
in routing-only YAML; `wf-publish.yml@v1` additionally requires the four stage-result inputs
and downloads `release-notes`/`bundle-*` via `actions/download-artifact` with no `run-id`,
which only reaches the **current run's** artifacts — a fresh publish-only dispatch has none.
The caller therefore offers `stage: full | prepare` only (`wf-prepare.yml@v1` IS
self-sufficient: version in, plan out, idempotent re-tag per ADR-0009). Wiring
prepare→build consumer-side would be the consumer-owned wiring ADR-0040 rejected — not done.
Until the shipit fix, a failed build/publish re-runs via full-chain re-dispatch, which
ADR-0009 makes convergent (prepare resumes onto the same tag; publish clobbers).

**F2/F3/F4 — the deb legs will fail at the rc dispatch as shipit stands** (padz is the first
deb-composition consumer; the lex campaign exercised archive only). Declared anyway per this
issue's mandated legacy-surface parity; the fixes land in shipit. Source evidence at the pin
(`e0862f8`) and `@v1`:

- **F2 (provisioning)**: nothing installs cargo-deb on the wf-build runner. Legacy build-deb
  ran `cargo install cargo-deb --locked`; wf-build runs only `shipit build` + `shipit release
  bundle` under pixi, `cargo-deb` is not on conda-forge (`pixi search cargo-deb`: no match),
  and shipit treats a missing cargo-deb as ExecError (`verbs/release.py:710`).
- **F3 (target-dir mismatch)**: `shipit build` runs plain `cargo build --release -p padz`
  (registry argv, no `--target` plumbing) → `target/release/`; wf-build's bundle step passes
  `--target "$TARGET"` → the deb composition forwards it to cargo-deb (`bundle.py::_compose_deb`,
  `target_declared=True`), and cargo-deb with `--target` reads `target/<triple>/release/`
  (padz's own `Cargo.toml` deb comment documents the rewrite) — where nothing was built.
- **F4 (assert-bundle has no deb tier)**: the deb entries carry `bundle: true`, so they ride
  wf-prepare's `unsigned-matrix` into wf-publish's assert fan, but `integrity.check_tree` has
  app/reseal/plain-archive/loose-exec tiers only and explicitly excludes `.deb` from the loose
  scan (`integrity.py::_is_executable`) → "no main binary found — nothing to assert", the same
  failure class campaign Finding 2 fixed for plain archives.

### Verification (all run in this Tree, before PR-open)

- `pixi run lint` — OK (12 checks, incl. actionlint + yamllint over the new caller);
  `pixi run test` — OK (680/680, cargo-nextest).
- `actionlint .github/workflows/shipit-release.yml` — clean.
- `shipit release preflight 1.9.0-release-rc` (secrets satisfied via placeholder env — preflight
  is pure planning) — plans clean:

```text
release preflight: 1.9.0-release-rc (prerelease, event dispatch)
  artifacts  padz, padz-deb
  matrix     5 entries (darwin-arm64, linux-x86_64, linux-arm64, linux-x86_64, linux-arm64)
  stages     preflight, prepare, bundle, assert-bundle, publish
  endpoints  gh-release
  secrets    RELEASE_TOKEN
  rc guard   -release-rc: GH release only, external endpoints dropped
```

- `shipit release preflight 1.9.0` (real version) — names exactly the required token set:

```text
release preflight: 1.9.0 (final, event dispatch)
  artifacts  padz, padz-deb
  matrix     5 entries (darwin-arm64, linux-x86_64, linux-arm64, linux-x86_64, linux-arm64)
  stages     preflight, prepare, bundle, assert-bundle, publish
  endpoints  gh-release, crates, brew
  secrets    RELEASE_TOKEN, CARGO_REGISTRY_TOKEN, HOMEBREW_TAP_TOKEN
```

  (Run without env placeholders it hard-fails naming the missing set — the designed
  fail-before-history behavior. The plan's `stages` names no separate `build`/`sign` entry:
  build liveness is the matrix fact and sign the per-entry flag, consumed by the verb per
  issue #745.)

- `shipit wf test` (act): `--event workflow_dispatch --input stage=prepare --dry-run` — **OK**
  (act resolved the remote `wf-prepare.yml@v1` and walked it green, proving the `@v1` refs
  resolve). `--input stage=full --dry-run` — prepare leg green, then act fails evaluating
  wf-build's `fromJson(inputs.matrix)` (empty dry-run outputs): the **act-untestable leg**,
  acknowledged per the lex#829 precedent — it is act's partial workflow_call fidelity
  (printed in the surface statement), plus macOS/arm runners and all release side effects.
  Only the coordinator's live rc dispatch verifies the resolved-block surface.

### Self-check against the governing docs

Diff checked against ADR-0010 (blocks + @vN distribution: remote refs only), ADR-0040
(routing-only consumer YAML: the caller carries zero logic — every decision is preflight's),
ADR-0041 (tag is the version authority: version input passed verbatim, never inferred),
ADR-0053 (floating `@v1`, never SHA-pinned/vendored), ADR-0007 (artifacts declared many-to-many
off the one rust workspace), ADR-0009 (resumability rationale in F1), and shipit
`docs/dev/workflows.lex` (check-name contract: caller job ids `release`/`prepare` keep the
`release / prepare / prepare` check surface). No shipit-managed file was hand-edited; the
managed set is untouched (`.shipit.toml`'s consumer-owned tables only).

**Out of scope**: any release dispatch (coordinator-owned, post-merge); legacy `release.yml`
and the e2e caller; the shipit-side fixes for F1–F4; secret provisioning (`gh-setup` /
existing repo secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
