### PR TITLE
Caller: prepare stage forwards the full plan-required secret set

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -38,7 +38,13 @@ name: shipit-release
 # at the tag, fans over nothing, and skips. The choice stays offered
 # because this caller rides the blessed shape, never a trimmed variant.
 #
-# Secrets — exactly the plan-required set for padz's plan:
+# Secrets — the UNIFORM plan-required set (shipit#896): preflight
+# re-validates the WHOLE release plan at every stage entry, so `prepare`
+# forwards the SAME secret set as `full` — no per-stage subsetting;
+# which secrets a stage actually spends is the plan's call, not this
+# caller's. (`build` declares no secrets, so it forwards none; padz's
+# plan has no sign stage — see above — so `sign` forwards none; `publish`
+# keeps the registry set its block spends.) The set for padz's plan:
 #   RELEASE_TOKEN         prepare's tag+branch push through the ruleset
 #                         (a GITHUB_TOKEN push would not re-trigger
 #                         workflows).
@@ -50,9 +56,7 @@ name: shipit-release
 #                         secret (renaming the repo secret is a
 #                         repo-settings operation outside this change;
 #                         the mapping keeps the caller correct as-is).
-# Both publish secrets ride the stages that can publish (`full`,
-# `publish`). gh-release rides the workflow's own GITHUB_TOKEN (no
-# registry entry).
+# gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
 
 on:
   workflow_dispatch:
@@ -133,6 +137,8 @@ jobs:
       unsigned: ${{ inputs.unsigned }}
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
 
   build:
     if: inputs.stage == 'build'


### PR DESCRIPTION
closes #186 (for arthur-debert/shipit#896, arthur-debert/shipit#841)

## Context

**Why this approach.** Preflight re-validates the WHOLE release plan at every stage entry (shipit#896), so a `prepare` dispatch fails on any plan-required secret the stage job wasn't granted — it forwarded only `RELEASE_TOKEN`. The fix is the issue's exact prescription, proven on arthur-debert/dodot's caller (dodot#247, two full staged rc chains green 2026-07-13): `jobs.prepare.secrets` is now an EXACT copy of `jobs.release.secrets` — same keys, same mapping expressions, including the legacy `CRATES_IO_KEY` → `CARGO_REGISTRY_TOKEN` mapping, kept verbatim. The header comment now states the uniform-grant rule (shipit#896), mirroring dodot's caller comment adapted to padz's plan (no sign stage), and the now-stale "publish secrets ride only full/publish" line is dropped. `wf-prepare.yml@v1` declares both added secrets as optional `workflow_call` secrets, so the forward is legal.

**Out of scope / do NOT "fix".**
- `sign`/`publish`/`build` jobs are untouched by explicit decision in the issue: sign forwards nothing (padz has no sign stage — unsigned darwin by owner decision, shipit#779), publish keeps its registry set, build forwards none. Do not "uniformize" them.
- The repo's legacy `CRATES_IO_KEY` secret name stays — renaming it is a repo-settings operation, not this caller's.
- No other workflow or code changes ("No other changes" per the issue). The coordinator re-runs the staged rc proof after merge.

**Self-check.** Diff checked against the issue's governing refs (ADR-0054 blessed caller shape / ADR-0040 routing-only — the change adds grants only, re-derives nothing) and dodot's proven caller. Verified: `./bin/shipit wf test .github/workflows/shipit-release.yml --event workflow_dispatch --input stage=prepare --dry-run` → `WF TEST: OK`; `pixi run test` → 680/680 pass; commit hook lint suite (incl. actionlint, yamllint) → `LINT: OK (12 checks)`.

**Brief-slot note.** This spawn brief arrived as a prompt, not the `shipit spawn brief implementer` template; the issue itself carried the verify commands and decision boundaries, which were used as such. Flagging per protocol rather than guessing at unnamed slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)