### PR TITLE
shipit: install/update the managed set

### DIFF
--- a/.shipit.toml
+++ b/.shipit.toml
@@ -100,7 +100,7 @@ bundle = { composition = "deb" }
 endpoints = ["gh-release"]
 
 [shipit]
-version = "760af791aa44bf6b7e9313c1d84b1863ecdc28d9"
+version = "9e23a2e10b8986cee81f5141162b11fc7db5d608"
 
 [managed]
 "skills/coordinating/SKILL.md" = "sha256:065a793b117dcfbb1e97fea0a80b405c69995850af9a350061dbcc1f4ea4976a"
@@ -129,6 +129,7 @@ claude-start = "sha256:29686623ac9b3a23b31930eb1306ed268e517e79ae28a52dc16906d40
 "pixi.toml#shipit-lint-deps" = "sha256:fa3ecaa2b6b3950fa4c26b26598d47ffa388e385191f03ac4986eb0f33bcae2e"
 "pixi.toml#shipit-environments" = "sha256:c54b53e3bb55cd59aaabf9daea85c81cffe3cbae8978e41cbef5db0f16b3838b"
 "pixi.toml#shipit-rust-lint-toolchain" = "sha256:e5105bbd8feb8a1d5bde16dd427028303d1f0b3b4c43d7b85689de95c1200285"
+"pixi.toml#shipit-rust-release-deps" = "sha256:c1533b94f3b6d678dbc9349ee45316b9b551ee5ebd144773be307119d3a0c9b4"
 ".claude/agents/explorer.md" = "sha256:9b32730d6a744d7ff2b5201b7a9f09ea9081f98d315e5534d975e9178e6afc08"
 ".claude/agents/implementer.md" = "sha256:56709647c70f122758616754f37f40de3f76d57dc93797f0ec8956939ea1b658"
 ".claude/agents/reviewer.md" = "sha256:f4060c763e1590cd6136cc810a30e137f5c76ae0629bdd45a6e9ce2d1a0de062"

--- a/pixi.lock
+++ b/pixi.lock
@@ -30,6 +30,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-edit-0.13.11-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-nextest-0.9.140-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
@@ -50,6 +51,7 @@ environments:
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-edit-0.13.11-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-nextest-0.9.140-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h74e174c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
@@ -69,12 +71,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.96.1-h38e4360_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-edit-0.13.11-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.140-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.96.1-h5655b98_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.28-hbe083cb_0.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.96.1-hf6ec828_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-edit-0.13.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.140-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.96.1-h4ff7c5d_2.conda
@@ -89,6 +93,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-edit-0.13.11-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-nextest-0.9.140-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
@@ -144,6 +149,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.45.1-default_h5f4c503_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-edit-0.13.11-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-nextest-0.9.140-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h74e174c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/go-shfmt-3.13.1-h22914b5_0.conda
@@ -203,6 +209,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-edit-0.13.11-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.140-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
@@ -247,6 +254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-edit-0.13.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.140-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
@@ -348,6 +356,19 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 207882
   timestamp: 1765214722852
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-edit-0.13.11-hb17b654_0.conda
+  sha256: 8b9f547a121560562c09b8493e2e7ab3e7363c08be6ddd6d19875f7b19db2340
+  md5: 963718083ec2eaa2580906b707a98b24
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 2727864
+  timestamp: 1780012863906
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-nextest-0.9.140-hb17b654_0.conda
   sha256: fe0a6e9c936f65518d1c5d10c9a7ef46c2208e2bccbb90c8e454aac6f1617210
   md5: ed8a6f270fbb4ea25513ce67171ee81b
@@ -968,6 +989,18 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 217215
   timestamp: 1765214743735
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-edit-0.13.11-h069e38c_0.conda
+  sha256: 235ab94954974d11fd56c5d8dbd214d6c413b28116b1fa09bd388757f82f6610
+  md5: 9ee4438c28a7e1f9cd95c1d8386837f3
+  depends:
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 2568296
+  timestamp: 1780012874809
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cargo-nextest-0.9.140-h069e38c_0.conda
   sha256: 2532d1d3d0cf9500d85217781bc435c98f19a434b5a74913df792d11a81beb6f
   md5: 9757e007ff71e5d5db1edb5cdcdb0900
@@ -1765,6 +1798,18 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 186122
   timestamp: 1765215100384
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-edit-0.13.11-h19f9e61_0.conda
+  sha256: 1df4aff250280ce36a114349a003b5b778f470278fdaae3c676775b7ca6ef771
+  md5: 311918bfc9d5b98e0690527c57a3bb64
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 2497661
+  timestamp: 1780013091399
 - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-nextest-0.9.140-h19f9e61_0.conda
   sha256: e046ab4c3bc5ff36f0d0566a78d8a0780cd7ffdfbd558a6721ad89a50e3c36d6
   md5: c452ce982dfba14c18c9d067848376f8
@@ -2259,6 +2304,18 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 180327
   timestamp: 1765215064054
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-edit-0.13.11-h6fdd925_0.conda
+  sha256: 4b3db0471d1b76fb776fc223db78565b76a99fab4365facc8aa8b5c1f1fdf1ef
+  md5: dc4416aef87510f6e43f8883c2318e99
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 2285219
+  timestamp: 1780013093433
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-nextest-0.9.140-h6fdd925_0.conda
   sha256: 76211f85956ec6f37f38b1b6165332233c3f5e016bb090859881d9e1ac1f1a12
   md5: 85190477f1f0a580ac199d87cf3227b2

--- a/pixi.toml
+++ b/pixi.toml
@@ -78,6 +78,23 @@ lint = ["lint"]
 # `cargo nextest` stack itself. Same conda-forge rust pin as the managed
 # [feature.lint.dependencies] block.
 [dependencies]
+# >>> shipit-managed rust release deps (do not edit; regenerate via `shipit install`) >>>
+# The rust RELEASE-side bump tool (#793, the #784-F2 failure class): `shipit
+# release prepare`'s rust bump adapter runs `cargo set-version --workspace`
+# (a cargo-edit subcommand), and wf-prepare executes shipit in the DEFAULT
+# pixi env (`pixi run --locked ./bin/shipit`), so cargo-edit anchors HERE —
+# [dependencies], not a feature — where that run's PATH resolves it (cargo
+# finds subcommands via $CARGO_HOME/bin then PATH, the #785 finding).
+# Provisioned from conda-forge under setup-pixi's lockfile-keyed cache (the
+# #582 doctrine: the release run NEVER `cargo install`s). Pinned to the patch
+# line (`0.13.11.*` — conda match-spec, so any 0.13.11.x build resolves); a
+# bump is one data edit, rolled out on each consumer's next `shipit install`
+# reconcile. If this repo no longer ships rust (the last Cargo.toml is gone),
+# delete this block and its `pixi.toml#shipit-rust-release-deps` entry in
+# .shipit.toml's [managed] table — a reconcile only ADDS toolchain blocks, it
+# never retires one.
+cargo-edit = "0.13.11.*"
+# <<< shipit-managed rust release deps <<<
 cargo-nextest = ">=0.9.138,<0.10"
 rust = "1.96.*"
 # uv backs the pinned bin/shipit launcher (ADR-0033: it provisions the repo's


### PR DESCRIPTION
`shipit install` reconciled the managed set.

Pinned to `9e23a2e10b8986cee81f5141162b11fc7db5d608` — the build that wrote this managed set and passed its self-certification (ADR-0033); the managed `bin/shipit` launcher execs exactly this build.

### Added
- `pixi.toml#shipit-rust-release-deps`

### Retired files kept — locally modified
shipit no longer distributes these files, but their content differs from every known pristine version, so they were NOT deleted. Remove them yourself once the local edits are no longer needed:
- `.github/workflows/copilot-review.yml`
- `bin/install-release-core`

### Checks activated locally
`lefthook install` ran where this install was invoked, so its `.git/hooks/{pre-commit,pre-push}` fire `pixi run lint` there now. Reviewers/mergers: run `./bin/shipit install` on your own checkout (shipit-self: `pixi run -e lint install-hooks`) to make the checks live for you too. Activation is idempotent and leaves unrelated hooks intact.
