### PR TITLE
PADZ-STD01-WS02: Epic: Complete Standout adoption - Workstream: Return typed mode-independent handler results

### DIFF
--- a/.claude/skills/padz-output-customization/SKILL.md
+++ b/.claude/skills/padz-output-customization/SKILL.md
@@ -98,10 +98,14 @@ Templates use **Jinja2 syntax** (minijinja). Located in `src/cli/templates/`.
 
 | File | Purpose |
 | ------ | --------- |
-| `list.jinja` | Main list view (`padz list`) |
-| `full_pad.jinja` | Detailed pad view (`padz view`) |
+| `list.jinja` | Main list view (`padz list`), via the `list_view` provider |
+| `modification_result.jinja` | Pads changed by a command, via the `modification_view` provider |
+| `view.jinja` | `padz view` output |
+| `full_pad.jinja` | Detailed pad view (title + content) |
 | `text_list.jinja` | Plain text list output |
 | `messages.jinja` | Success/error messages |
+| `path.jinja` | One pad file path per line |
+| `uuid.jinja` | One pad uuid per line |
 | `_pad_line.jinja` | Partial: single pad row |
 | `_deleted_help.jinja` | Partial: deleted section help |
 | `_peek_content.jinja` | Partial: content preview |
@@ -119,8 +123,9 @@ Templates use **Jinja2 syntax** (minijinja). Located in `src/cli/templates/`.
 {# Conditionals #}
 {% if pad.is_pinned %}{{ "⚲" | style("pinned") }}{% endif %}
 
-{# Loops #}
-{% for pad in pads %}
+{# Loops. list.jinja reads its rows from the render-time `list_view` provider,
+   not from the handler result directly — see the padz-output skill. #}
+{% for pad in list_view.pads %}
   {% include "_pad_line.jinja" %}
 {% endfor %}
 

--- a/.claude/skills/padz-output/SKILL.md
+++ b/.claude/skills/padz-output/SKILL.md
@@ -44,12 +44,36 @@ padz list --output=json       # Machine-readable JSON
 
 Templates use Minijinja syntax. Located in `crates/padz/src/cli/templates/`.
 
+### Where template data comes from
+
+Handlers return one typed, mode-independent result (`crates/padz/src/cli/result.rs`).
+Standout serializes it once, then either emits it directly (`--output json`) or renders
+a template with it. Templates therefore see the handler's result at the top level.
+
+Terminal-only fields — column widths, status glyphs, `time_ago`, the pin marker — are
+**not** in the handler result. They are derived at render time by the view builders in
+`crates/padz/src/cli/render.rs`, registered as standout context providers
+(`context_fn`) in `crates/padz/src/cli/commands.rs`. Standout resolves providers only
+on the template path, which is what keeps structured output free of them.
+
+Two templates read a provider rather than the raw result:
+
+| Template | Reads | Provider |
+| -------- | ----- | -------- |
+| `list.jinja` | `list_view` | `render::list_view_provider` |
+| `modification_result.jinja` | `modification_view` | `render::modification_view_provider` |
+
+Every other template reads the handler result directly.
+
 ### Main Templates
 
-- `list.jinja` - Pad list with columns, indentation, status icons
+- `list.jinja` - Pad list with columns, indentation, status icons (via `list_view`)
+- `modification_result.jinja` - Pads changed by a command (via `modification_view`)
+- `view.jinja` - `padz view`: title + body per pad
 - `full_pad.jinja` - Complete pad view (title + content)
 - `text_list.jinja` - Simple line-by-line output
 - `messages.jinja` - Command feedback (success/error/info)
+- `path.jinja` / `uuid.jinja` - One pad path / uuid per line
 
 ### Partial Templates (reusable)
 
@@ -62,8 +86,9 @@ Templates use Minijinja syntax. Located in `crates/padz/src/cli/templates/`.
 
 ```jinja
 {#- Whitespace-trimming comment -#}
-{% for pad in pads %}
-  {{- pad.title | col(width) | style("list-title") | nl -}}
+{%- set view = list_view -%}
+{% for pad in view.pads %}
+  {{- pad.title | col(pad.title_width) | style("list-title") | nl -}}
 {% endfor %}
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "console 0.15.11",
  "dark-light",
  "directories",
+ "minijinja",
  "once_cell",
  "padzapp",
  "predicates",

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -26,6 +26,9 @@ once_cell = "1.19"
 standout = "7.6.4"
 standout-macros = "7.6.4"
 standout-dispatch = "7.6.4"
+# Standout's template engine. Needed directly to type the context providers in
+# cli::render, whose values standout hands to MiniJinja.
+minijinja = "2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -17,6 +17,7 @@
 //! 5. **Error Handling**: Convert errors to user-friendly messages and exit codes
 
 use super::handlers::AppState;
+use super::render::{list_view_provider, modification_view_provider, LIST_VIEW, MODIFICATION_VIEW};
 use super::setup::{
     build_command, parse_cli, Cli, Commands, CompletionAction, CompletionShell, ConfigSubcommand,
 };
@@ -25,7 +26,7 @@ use padzapp::config::PadzConfig;
 use padzapp::error::Result;
 use padzapp::init::initialize;
 use standout::cli::{App, RunResult};
-use standout::{embed_styles, embed_templates, OutputMode};
+use standout::{embed_styles, embed_templates};
 use std::io::IsTerminal;
 
 pub fn run() -> Result<()> {
@@ -48,7 +49,7 @@ pub fn run() -> Result<()> {
     }
 
     // Initialize app state for handlers
-    let app_state = create_app_state(&cli, output_mode)?;
+    let app_state = create_app_state(&cli)?;
 
     // Determine effective args: handle naked invocation by injecting synthetic command
     let args: Vec<String> = if cli.command.is_none() {
@@ -71,6 +72,11 @@ pub fn run() -> Result<()> {
 }
 
 /// Build the dispatch-ready App with templates, styles, command configuration, and app state
+///
+/// The two `context_fn` registrations are the render-time seam: handlers return typed,
+/// mode-independent results, and these providers derive the template-ready view from
+/// the serialized result. Standout resolves context providers only when it renders a
+/// template, so structured output never sees the derived presentation fields.
 fn build_dispatch_app(app_state: AppState) -> App {
     App::builder()
         .app_state(app_state)
@@ -78,6 +84,8 @@ fn build_dispatch_app(app_state: AppState) -> App {
         .template_ext(".jinja")
         .styles(embed_styles!("src/styles"))
         .default_theme("default")
+        .context_fn(LIST_VIEW, list_view_provider)
+        .context_fn(MODIFICATION_VIEW, modification_view_provider)
         .commands(Commands::dispatch_config())
         .expect("Failed to configure commands")
         .build()
@@ -124,7 +132,10 @@ fn handle_dispatch_result(result: RunResult) -> Result<()> {
 }
 
 /// Create app state containing API, scope, and configuration for handlers
-fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
+///
+/// Deliberately takes no `OutputMode`: durable state carries no rendering concern.
+/// The mode stays here in the app-execution path, where it is passed to `dispatch`.
+fn create_app_state(cli: &Cli) -> Result<AppState> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     let data_override = cli.data.as_ref().map(std::path::PathBuf::from);
 
@@ -174,7 +185,6 @@ fn create_app_state(cli: &Cli, output_mode: OutputMode) -> Result<AppState> {
         padz_ctx.api,
         padz_ctx.scope,
         padz_ctx.config.import_extensions(),
-        output_mode,
         padz_ctx.config.mode,
         local_padz_dir,
     ))

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -14,21 +14,22 @@
 // Allow non_snake_case for macro-generated __handler wrapper functions
 #![allow(non_snake_case)]
 
-use padzapp::api::{PadFilter, PadStatusFilter, PadzApi, TodoStatus};
+use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
 use padzapp::clipboard::{copy_to_clipboard, format_for_clipboard};
 use padzapp::commands::{CmdResult, NestingMode};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
 use padzapp::model::{extract_title_and_body, Scope};
 use padzapp::store::fs::FileStore;
-use serde_json::Value;
 use standout::cli::{CommandContext, Output};
-use standout::OutputMode;
 use standout_macros::handler;
 use std::cell::RefCell;
 use std::io::IsTerminal;
 
-use super::render::{build_list_result_value, build_modification_result_value, ListOptions};
+use super::result::{
+    ListRequest, MessagesResult, ModificationRequest, ModificationResult, PadContent,
+    PadContentResult, PadListResult, PathResult, UuidResult,
+};
 
 // =============================================================================
 // App State Types (for standout's type-based app_state lookup)
@@ -40,11 +41,14 @@ pub struct ImportExtensions(pub Vec<String>);
 
 /// Shared application state injected via app_state
 /// Contains the API instance wrapped in RefCell for interior mutability
+///
+/// State is deliberately free of `OutputMode`: handlers return one typed result
+/// regardless of `--output`, and the output mode is resolved at the app-execution
+/// boundary (see [`super::commands`]).
 pub struct AppState {
     api: RefCell<PadzApi<FileStore>>,
     pub scope: Scope,
     pub import_extensions: ImportExtensions,
-    pub output_mode: OutputMode,
     pub mode: PadzMode,
     /// The local `.padz/` directory (pre-link-resolution), used by link/unlink commands.
     pub local_padz_dir: std::path::PathBuf,
@@ -55,7 +59,6 @@ impl AppState {
         api: PadzApi<FileStore>,
         scope: Scope,
         import_extensions: Vec<String>,
-        output_mode: OutputMode,
         mode: PadzMode,
         local_padz_dir: std::path::PathBuf,
     ) -> Self {
@@ -63,10 +66,18 @@ impl AppState {
             api: RefCell::new(api),
             scope,
             import_extensions: ImportExtensions(import_extensions),
-            output_mode,
             mode,
             local_padz_dir,
         }
+    }
+
+    /// Whether todo status icons are part of this invocation's request.
+    ///
+    /// Todos mode asks for them implicitly; `force` covers commands that change
+    /// status (`complete`, `reopen`) and the explicit `--show-status` flag.
+    /// Mode-independent: it says what to include, not how to draw it.
+    pub fn wants_status(&self, force: bool) -> bool {
+        force || self.mode == PadzMode::Todos
     }
 
     /// Access the API with mutable borrow
@@ -89,7 +100,8 @@ fn get_state(ctx: &CommandContext) -> &AppState {
 // Scoped API - eliminates handler boilerplate
 // =============================================================================
 
-/// Scoped API accessor that binds scope and handles error conversion + rendering.
+/// Scoped API accessor that binds scope, converts errors, and maps `CmdResult` into
+/// the CLI's typed result contract.
 ///
 /// This wrapper eliminates the repetitive boilerplate pattern:
 /// ```ignore
@@ -97,13 +109,16 @@ fn get_state(ctx: &CommandContext) -> &AppState {
 /// let result = state.with_api(|api| {
 ///     api.method(state.scope, &args).map_err(|e| anyhow::anyhow!("{}", e))
 /// })?;
-/// Ok(Output::Render(build_modification_result_value(...)))
+/// Ok(Output::Render(ModificationResult { ... }))
 /// ```
 ///
 /// With ScopedApi, handlers become one-liners:
 /// ```ignore
 /// api(ctx).pin_pads(&indexes)
 /// ```
+///
+/// Nothing here renders or prints: it returns the same typed value whatever
+/// `--output` asked for.
 pub struct ScopedApi<'a> {
     state: &'a AppState,
 }
@@ -118,83 +133,119 @@ impl<'a> ScopedApi<'a> {
             .with_api(|api| f(api, self.state.scope).map_err(|e| anyhow::anyhow!("{}", e)))
     }
 
-    /// Wrap a CmdResult (modification) into rendered output.
-    /// When `force_show_status` is true, status icons are shown regardless of mode.
+    /// Map a CmdResult (modification) into the typed modification result.
+    /// When `force_show_status` is true, status icons are requested regardless of mode.
     fn modification(
         &self,
         action: &str,
         result: CmdResult,
         force_show_status: bool,
-    ) -> Result<Output<Value>, anyhow::Error> {
-        Ok(Output::Render(build_modification_result_value(
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+        Ok(Output::Render(self.modification_result(
             action,
-            &result.affected_pads,
-            &result.messages,
-            self.state.output_mode,
-            self.state.mode,
+            result,
             force_show_status,
         )))
     }
 
-    /// Wrap a CmdResult (messages only) into rendered output
-    fn messages(&self, result: CmdResult) -> Result<Output<Value>, anyhow::Error> {
-        Ok(Output::Render(serde_json::json!({
-            "messages": result.messages,
-        })))
+    /// Build a typed modification result without wrapping it in `Output`.
+    ///
+    /// Used by the handlers that assemble a `CmdResult` themselves (create, edit).
+    fn modification_result(
+        &self,
+        action: &str,
+        result: CmdResult,
+        force_show_status: bool,
+    ) -> ModificationResult {
+        ModificationResult {
+            action: action.to_string(),
+            pads: result.affected_pads,
+            messages: result.messages,
+            request: ModificationRequest {
+                status: self.state.wants_status(force_show_status),
+            },
+        }
+    }
+
+    /// Map a CmdResult (messages only) into the typed messages result
+    fn messages(&self, result: CmdResult) -> Result<Output<MessagesResult>, anyhow::Error> {
+        Ok(Output::Render(MessagesResult::new(result.messages)))
     }
 
     // --- Modification operations ---
 
-    pub fn pin_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn pin_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.pin_pads(scope, indexes))?;
         self.modification("Pinned", result, false)
     }
 
-    pub fn unpin_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn unpin_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.unpin_pads(scope, indexes))?;
         self.modification("Unpinned", result, false)
     }
 
-    pub fn delete_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn delete_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_pads(scope, indexes))?;
         self.modification("Deleted", result, false)
     }
 
-    pub fn delete_completed_pads(&self) -> Result<Output<Value>, anyhow::Error> {
-        let result = self.call(|api, scope| api.delete_completed_pads(scope))?;
+    pub fn delete_completed_pads(&self) -> Result<Output<ModificationResult>, anyhow::Error> {
+        let mut result = self.call(|api, scope| api.delete_completed_pads(scope))?;
 
         if result.affected_pads.is_empty() {
-            return Ok(Output::Render(serde_json::json!({
-                "start_message": "",
-                "pads": [],
-                "trailing_messages": [{"content": "No completed pads to delete.", "style": "info"}]
-            })));
+            result
+                .messages
+                .push(CmdMessage::info("No completed pads to delete."));
         }
 
         self.modification("Deleted", result, false)
     }
 
-    pub fn restore_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn restore_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.restore_pads(scope, indexes))?;
         self.modification("Restored", result, false)
     }
 
-    pub fn archive_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn archive_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.archive_pads(scope, indexes))?;
         self.modification("Archived", result, false)
     }
 
-    pub fn unarchive_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn unarchive_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.unarchive_pads(scope, indexes))?;
         self.modification("Unarchived", result, false)
     }
 
-    pub fn complete_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn complete_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.complete_pads(scope, indexes))?;
         self.modification("Completed", result, true)
     }
 
-    pub fn reopen_pads(&self, indexes: &[String]) -> Result<Output<Value>, anyhow::Error> {
+    pub fn reopen_pads(
+        &self,
+        indexes: &[String],
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.reopen_pads(scope, indexes))?;
         self.modification("Reopened", result, true)
     }
@@ -203,7 +254,7 @@ impl<'a> ScopedApi<'a> {
         &self,
         indexes: &[String],
         to_root: bool,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = if to_root {
             self.call(|api, scope| api.move_pads(scope, indexes, None))?
         } else {
@@ -225,31 +276,31 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
         yes: bool,
         recursive: bool,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         let include_done = self.state.mode == PadzMode::Todos;
         let result =
             self.call(|api, scope| api.purge_pads(scope, indexes, recursive, yes, include_done))?;
         self.messages(result)
     }
 
-    pub fn doctor(&self) -> Result<Output<Value>, anyhow::Error> {
+    pub fn doctor(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.doctor(scope))?;
         self.messages(result)
     }
 
-    pub fn init(&self) -> Result<Output<Value>, anyhow::Error> {
+    pub fn init(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.init(scope))?;
         self.messages(result)
     }
 
-    pub fn init_link(&self, target: &str) -> Result<Output<Value>, anyhow::Error> {
+    pub fn init_link(&self, target: &str) -> Result<Output<MessagesResult>, anyhow::Error> {
         let target_path = std::path::PathBuf::from(target);
         let local_padz = &self.state.local_padz_dir;
         let result = self.call(|api, _scope| api.init_link(local_padz, &target_path))?;
         self.messages(result)
     }
 
-    pub fn init_unlink(&self) -> Result<Output<Value>, anyhow::Error> {
+    pub fn init_unlink(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
         let local_padz = &self.state.local_padz_dir;
         let result = self.call(|api, _scope| api.init_unlink(local_padz))?;
         self.messages(result)
@@ -263,7 +314,7 @@ impl<'a> ScopedApi<'a> {
         json: bool,
         with_metadata: bool,
         nesting: NestingMode,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = if let Some(title) = single_file {
             self.call(|api, scope| api.export_pads_single_file(scope, indexes, title, nesting))?
         } else if json {
@@ -277,7 +328,7 @@ impl<'a> ScopedApi<'a> {
     pub fn import_pads(
         &self,
         paths: Vec<std::path::PathBuf>,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         let extensions = &self.state.import_extensions.0;
         let result = self.call(|api, scope| api.import_pads(scope, paths.clone(), extensions))?;
         self.messages(result)
@@ -289,7 +340,7 @@ impl<'a> ScopedApi<'a> {
         to: Option<&str>,
         from: Option<&str>,
         mode: padzapp::commands::transfer::TransferMode,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         match (to, from) {
             (Some(dest), None) => {
                 let path = std::path::PathBuf::from(dest);
@@ -310,12 +361,12 @@ impl<'a> ScopedApi<'a> {
 
     // --- Tags subcommand operations ---
 
-    pub fn list_tags(&self) -> Result<Output<Value>, anyhow::Error> {
+    pub fn list_tags(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.list_tags(scope))?;
         self.messages(result)
     }
 
-    pub fn delete_tag(&self, name: &str) -> Result<Output<Value>, anyhow::Error> {
+    pub fn delete_tag(&self, name: &str) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_tag(scope, name))?;
         self.messages(result)
     }
@@ -324,7 +375,7 @@ impl<'a> ScopedApi<'a> {
         &self,
         old_name: &str,
         new_name: &str,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.rename_tag(scope, old_name, new_name))?;
         self.messages(result)
     }
@@ -341,26 +392,24 @@ impl<'a> ScopedApi<'a> {
         ids: &[String],
         show_uuid: bool,
         show_status: bool,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<PadListResult>, anyhow::Error> {
         let filtered = filter.search_term.is_some()
             || filter.todo_status.is_some()
             || filter.tags.is_some()
             || !ids.is_empty();
         let result = self.call(|api, scope| api.get_pads(scope, filter, ids))?;
-        Ok(Output::Render(build_list_result_value(
-            &result.listed_pads,
-            &result.messages,
-            ListOptions {
+        Ok(Output::Render(PadListResult {
+            pads: result.listed_pads,
+            messages: result.messages,
+            request: ListRequest {
                 peek,
-                show_deleted_help,
-                show_all_sections,
-                output_mode: self.state.output_mode,
-                mode: self.state.mode,
-                show_uuid,
+                uuid: show_uuid,
+                status: self.state.wants_status(show_status),
                 filtered,
-                show_status,
+                deleted_help: show_deleted_help,
+                sections: show_all_sections,
             },
-        )))
+        }))
     }
 
     // --- View operations ---
@@ -370,7 +419,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
         show_uuid: bool,
         nesting: NestingMode,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<PadContentResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
         // Copy content to clipboard (only root-level pads for tree/indented)
@@ -386,7 +435,7 @@ impl<'a> ScopedApi<'a> {
             _ => 0,
         };
 
-        let pads: Vec<serde_json::Value> = result
+        let pads: Vec<PadContent> = result
             .listed_pads
             .iter()
             .enumerate()
@@ -410,18 +459,15 @@ impl<'a> ScopedApi<'a> {
                     )
                 };
 
-                let mut v = serde_json::json!({
-                    "title": display_title,
-                    "content": display_body,
-                    "depth": depth,
-                });
-                if show_uuid {
-                    v["uuid"] = serde_json::json!(dp.pad.metadata.id.to_string());
+                PadContent {
+                    title: display_title,
+                    content: display_body,
+                    depth,
+                    uuid: show_uuid.then(|| dp.pad.metadata.id.to_string()),
                 }
-                v
             })
             .collect();
-        Ok(Output::Render(serde_json::json!({ "pads": pads })))
+        Ok(Output::Render(PadContentResult { pads }))
     }
 
     // --- Copy operations ---
@@ -430,7 +476,7 @@ impl<'a> ScopedApi<'a> {
         &self,
         indexes: &[String],
         nesting: NestingMode,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
         let indent_per_level: usize = match nesting {
@@ -483,9 +529,9 @@ impl<'a> ScopedApi<'a> {
             root_titles.join(", ")
         );
 
-        Ok(Output::Render(serde_json::json!({
-            "messages": [{ "content": msg, "style": "info" }]
-        })))
+        Ok(Output::Render(MessagesResult::new(vec![CmdMessage::info(
+            msg,
+        )])))
     }
 }
 
@@ -588,7 +634,7 @@ pub fn create(
     #[arg] inside: Option<String>,
     #[arg] format: Option<String>,
     #[arg] title: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     let state = get_state(ctx);
     let title_arg = if title.is_empty() {
         None
@@ -640,11 +686,7 @@ pub fn create(
     } else if let Some(raw) = try_read_stdin()? {
         // Piped content from stdin
         if raw.is_empty() {
-            return Ok(Output::Render(serde_json::json!({
-                "start_message": "",
-                "pads": [],
-                "trailing_messages": [{"content": "Aborted: empty content", "style": "warning"}]
-            })));
+            return Ok(Output::Render(aborted_create()));
         }
         let parsed = padzapp::editor::EditorContent::from_buffer(&raw);
         // Determine title: title_arg override > parsed title > empty
@@ -703,24 +745,26 @@ pub fn create(
             }
             None => {
                 // Empty file - user aborted
-                return Ok(Output::Render(serde_json::json!({
-                    "start_message": "",
-                    "pads": [],
-                    "trailing_messages": [{"content": "Aborted: empty content", "style": "warning"}]
-                })));
+                return Ok(Output::Render(aborted_create()));
             }
         }
     };
 
-    let data = build_modification_result_value(
-        "Created",
-        &result.affected_pads,
-        &result.messages,
-        state.output_mode,
-        state.mode,
-        false,
-    );
-    Ok(Output::Render(data))
+    Ok(Output::Render(
+        api(ctx).modification_result("Created", result, false),
+    ))
+}
+
+/// The result of a `create` the user abandoned by supplying no content.
+///
+/// No pad was created, so there is nothing to report but the warning.
+fn aborted_create() -> ModificationResult {
+    ModificationResult {
+        action: "Created".to_string(),
+        pads: Vec::new(),
+        messages: vec![CmdMessage::warning("Aborted: empty content")],
+        request: ModificationRequest::default(),
+    }
 }
 
 /// List all pads with optional filtering.
@@ -742,7 +786,7 @@ pub fn list(
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
     #[flag(name = "show_status")] show_status: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<PadListResult>, anyhow::Error> {
     let todo_status = if planned {
         Some(TodoStatus::Planned)
     } else if completed {
@@ -785,7 +829,7 @@ pub fn peek(
     #[arg] ids: Vec<String>,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<PadListResult>, anyhow::Error> {
     let filter = PadFilter {
         status: PadStatusFilter::Active,
         search_term: None,
@@ -806,7 +850,7 @@ pub fn search(
     #[flag] completed: bool,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<PadListResult>, anyhow::Error> {
     let filter = PadFilter {
         status: if all {
             PadStatusFilter::All
@@ -842,7 +886,7 @@ pub fn view(
     #[flag] flat: bool,
     #[flag] tree: bool,
     #[flag] indented: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<PadContentResult>, anyhow::Error> {
     let nesting = parse_nesting_mode(flat, tree, indented);
     api(ctx).view_pads(&indexes, uuid, nesting)
 }
@@ -855,7 +899,7 @@ pub fn copy(
     #[flag] flat: bool,
     #[flag] tree: bool,
     #[flag] indented: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     let nesting = parse_nesting_mode(flat, tree, indented);
     api(ctx).copy_pads(&indexes, nesting)
 }
@@ -864,7 +908,7 @@ pub fn copy(
 pub fn edit(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     let state = get_state(ctx);
 
     // Split args into index selectors and trailing content words.
@@ -896,15 +940,9 @@ pub fn edit(
         let clipboard_text = raw.clone();
         let _ = copy_to_clipboard(&clipboard_text);
 
-        let data = build_modification_result_value(
-            "Updated",
-            &result.affected_pads,
-            &result.messages,
-            state.output_mode,
-            state.mode,
-            false,
-        );
-        return Ok(Output::Render(data));
+        return Ok(Output::Render(
+            api(ctx).modification_result("Updated", result, false),
+        ));
     }
 
     // Check for piped stdin
@@ -919,15 +957,9 @@ pub fn edit(
 
         copy_content_to_clipboard(&raw);
 
-        let data = build_modification_result_value(
-            "Updated",
-            &result.affected_pads,
-            &result.messages,
-            state.output_mode,
-            state.mode,
-            false,
-        );
-        return Ok(Output::Render(data));
+        return Ok(Output::Render(
+            api(ctx).modification_result("Updated", result, false),
+        ));
     }
 
     // Interactive editor: open real pad file
@@ -973,19 +1005,13 @@ pub fn edit(
                 affected_pads: vec![display_pad],
                 ..Default::default()
             };
-            let data = build_modification_result_value(
-                "Updated",
-                &result.affected_pads,
-                &result.messages,
-                state.output_mode,
-                state.mode,
-                false,
-            );
-            Ok(Output::Render(data))
+            Ok(Output::Render(
+                api(ctx).modification_result("Updated", result, false),
+            ))
         }
         None => {
             // User emptied the file
-            Ok(Output::<Value>::Silent)
+            Ok(Output::<ModificationResult>::Silent)
         }
     }
 }
@@ -995,7 +1021,7 @@ pub fn delete(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
     #[flag] completed: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     if completed {
         api(ctx).delete_completed_pads()
     } else {
@@ -1007,7 +1033,7 @@ pub fn delete(
 pub fn restore(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).restore_pads(&indexes)
 }
 
@@ -1015,7 +1041,7 @@ pub fn restore(
 pub fn archive(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).archive_pads(&indexes)
 }
 
@@ -1023,7 +1049,7 @@ pub fn archive(
 pub fn unarchive(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).unarchive_pads(&indexes)
 }
 
@@ -1032,7 +1058,7 @@ pub fn unarchive(
 pub fn pin(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).pin_pads(&indexes)
 }
 
@@ -1040,7 +1066,7 @@ pub fn pin(
 pub fn unpin(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).unpin_pads(&indexes)
 }
 
@@ -1049,45 +1075,53 @@ pub fn move_pads(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
     #[flag] root: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).move_pads(&indexes, root)
 }
 
-/// Returns pad file paths - outputs directly and returns Silent.
+/// Returns the file path of each selected pad.
 #[handler]
-pub fn path(#[ctx] ctx: &CommandContext, #[arg] indexes: Vec<String>) -> Result<(), anyhow::Error> {
+pub fn path(
+    #[ctx] ctx: &CommandContext,
+    #[arg] indexes: Vec<String>,
+) -> Result<Output<PathResult>, anyhow::Error> {
     let state = get_state(ctx);
     let result = state.with_api(|api| {
         api.pad_paths(state.scope, &indexes)
             .map_err(|e| anyhow::anyhow!("{}", e))
     })?;
 
-    for path in &result.pad_paths {
-        println!("{}", path.display());
-    }
-    Ok(())
+    Ok(Output::Render(PathResult {
+        paths: result
+            .pad_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect(),
+    }))
 }
 
-/// Returns pad UUIDs - outputs directly and returns Silent.
+/// Returns the UUID of each selected pad.
 #[handler]
-pub fn uuid(#[ctx] ctx: &CommandContext, #[arg] indexes: Vec<String>) -> Result<(), anyhow::Error> {
+pub fn uuid(
+    #[ctx] ctx: &CommandContext,
+    #[arg] indexes: Vec<String>,
+) -> Result<Output<UuidResult>, anyhow::Error> {
     let state = get_state(ctx);
     let result = state.with_api(|api| {
         api.pad_uuids(state.scope, &indexes)
             .map_err(|e| anyhow::anyhow!("{}", e))
     })?;
 
-    for msg in &result.messages {
-        println!("{}", msg.content);
-    }
-    Ok(())
+    Ok(Output::Render(UuidResult {
+        uuids: result.messages.iter().map(|m| m.content.clone()).collect(),
+    }))
 }
 
 #[handler]
 pub fn complete(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).complete_pads(&indexes)
 }
 
@@ -1095,7 +1129,7 @@ pub fn complete(
 pub fn reopen(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<ModificationResult>, anyhow::Error> {
     api(ctx).reopen_pads(&indexes)
 }
 
@@ -1109,7 +1143,7 @@ pub fn purge(
     #[arg] indexes: Vec<String>,
     #[flag] yes: bool,
     #[flag] recursive: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     api(ctx).purge_pads(&indexes, yes, recursive)
 }
 
@@ -1124,7 +1158,7 @@ pub fn export(
     #[flag] flat: bool,
     #[flag] tree: bool,
     #[flag] indented: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     let nesting = parse_nesting_mode(flat, tree, indented);
     api(ctx).export_pads(
         &indexes,
@@ -1139,7 +1173,7 @@ pub fn export(
 pub fn import(
     #[ctx] ctx: &CommandContext,
     #[arg] paths: Vec<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     let paths: Vec<std::path::PathBuf> = paths.into_iter().map(std::path::PathBuf::from).collect();
     api(ctx).import_pads(paths)
 }
@@ -1150,7 +1184,7 @@ pub fn clone(
     #[arg] indexes: Vec<String>,
     #[arg] to: Option<String>,
     #[arg] from: Option<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     api(ctx).transfer_pads(
         &indexes,
         to.as_deref(),
@@ -1165,7 +1199,7 @@ pub fn migrate(
     #[arg] indexes: Vec<String>,
     #[arg] to: Option<String>,
     #[arg] from: Option<String>,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     api(ctx).transfer_pads(
         &indexes,
         to.as_deref(),
@@ -1179,7 +1213,7 @@ pub fn migrate(
 // =============================================================================
 
 #[handler]
-pub fn doctor(#[ctx] ctx: &CommandContext) -> Result<Output<Value>, anyhow::Error> {
+pub fn doctor(#[ctx] ctx: &CommandContext) -> Result<Output<MessagesResult>, anyhow::Error> {
     api(ctx).doctor()
 }
 
@@ -1188,7 +1222,7 @@ pub fn init(
     #[ctx] ctx: &CommandContext,
     #[arg] link: Option<String>,
     #[flag] unlink: bool,
-) -> Result<Output<Value>, anyhow::Error> {
+) -> Result<Output<MessagesResult>, anyhow::Error> {
     if let Some(target) = link {
         api(ctx).init_link(&target)
     } else if unlink {
@@ -1246,42 +1280,32 @@ pub mod tag {
     pub fn add(
         #[ctx] ctx: &CommandContext,
         #[arg] args: Vec<String>,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let (indexes, tags) = split_indexes_and_tags(&args)?;
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.add_tags_to_pads(state.scope, &indexes, &tags)
                 .map_err(|e| anyhow::anyhow!("{}", e))
         })?;
-        Ok(Output::Render(build_modification_result_value(
-            "Tagged",
-            &result.affected_pads,
-            &result.messages,
-            state.output_mode,
-            state.mode,
-            false,
-        )))
+        Ok(Output::Render(
+            api(ctx).modification_result("Tagged", result, false),
+        ))
     }
 
     #[handler]
     pub fn remove(
         #[ctx] ctx: &CommandContext,
         #[arg] args: Vec<String>,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let (indexes, tags) = split_indexes_and_tags(&args)?;
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.remove_tags_from_pads(state.scope, &indexes, &tags)
                 .map_err(|e| anyhow::anyhow!("{}", e))
         })?;
-        Ok(Output::Render(build_modification_result_value(
-            "Untagged",
-            &result.affected_pads,
-            &result.messages,
-            state.output_mode,
-            state.mode,
-            false,
-        )))
+        Ok(Output::Render(
+            api(ctx).modification_result("Untagged", result, false),
+        ))
     }
 
     #[handler]
@@ -1289,7 +1313,7 @@ pub mod tag {
         #[ctx] ctx: &CommandContext,
         #[arg(name = "old_name")] old_name: String,
         #[arg(name = "new_name")] new_name: String,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         api(ctx).rename_tag(&old_name, &new_name)
     }
 
@@ -1297,7 +1321,7 @@ pub mod tag {
     pub fn delete(
         #[ctx] ctx: &CommandContext,
         #[arg] name: String,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         api(ctx).delete_tag(&name)
     }
 
@@ -1305,7 +1329,7 @@ pub mod tag {
     pub fn list(
         #[ctx] ctx: &CommandContext,
         #[arg] ids: Vec<String>,
-    ) -> Result<Output<Value>, anyhow::Error> {
+    ) -> Result<Output<MessagesResult>, anyhow::Error> {
         if ids.is_empty() {
             api(ctx).list_tags()
         } else {
@@ -1314,9 +1338,361 @@ pub mod tag {
                 api.list_pad_tags(state.scope, &ids)
                     .map_err(|e| anyhow::anyhow!("{}", e))
             })?;
-            Ok(Output::Render(serde_json::json!({
-                "messages": result.messages,
-            })))
+            Ok(Output::Render(MessagesResult::new(result.messages)))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Direct typed-handler tests.
+    //!
+    //! These call the typed function the `#[handler]` macro preserves — no
+    //! `ArgMatches`, no dispatch, no renderer. That is the whole point: a handler's
+    //! value is the same object whatever `--output` the user passed, so asserting on
+    //! it here is asserting on what both the human and the structured path receive.
+
+    use super::*;
+    use padzapp::index::DisplayIndex;
+    use padzapp::init::initialize;
+    use standout_dispatch::Extensions;
+    use std::rc::Rc;
+    use tempfile::TempDir;
+
+    /// A project-scoped store in a temp dir, wired into a CommandContext.
+    ///
+    /// Uses `data_override` so the store is explicit and no global/env state is read.
+    struct TestApp {
+        _temp: TempDir,
+        ctx: CommandContext,
+    }
+
+    impl TestApp {
+        fn new(mode: PadzMode) -> Self {
+            let temp = TempDir::new().unwrap();
+            let root = temp.path().to_path_buf();
+            let padz_ctx = initialize(&root, false, Some(root.clone()), true).unwrap();
+
+            let state = AppState::new(
+                padz_ctx.api,
+                padz_ctx.scope,
+                vec!["txt".to_string(), "md".to_string()],
+                mode,
+                root.join(".padz"),
+            );
+
+            let mut app_state = Extensions::new();
+            app_state.insert(state);
+
+            Self {
+                _temp: temp,
+                ctx: CommandContext::new(vec![], Rc::new(app_state)),
+            }
+        }
+
+        /// Seeds a pad straight through the API, bypassing the create handler (which
+        /// would want an editor).
+        fn seed(&self, title: &str, body: &str) {
+            let state = get_state(&self.ctx);
+            state
+                .with_api(|api| api.create_pad(state.scope, title.into(), body.into(), None))
+                .unwrap();
+        }
+    }
+
+    fn rendered<T>(output: Output<T>) -> T
+    where
+        T: serde::Serialize,
+    {
+        match output {
+            Output::Render(data) => data,
+            _ => panic!("expected Output::Render"),
+        }
+    }
+
+    // --- list -----------------------------------------------------------------
+
+    #[test]
+    fn list_returns_typed_pads_with_display_indexes() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("First", "body");
+        app.seed("Second", "body");
+
+        let result = rendered(
+            list(
+                &app.ctx,
+                vec![],
+                None,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                vec![],
+                false,
+                false,
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(result.pads.len(), 2);
+        // Canonical display identifiers come from index_pads and are preserved as-is.
+        assert!(matches!(result.pads[0].index, DisplayIndex::Regular(1)));
+        assert!(matches!(result.pads[1].index, DisplayIndex::Regular(2)));
+        assert_eq!(result.request, ListRequest::default());
+    }
+
+    #[test]
+    fn list_in_todos_mode_requests_status_icons() {
+        let app = TestApp::new(PadzMode::Todos);
+        app.seed("Todo", "body");
+
+        let result = rendered(
+            list(
+                &app.ctx,
+                vec![],
+                None,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                vec![],
+                false,
+                false,
+            )
+            .unwrap(),
+        );
+
+        // Todos mode asks for status icons implicitly; notes mode does not.
+        assert!(result.request.status);
+    }
+
+    #[test]
+    fn list_records_the_display_request() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Only", "body");
+
+        let result = rendered(
+            list(
+                &app.ctx,
+                vec![],
+                None,
+                false,
+                false,
+                false,
+                true, // peek
+                false,
+                false,
+                false,
+                vec![],
+                true,  // uuid
+                false, // show_status
+            )
+            .unwrap(),
+        );
+
+        assert!(result.request.peek);
+        assert!(result.request.uuid);
+        assert!(!result.request.filtered);
+    }
+
+    #[test]
+    fn search_marks_the_listing_filtered() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Alpha", "body");
+        app.seed("Beta", "body");
+
+        let result = rendered(
+            search(
+                &app.ctx,
+                "Alpha".to_string(),
+                false,
+                false,
+                false,
+                false,
+                vec![],
+                false,
+            )
+            .unwrap(),
+        );
+
+        // An empty filtered listing means "nothing matched", not "no pads yet".
+        assert!(result.request.filtered);
+        assert_eq!(result.pads.len(), 1);
+        assert_eq!(result.pads[0].pad.metadata.title, "Alpha");
+    }
+
+    // --- view -----------------------------------------------------------------
+
+    #[test]
+    fn view_returns_title_and_body_without_uuid_by_default() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Viewed", "the body");
+
+        let result = rendered(
+            view(
+                &app.ctx,
+                vec!["1".into()],
+                false,
+                false,
+                false,
+                false,
+                false,
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(result.pads.len(), 1);
+        assert_eq!(result.pads[0].title, "Viewed");
+        assert!(result.pads[0].content.contains("the body"));
+        assert_eq!(result.pads[0].depth, 0);
+        assert!(result.pads[0].uuid.is_none());
+    }
+
+    #[test]
+    fn view_includes_uuid_when_requested() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Viewed", "the body");
+
+        // view's flags are (peek, uuid, flat, tree, indented).
+        let result =
+            rendered(view(&app.ctx, vec!["1".into()], false, true, false, false, false).unwrap());
+
+        assert!(result.pads[0].uuid.is_some());
+    }
+
+    // --- mutation -------------------------------------------------------------
+
+    #[test]
+    fn pin_returns_the_action_and_the_affected_pad() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Pin me", "body");
+
+        let result = rendered(pin(&app.ctx, vec!["1".into()]).unwrap());
+
+        assert_eq!(result.action, "Pinned");
+        assert_eq!(result.pads.len(), 1);
+        assert_eq!(result.pads[0].pad.metadata.title, "Pin me");
+        assert!(result.pads[0].pad.metadata.is_pinned);
+    }
+
+    #[test]
+    fn complete_requests_status_icons_even_in_notes_mode() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Finish me", "body");
+
+        let result = rendered(complete(&app.ctx, vec!["1".into()]).unwrap());
+
+        assert_eq!(result.action, "Completed");
+        // A command that changes status always shows it, whatever the mode.
+        assert!(result.request.status);
+    }
+
+    #[test]
+    fn delete_completed_with_nothing_to_delete_reports_a_message() {
+        let app = TestApp::new(PadzMode::Todos);
+        app.seed("Still open", "body");
+
+        let result = rendered(delete(&app.ctx, vec![], true).unwrap());
+
+        assert!(result.pads.is_empty());
+        assert_eq!(result.messages.len(), 1);
+        assert!(result.messages[0].content.contains("No completed pads"));
+    }
+
+    // --- path / uuid ----------------------------------------------------------
+
+    #[test]
+    fn path_returns_the_pad_file_path_instead_of_printing_it() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Located", "body");
+
+        let result = rendered(path(&app.ctx, vec!["1".into()]).unwrap());
+
+        assert_eq!(result.paths.len(), 1);
+        assert!(result.paths[0].contains(".padz"));
+        assert!(std::path::Path::new(&result.paths[0]).exists());
+    }
+
+    #[test]
+    fn uuid_returns_the_pad_uuid_instead_of_printing_it() {
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Identified", "body");
+
+        let expected = {
+            let state = get_state(&app.ctx);
+            let listed = state
+                .with_api(|api| api.view_pads(state.scope, &["1".to_string()], NestingMode::Flat))
+                .unwrap();
+            listed.listed_pads[0].pad.metadata.id.to_string()
+        };
+
+        let result = rendered(uuid(&app.ctx, vec!["1".into()]).unwrap());
+
+        assert_eq!(result.uuids, vec![expected]);
+    }
+
+    // --- the mode-independence contract ---------------------------------------
+
+    #[test]
+    fn handler_results_serialize_to_one_shape_for_every_output_mode() {
+        // There is no mode input to a handler, so there is only one value to serialize.
+        // This pins the shape that both the template path and the structured path see.
+        let app = TestApp::new(PadzMode::Notes);
+        app.seed("Only", "body");
+
+        let result = rendered(
+            list(
+                &app.ctx,
+                vec![],
+                None,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                vec![],
+                false,
+                false,
+            )
+            .unwrap(),
+        );
+
+        let json = serde_json::to_value(&result).unwrap();
+        assert!(json.get("pads").unwrap().is_array());
+        assert!(json.get("messages").unwrap().is_array());
+        assert!(json.get("request").unwrap().is_object());
+
+        // Terminal-only derivations must not be anywhere in the handler's value.
+        let raw = serde_json::to_string(&json).unwrap();
+        for template_only in [
+            "title_width",
+            "line_width",
+            "status_icon",
+            "time_ago",
+            "left_pin",
+        ] {
+            assert!(
+                !raw.contains(template_only),
+                "handler result leaked the template-only field `{template_only}`"
+            );
+        }
+    }
+
+    #[test]
+    fn app_state_paths_are_untouched_by_rendering() {
+        // AppState carries no OutputMode: nothing in it can branch on presentation.
+        let app = TestApp::new(PadzMode::Notes);
+        let state = get_state(&app.ctx);
+        assert_eq!(state.mode, PadzMode::Notes);
+        assert!(state.wants_status(true));
+        assert!(!state.wants_status(false));
     }
 }

--- a/crates/padz/src/cli/mod.rs
+++ b/crates/padz/src/cli/mod.rs
@@ -53,14 +53,17 @@
 //!
 //! ## Module Structure
 //!
-//! - `commands`: Per-command handlers that call API and format output
-//! - `render`: Output formatting using standout's `App` (styles and templates embedded at compile time)
+//! - `commands`: App construction, state wiring, and dispatch
+//! - `handlers`: Thin typed adapters — extract args, call the API, return a typed result
+//! - `result`: The typed, mode-independent result each handler returns
+//! - `render`: Render-time view derivation for standout's templates
 //! - `setup`: Argument parsing via clap, help text
 
 mod commands;
 mod complete;
 pub mod handlers;
-mod render;
+pub mod render;
+pub mod result;
 pub mod setup;
 
 pub use commands::run;

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -1,35 +1,54 @@
 //! # Rendering Module
 //!
-//! This module builds data structures for standout's template-based rendering.
-//! The CLI layer uses standout's `App` for actual rendering via templates and styles.
+//! This module derives **template-ready view data** from the typed, mode-independent
+//! results that handlers return (see [`super::result`]). It is a render concern only:
+//! nothing here runs unless standout has decided to render a human template.
 //!
 //! ## Architecture
 //!
-//! - Handlers call `build_*_value` functions to create `serde_json::Value` data
-//! - Handlers return `Output::Render(value)` to standout's dispatch pipeline
-//! - Standout renders using templates embedded via `embed_templates!` macro
-//! - Structured output modes (JSON, YAML) are handled automatically
+//! ```text
+//! handler -> Output::Render(typed result) -> serialize once
+//!                                              |-- structured mode: emitted as-is
+//!                                              `-- human mode: template + view builder
+//! ```
+//!
+//! Handlers return one value regardless of `--output`. Standout serializes it once and
+//! then either emits it directly (json/yaml/xml/csv) or renders a MiniJinja template
+//! with it. The view builders here are registered as standout **context providers**
+//! (`AppBuilder::context_fn`, wired in [`super::commands`]), which standout resolves
+//! *only* on the template path. That is the seam that keeps column widths, glyphs, and
+//! relative timestamps out of structured output while still giving templates
+//! everything they need — derived from the very same handler value.
+//!
+//! Providers receive the serialized result as JSON, so each one deserializes it back
+//! into its typed result and returns `undefined` if the data is a different command's
+//! shape. Templates only read the provider matching their own command, so a
+//! non-matching provider is simply unused.
 //!
 //! ## Table Layout
 //!
-//! The list view uses standout's `col()` filter for declarative column layout. Each row has:
+//! The list view uses standout's `tabular()` filter for declarative column layout.
+//! Each row has:
 //! - `left_pin` (2 chars): Pin marker for pinned pads (both sections) or empty
 //! - `status_icon` (2 chars): Todo status indicator
 //! - `index` (4 chars): Display index (p1., 1., d1.)
 //! - `title` (fill): Pad title, truncated to fit
 //! - `time_ago` (14 chars, right-aligned): Relative timestamp
 //!
-//! Column widths are defined as constants and the title width is calculated per-row based on
-//! the variable prefix width (which depends on section type and nesting depth).
-//!
+//! Column widths are defined as constants and the title width is calculated per-row
+//! based on the variable prefix width (which depends on section type and nesting
+//! depth). Each row carries its own column widths so that `_pad_line.jinja` is
+//! self-contained and can be shared by the list and modification templates.
 
+use super::result::{ModificationResult, PadListResult};
 use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
+use minijinja::Value;
 use padzapp::api::{CmdMessage, MessageLevel, TodoStatus};
-use padzapp::config::PadzMode;
 use padzapp::index::{DisplayIndex, DisplayPad};
 use padzapp::peek::format_as_peek;
-use standout::{truncate_to_width, OutputMode};
+use standout::context::RenderContext;
+use standout::truncate_to_width;
 
 /// Minimum terminal width — below this we stop shrinking and let the terminal wrap.
 pub const MIN_LINE_WIDTH: usize = 30;
@@ -58,7 +77,7 @@ pub fn line_width() -> usize {
     raw.max(MIN_LINE_WIDTH).saturating_sub(1)
 }
 
-/// Column widths for list layout (used by standout's `col()` filter)
+/// Column widths for list layout (used by standout's `tabular()` filter)
 pub const COL_LEFT_PIN: usize = 2; // Pin marker or empty ("⚲ " or "  ")
 pub const COL_STATUS: usize = 2; // Status icon + space
 pub const COL_INDEX: usize = 4; // "p1.", " 1.", "d1."
@@ -69,157 +88,105 @@ pub const STATUS_PLANNED: &str = "⚪︎";
 pub const STATUS_IN_PROGRESS: &str = "☉︎︎";
 pub const STATUS_DONE: &str = "⚫︎";
 
-/// Builds modification result data as serde_json::Value for Dispatch handlers.
+/// The context name `list.jinja` reads its view data from.
+pub const LIST_VIEW: &str = "list_view";
+/// The context name `modification_result.jinja` reads its view data from.
+pub const MODIFICATION_VIEW: &str = "modification_view";
+
+// =============================================================================
+// Context providers (the render-time seam)
+// =============================================================================
+
+/// Context provider for `list.jinja`.
 ///
-/// This function creates the appropriate data structure based on output mode:
-/// - For structured modes (JSON, YAML): Clean API-friendly format with just action, pads, messages
-/// - For terminal modes: Full template-ready format with column widths and transformed pad data
+/// Returns `undefined` when the rendered command did not produce a [`PadListResult`].
+pub fn list_view_provider(ctx: &RenderContext) -> Value {
+    match serde_json::from_value::<PadListResult>(ctx.data.clone()) {
+        Ok(result) => Value::from_serialize(build_list_view(&result)),
+        Err(_) => Value::UNDEFINED,
+    }
+}
+
+/// Context provider for `modification_result.jinja`.
 ///
-/// Used by LocalApp handlers that need to return data for standout's rendering pipeline.
-pub fn build_modification_result_value(
-    action_verb: &str,
-    pads: &[DisplayPad],
-    trailing_messages: &[CmdMessage],
-    output_mode: OutputMode,
-    mode: PadzMode,
-    force_show_status: bool,
-) -> serde_json::Value {
+/// Returns `undefined` when the rendered command did not produce a
+/// [`ModificationResult`].
+pub fn modification_view_provider(ctx: &RenderContext) -> Value {
+    match serde_json::from_value::<ModificationResult>(ctx.data.clone()) {
+        Ok(result) => Value::from_serialize(build_modification_view(&result)),
+        Err(_) => Value::UNDEFINED,
+    }
+}
+
+// =============================================================================
+// View builders
+// =============================================================================
+
+/// Builds the template-ready view for a modification result.
+///
+/// Produces the start message ("Created 1 pad..."), one self-contained row per
+/// affected pad, and the trailing messages.
+pub fn build_modification_view(result: &ModificationResult) -> serde_json::Value {
     use serde_json::json;
 
-    // For structured modes, return clean API format
-    if output_mode.is_structured() {
-        return json!({
-            "action": action_verb,
-            "pads": pads,
-            "messages": trailing_messages,
-        });
-    }
-
-    let show_status = force_show_status || mode == PadzMode::Todos;
+    let show_status = result.request.status;
     let col_status = if show_status { COL_STATUS } else { 0 };
     let width = line_width();
 
-    // For terminal modes, build full template data
-    let count = pads.len();
+    let count = result.pads.len();
     let start_message = if count == 0 {
         String::new()
     } else {
         let pad_word = if count == 1 { "pad" } else { "pads" };
-        format!("{} {} {}...", action_verb, count, pad_word)
+        format!("{} {} {}...", result.action, count, pad_word)
     };
 
-    // Convert pads to template-ready format
-    let pad_lines: Vec<serde_json::Value> = pads
+    let pad_lines: Vec<serde_json::Value> = result
+        .pads
         .iter()
         .map(|dp| {
-            let is_pinned_section = matches!(dp.index, DisplayIndex::Pinned(_));
-            let is_deleted = matches!(dp.index, DisplayIndex::Deleted(_));
-
-            let local_idx_str = match &dp.index {
-                DisplayIndex::Pinned(n) => format!("p{}", n),
-                DisplayIndex::Regular(n) => format!("{:2}", n),
-                DisplayIndex::Archived(n) => format!("ar{}", n),
-                DisplayIndex::Deleted(n) => format!("d{}", n),
-            };
-            let full_idx_str = format!("{}.", local_idx_str);
-
-            let status_icon = if show_status {
-                match dp.pad.metadata.status {
-                    TodoStatus::Planned => STATUS_PLANNED,
-                    TodoStatus::InProgress => STATUS_IN_PROGRESS,
-                    TodoStatus::Done => STATUS_DONE,
-                }
-            } else {
-                ""
-            };
-
-            let left_pin = if dp.pad.metadata.is_pinned {
-                PIN_MARKER.to_string()
-            } else {
-                String::new()
-            };
-
             let fixed_columns = COL_LEFT_PIN + col_status + COL_INDEX + COL_TIME;
-            let title_width = width.saturating_sub(fixed_columns);
-
-            json!({
-                "indent": "",
-                "left_pin": left_pin,
-                "status_icon": status_icon,
-                "index": full_idx_str,
-                "title": dp.pad.metadata.title,
-                "title_width": title_width,
-                "tags": dp.pad.metadata.tags,
-                "tags_display": format_tags_display(&dp.pad.metadata.tags),
-                "time_ago": format_time_ago(dp.pad.metadata.created_at),
-                "is_pinned_section": is_pinned_section,
-                "is_deleted": is_deleted,
-                "is_separator": false,
-                "matches": [],
-                "more_matches_count": 0,
-                "peek": serde_json::Value::Null,
-            })
+            let mut row = base_pad_row(
+                dp,
+                RowLayout {
+                    indent_width: 0,
+                    title_width: width.saturating_sub(fixed_columns),
+                    show_status,
+                    col_status,
+                    line_width: width,
+                    is_peek: false,
+                },
+            );
+            if dp.pad.metadata.is_pinned {
+                row["left_pin"] = json!(PIN_MARKER);
+            }
+            row["is_pinned_section"] = json!(matches!(dp.index, DisplayIndex::Pinned(_)));
+            row["is_deleted"] = json!(matches!(dp.index, DisplayIndex::Deleted(_)));
+            row
         })
         .collect();
-
-    // Convert trailing messages
-    let trailing_data = convert_messages_to_json(trailing_messages);
 
     json!({
         "start_message": start_message,
         "pads": pad_lines,
-        "trailing_messages": trailing_data,
-        "peek": false,
-        "pin_marker": PIN_MARKER,
-        "line_width": width,
-        "col_left_pin": COL_LEFT_PIN,
-        "col_status": col_status,
-        "col_index": COL_INDEX,
-        "col_time": COL_TIME,
+        "trailing_messages": convert_messages_to_json(&result.messages),
     })
 }
 
-pub struct ListOptions {
-    pub peek: bool,
-    pub show_deleted_help: bool,
-    pub show_all_sections: bool,
-    pub output_mode: OutputMode,
-    pub mode: PadzMode,
-    pub show_uuid: bool,
-    pub filtered: bool,
-    pub show_status: bool,
-}
-
-/// Builds list result data as serde_json::Value for Dispatch handlers.
+/// Builds the template-ready view for a listing.
 ///
-/// This function creates the appropriate data structure based on output mode:
-/// - For structured modes (JSON, YAML): Clean API-friendly format with just pads
-/// - For terminal modes: Full template-ready format with column widths and transformed pad data
-///
-/// Used by list/search handlers that need to return data for standout's rendering pipeline.
-pub fn build_list_result_value(
-    pads: &[DisplayPad],
-    trailing_messages: &[CmdMessage],
-    opts: ListOptions,
-) -> serde_json::Value {
+/// Flattens the pad tree into indented rows, carries per-row column widths, and
+/// derives the empty-state and section-header structure.
+pub fn build_list_view(result: &PadListResult) -> serde_json::Value {
     use serde_json::json;
 
-    // For structured modes, return clean API format
-    if opts.output_mode.is_structured() {
-        return json!({
-            "pads": pads,
-            "messages": trailing_messages,
-        });
-    }
-
-    let show_status = opts.show_status || opts.mode == PadzMode::Todos;
+    let opts = &result.request;
+    let show_status = opts.status;
     let col_status = if show_status { COL_STATUS } else { 0 };
     let width = line_width();
+    let trailing_data = convert_messages_to_json(&result.messages);
 
-    // For terminal modes, build full template data
-    let trailing_data = convert_messages_to_json(trailing_messages);
-
-    if pads.is_empty() {
+    if result.pads.is_empty() {
         if opts.filtered {
             return json!({
                 "pads": [],
@@ -230,212 +197,53 @@ pub fn build_list_result_value(
         return json!({
             "pads": [],
             "empty": true,
-            "pin_marker": PIN_MARKER,
             "help_text": get_grouped_help(),
             "deleted_help": false,
-            "peek": false,
-            "line_width": width,
-            "col_left_pin": COL_LEFT_PIN,
-            "col_status": col_status,
-            "col_index": COL_INDEX,
-            "col_time": COL_TIME,
             "trailing_messages": trailing_data,
         });
     }
 
     let mut pad_lines: Vec<serde_json::Value> = Vec::new();
     let mut last_was_pinned = false;
-
-    // Recursive helper to flatten the tree with depth/indentation
-    #[allow(clippy::too_many_arguments)]
-    fn process_pad_to_json(
-        dp: &DisplayPad,
-        pad_lines: &mut Vec<serde_json::Value>,
-        depth: usize,
-        is_pinned_section: bool,
-        is_deleted_root: bool,
-        peek: bool,
-        show_status: bool,
-        col_status: usize,
-        show_uuid: bool,
-        width: usize,
-    ) {
-        let is_deleted = matches!(dp.index, DisplayIndex::Deleted(_));
-
-        let local_idx_str = match &dp.index {
-            DisplayIndex::Pinned(n) => format!("p{}", n),
-            DisplayIndex::Regular(n) => format!("{:2}", n),
-            DisplayIndex::Archived(n) => format!("ar{}", n),
-            DisplayIndex::Deleted(n) => format!("d{}", n),
-        };
-        let full_idx_str = format!("{}.", local_idx_str);
-
-        let status_icon = if show_status {
-            match dp.pad.metadata.status {
-                TodoStatus::Planned => STATUS_PLANNED,
-                TodoStatus::InProgress => STATUS_IN_PROGRESS,
-                TodoStatus::Done => STATUS_DONE,
-            }
-        } else {
-            ""
-        };
-
-        let indent_width = depth * 2;
-        let indent = " ".repeat(indent_width);
-
-        let left_pin = if dp.pad.metadata.is_pinned && depth == 0 {
-            PIN_MARKER.to_string()
-        } else {
-            String::new()
-        };
-
-        let fixed_columns = COL_LEFT_PIN + col_status + COL_INDEX + COL_TIME;
-        let title_width = width.saturating_sub(fixed_columns + indent_width);
-
-        // Process matches
-        let mut match_lines: Vec<serde_json::Value> = Vec::new();
-        if let Some(matches) = &dp.matches {
-            for m in matches {
-                if m.line_number == 0 {
-                    continue;
-                }
-                let segments: Vec<serde_json::Value> = m
-                    .segments
-                    .iter()
-                    .map(|s| {
-                        let (text, style) = match s {
-                            padzapp::index::MatchSegment::Plain(t) => (t.clone(), "info"),
-                            padzapp::index::MatchSegment::Match(t) => (t.clone(), "match"),
-                        };
-                        serde_json::json!({ "text": text, "style": style })
-                    })
-                    .collect();
-
-                let match_indent = indent_width + COL_LEFT_PIN + col_status + COL_INDEX;
-                let match_available = width.saturating_sub(COL_TIME + match_indent);
-
-                // Truncate segments to available width
-                let truncated = truncate_match_segments_to_json(&segments, match_available);
-
-                match_lines.push(serde_json::json!({
-                    "line_number": format!("{:02}", m.line_number),
-                    "segments": truncated,
-                }));
-            }
-        }
-
-        let peek_data = if peek {
-            let body_lines: Vec<&str> = dp.pad.content.lines().skip(1).collect();
-            let body = body_lines.join("\n");
-            let result = format_as_peek(&body, 3);
-            if result.opening_lines.is_empty() {
-                serde_json::Value::Null
-            } else {
-                serde_json::to_value(&result).unwrap_or(serde_json::Value::Null)
-            }
-        } else {
-            serde_json::Value::Null
-        };
-
-        let display_title = if show_uuid {
-            let short_uuid = &dp.pad.metadata.id.to_string()[..8];
-            format!("({}) {}", short_uuid, dp.pad.metadata.title)
-        } else {
-            dp.pad.metadata.title.clone()
-        };
-
-        pad_lines.push(serde_json::json!({
-            "indent": indent,
-            "left_pin": left_pin,
-            "status_icon": status_icon,
-            "index": full_idx_str,
-            "title": display_title,
-            "title_width": title_width,
-            "tags": dp.pad.metadata.tags,
-                "tags_display": format_tags_display(&dp.pad.metadata.tags),
-            "time_ago": format_time_ago(dp.pad.metadata.created_at),
-            "is_pinned_section": is_pinned_section && depth == 0,
-            "is_deleted": is_deleted || is_deleted_root,
-            "is_separator": false,
-            "matches": match_lines,
-            "more_matches_count": 0,
-            "peek": peek_data,
-        }));
-
-        // Recurse children
-        for child in &dp.children {
-            process_pad_to_json(
-                child,
-                pad_lines,
-                depth + 1,
-                is_pinned_section,
-                is_deleted_root,
-                peek,
-                show_status,
-                col_status,
-                show_uuid,
-                width,
-            );
-        }
-    }
-
     let mut entered_archived = false;
     let mut entered_deleted = false;
 
-    for dp in pads {
+    for dp in &result.pads {
         let is_pinned_section = matches!(dp.index, DisplayIndex::Pinned(_));
         let is_archived_section = matches!(dp.index, DisplayIndex::Archived(_));
         let is_deleted_section = matches!(dp.index, DisplayIndex::Deleted(_));
 
         // Separator between pinned and regular roots
         if last_was_pinned && !is_pinned_section {
-            pad_lines.push(serde_json::json!({
-                "indent": "",
-                "left_pin": "",
-                "status_icon": "",
-                "index": "",
-                "title": "",
-                "title_width": 0,
-                "tags": [],
-                "tags_display": "",
-                "time_ago": "",
-                "is_pinned_section": false,
-                "is_deleted": false,
-                "is_separator": true,
-                "is_section_header": false,
-                "matches": [],
-                "more_matches_count": 0,
-                "peek": serde_json::Value::Null,
-            }));
+            pad_lines.push(separator_row());
         }
         last_was_pinned = is_pinned_section;
 
         // Section headers for --all mode
-        if opts.show_all_sections {
+        if opts.sections {
             if is_archived_section && !entered_archived {
                 entered_archived = true;
+                pad_lines.push(json!({ "is_separator": true, "is_section_header": false }));
                 pad_lines
-                    .push(serde_json::json!({ "is_separator": true, "is_section_header": false }));
-                pad_lines.push(serde_json::json!({ "is_section_header": true, "section_title": "Archived Pads" }));
+                    .push(json!({ "is_section_header": true, "section_title": "Archived Pads" }));
             }
             if is_deleted_section && !entered_deleted {
                 entered_deleted = true;
+                pad_lines.push(json!({ "is_separator": true, "is_section_header": false }));
                 pad_lines
-                    .push(serde_json::json!({ "is_separator": true, "is_section_header": false }));
-                pad_lines.push(serde_json::json!({ "is_section_header": true, "section_title": "Deleted Pads" }));
+                    .push(json!({ "is_section_header": true, "section_title": "Deleted Pads" }));
             }
         }
 
-        process_pad_to_json(
+        push_pad_row(
             dp,
             &mut pad_lines,
             0,
             is_pinned_section,
             is_deleted_section,
-            opts.peek,
+            opts,
             show_status,
             col_status,
-            opts.show_uuid,
             width,
         );
     }
@@ -443,17 +251,193 @@ pub fn build_list_result_value(
     json!({
         "pads": pad_lines,
         "empty": false,
-        "pin_marker": PIN_MARKER,
         "help_text": "",
-        "deleted_help": opts.show_deleted_help,
-        "peek": opts.peek,
-        "line_width": width,
-        "col_left_pin": COL_LEFT_PIN,
-        "col_status": col_status,
-        "col_index": COL_INDEX,
-        "col_time": COL_TIME,
+        "deleted_help": opts.deleted_help,
         "trailing_messages": trailing_data,
     })
+}
+
+/// Layout inputs for one rendered pad row.
+struct RowLayout {
+    indent_width: usize,
+    title_width: usize,
+    show_status: bool,
+    col_status: usize,
+    line_width: usize,
+    is_peek: bool,
+}
+
+/// Builds the fields every pad row shares.
+///
+/// Each row is self-contained — it carries its own column widths and line width — so
+/// that `_pad_line.jinja` needs nothing but the row itself and can be included from
+/// both the list and modification templates.
+fn base_pad_row(dp: &DisplayPad, layout: RowLayout) -> serde_json::Value {
+    use serde_json::json;
+
+    let local_idx_str = match &dp.index {
+        DisplayIndex::Pinned(n) => format!("p{}", n),
+        DisplayIndex::Regular(n) => format!("{:2}", n),
+        DisplayIndex::Archived(n) => format!("ar{}", n),
+        DisplayIndex::Deleted(n) => format!("d{}", n),
+    };
+
+    let status_icon = if layout.show_status {
+        match dp.pad.metadata.status {
+            TodoStatus::Planned => STATUS_PLANNED,
+            TodoStatus::InProgress => STATUS_IN_PROGRESS,
+            TodoStatus::Done => STATUS_DONE,
+        }
+    } else {
+        ""
+    };
+
+    json!({
+        "indent": " ".repeat(layout.indent_width),
+        "left_pin": "",
+        "status_icon": status_icon,
+        "index": format!("{}.", local_idx_str),
+        "title": dp.pad.metadata.title,
+        "title_width": layout.title_width,
+        "tags": dp.pad.metadata.tags,
+        "tags_display": format_tags_display(&dp.pad.metadata.tags),
+        "time_ago": format_time_ago(dp.pad.metadata.created_at),
+        "is_pinned_section": false,
+        "is_deleted": false,
+        "is_separator": false,
+        "is_peek": layout.is_peek,
+        "matches": [],
+        "more_matches_count": 0,
+        "peek": serde_json::Value::Null,
+        "line_width": layout.line_width,
+        "cols": {
+            "left_pin": COL_LEFT_PIN,
+            "status": layout.col_status,
+            "index": COL_INDEX,
+            "time": COL_TIME,
+        },
+    })
+}
+
+/// A blank row separating the pinned block from the regular block.
+fn separator_row() -> serde_json::Value {
+    serde_json::json!({
+        "is_separator": true,
+        "is_section_header": false,
+    })
+}
+
+/// Recursively flattens a pad and its children into indented rows.
+#[allow(clippy::too_many_arguments)]
+fn push_pad_row(
+    dp: &DisplayPad,
+    pad_lines: &mut Vec<serde_json::Value>,
+    depth: usize,
+    is_pinned_section: bool,
+    is_deleted_root: bool,
+    opts: &super::result::ListRequest,
+    show_status: bool,
+    col_status: usize,
+    width: usize,
+) {
+    let is_deleted = matches!(dp.index, DisplayIndex::Deleted(_));
+    let indent_width = depth * 2;
+    let fixed_columns = COL_LEFT_PIN + col_status + COL_INDEX + COL_TIME;
+
+    let mut row = base_pad_row(
+        dp,
+        RowLayout {
+            indent_width,
+            title_width: width.saturating_sub(fixed_columns + indent_width),
+            show_status,
+            col_status,
+            line_width: width,
+            is_peek: opts.peek,
+        },
+    );
+
+    if dp.pad.metadata.is_pinned && depth == 0 {
+        row["left_pin"] = serde_json::json!(PIN_MARKER);
+    }
+    row["is_pinned_section"] = serde_json::json!(is_pinned_section && depth == 0);
+    row["is_deleted"] = serde_json::json!(is_deleted || is_deleted_root);
+    row["matches"] = serde_json::json!(build_match_lines(dp, indent_width, col_status, width));
+
+    if opts.peek {
+        row["peek"] = build_peek(dp);
+    }
+
+    if opts.uuid {
+        let short_uuid = &dp.pad.metadata.id.to_string()[..8];
+        row["title"] = serde_json::json!(format!("({}) {}", short_uuid, dp.pad.metadata.title));
+    }
+
+    pad_lines.push(row);
+
+    for child in &dp.children {
+        push_pad_row(
+            child,
+            pad_lines,
+            depth + 1,
+            is_pinned_section,
+            is_deleted_root,
+            opts,
+            show_status,
+            col_status,
+            width,
+        );
+    }
+}
+
+/// Builds the styled, width-truncated search-match lines shown under a pad.
+fn build_match_lines(
+    dp: &DisplayPad,
+    indent_width: usize,
+    col_status: usize,
+    width: usize,
+) -> Vec<serde_json::Value> {
+    let mut match_lines: Vec<serde_json::Value> = Vec::new();
+    let Some(matches) = &dp.matches else {
+        return match_lines;
+    };
+
+    for m in matches {
+        if m.line_number == 0 {
+            continue;
+        }
+        let segments: Vec<serde_json::Value> = m
+            .segments
+            .iter()
+            .map(|s| {
+                let (text, style) = match s {
+                    padzapp::index::MatchSegment::Plain(t) => (t.clone(), "info"),
+                    padzapp::index::MatchSegment::Match(t) => (t.clone(), "match"),
+                };
+                serde_json::json!({ "text": text, "style": style })
+            })
+            .collect();
+
+        let match_indent = indent_width + COL_LEFT_PIN + col_status + COL_INDEX;
+        let match_available = width.saturating_sub(COL_TIME + match_indent);
+
+        match_lines.push(serde_json::json!({
+            "line_number": format!("{:02}", m.line_number),
+            "segments": truncate_match_segments_to_json(&segments, match_available),
+        }));
+    }
+    match_lines
+}
+
+/// Builds the peek preview for a pad, or `null` when it has no body to preview.
+fn build_peek(dp: &DisplayPad) -> serde_json::Value {
+    let body_lines: Vec<&str> = dp.pad.content.lines().skip(1).collect();
+    let body = body_lines.join("\n");
+    let result = format_as_peek(&body, 3);
+    if result.opening_lines.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::to_value(&result).unwrap_or(serde_json::Value::Null)
+    }
 }
 
 /// Helper to convert CmdMessages to JSON values for templates
@@ -542,8 +526,8 @@ fn format_time_ago(timestamp: DateTime<Utc>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::result::{ListRequest, ModificationRequest};
     use padzapp::model::Pad;
-    use standout::OutputMode;
 
     fn make_pad(title: &str, pinned: bool) -> Pad {
         let mut p = Pad::new(title.to_string(), "some content".to_string());
@@ -576,22 +560,50 @@ mod tests {
         }
     }
 
+    fn list_result(pads: Vec<DisplayPad>, request: ListRequest) -> PadListResult {
+        PadListResult {
+            pads,
+            messages: vec![],
+            request,
+        }
+    }
+
+    /// Todos-mode listing: status icons on, nothing else requested.
+    fn todos_request() -> ListRequest {
+        ListRequest {
+            status: true,
+            ..Default::default()
+        }
+    }
+
+    /// Notes-mode listing: no status icons.
+    fn notes_request() -> ListRequest {
+        ListRequest::default()
+    }
+
+    fn modification_result(
+        action: &str,
+        pads: Vec<DisplayPad>,
+        status: bool,
+    ) -> ModificationResult {
+        ModificationResult {
+            action: action.to_string(),
+            pads,
+            messages: vec![],
+            request: ModificationRequest { status },
+        }
+    }
+
+    fn row_col_status(row: &serde_json::Value) -> u64 {
+        row.get("cols")
+            .and_then(|c| c.get("status"))
+            .and_then(|v| v.as_u64())
+            .unwrap()
+    }
+
     #[test]
     fn test_build_list_empty() {
-        let data = build_list_result_value(
-            &[],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let data = build_list_view(&list_result(vec![], todos_request()));
         assert!(data.get("empty").and_then(|v| v.as_bool()).unwrap_or(false));
         assert!(data
             .get("help_text")
@@ -601,24 +613,22 @@ mod tests {
     }
 
     #[test]
-    fn test_build_list_single_regular_pad() {
-        let pad = make_pad("Test Note", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
+    fn test_build_list_empty_filtered() {
+        let request = ListRequest {
+            filtered: true,
+            ..todos_request()
+        };
+        let data = build_list_view(&list_result(vec![], request));
+        assert_eq!(
+            data.get("empty_filtered").and_then(|v| v.as_bool()),
+            Some(true)
         );
+    }
+
+    #[test]
+    fn test_build_list_single_regular_pad() {
+        let dp = make_display_pad(make_pad("Test Note", false), DisplayIndex::Regular(1));
+        let data = build_list_view(&list_result(vec![dp], todos_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         assert_eq!(pads.len(), 1);
@@ -637,23 +647,8 @@ mod tests {
 
     #[test]
     fn test_build_list_pinned_pad() {
-        let pad = make_pad("Pinned Note", true);
-        let dp = make_display_pad(pad, DisplayIndex::Pinned(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let dp = make_display_pad(make_pad("Pinned Note", true), DisplayIndex::Pinned(1));
+        let data = build_list_view(&list_result(vec![dp], todos_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         let pad_data = &pads[0];
@@ -671,23 +666,12 @@ mod tests {
 
     #[test]
     fn test_build_list_deleted_pad() {
-        let pad = make_pad("Deleted Note", false);
-        let dp = make_display_pad(pad, DisplayIndex::Deleted(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: true,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let dp = make_display_pad(make_pad("Deleted Note", false), DisplayIndex::Deleted(1));
+        let request = ListRequest {
+            deleted_help: true,
+            ..todos_request()
+        };
+        let data = build_list_view(&list_result(vec![dp], request));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         let pad_data = &pads[0];
@@ -705,29 +689,12 @@ mod tests {
 
     #[test]
     fn test_build_list_mixed_pinned_and_regular() {
-        let pinned = make_pad("Pinned", true);
-        let regular = make_pad("Regular", false);
-
         let pads = vec![
-            make_display_pad(pinned.clone(), DisplayIndex::Pinned(1)),
-            make_display_pad(regular, DisplayIndex::Regular(1)),
+            make_display_pad(make_pad("Pinned", true), DisplayIndex::Pinned(1)),
+            make_display_pad(make_pad("Regular", false), DisplayIndex::Regular(1)),
         ];
 
-        let data = build_list_result_value(
-            &pads,
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
-
+        let data = build_list_view(&list_result(pads, todos_request()));
         let pad_list = data.get("pads").and_then(|v| v.as_array()).unwrap();
         // Should have: pinned pad, separator, regular pad
         assert_eq!(pad_list.len(), 3);
@@ -742,56 +709,26 @@ mod tests {
     #[test]
     fn test_build_list_pinned_in_regular_section_shows_left_pin() {
         // A pinned pad displayed in regular section should show left_pin
-        let mut pad = make_pad("Pinned Note", true);
-        pad.metadata.is_pinned = true;
-
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let dp = make_display_pad(make_pad("Pinned Note", true), DisplayIndex::Regular(1));
+        let data = build_list_view(&list_result(vec![dp], todos_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
-        let pad_data = &pads[0];
-
         assert_eq!(
-            pad_data.get("left_pin").and_then(|v| v.as_str()),
+            pads[0].get("left_pin").and_then(|v| v.as_str()),
             Some(PIN_MARKER)
         );
     }
 
     #[test]
     fn test_build_list_with_messages() {
-        let pad = make_pad("Test", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-        let messages = vec![CmdMessage::success("Operation completed")];
+        let dp = make_display_pad(make_pad("Test", false), DisplayIndex::Regular(1));
+        let result = PadListResult {
+            pads: vec![dp],
+            messages: vec![CmdMessage::success("Operation completed")],
+            request: todos_request(),
+        };
 
-        let data = build_list_result_value(
-            &[dp],
-            &messages,
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
-
+        let data = build_list_view(&result);
         let trailing = data
             .get("trailing_messages")
             .and_then(|v| v.as_array())
@@ -808,50 +745,74 @@ mod tests {
     }
 
     #[test]
-    fn test_build_list_json_mode_returns_raw_pads() {
+    fn test_build_list_uuid_prefixes_title() {
         let pad = make_pad("Test", false);
+        let short = pad.metadata.id.to_string()[..8].to_string();
         let dp = make_display_pad(pad, DisplayIndex::Regular(1));
+        let request = ListRequest {
+            uuid: true,
+            ..todos_request()
+        };
 
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Json,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
-
-        // In JSON mode, should return raw pads array, not processed pad lines
+        let data = build_list_view(&list_result(vec![dp], request));
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
-        assert_eq!(pads.len(), 1);
-        // Raw pads have "pad" field with content
-        assert!(pads[0].get("pad").is_some());
+        assert_eq!(
+            pads[0].get("title").and_then(|v| v.as_str()),
+            Some(format!("({}) Test", short).as_str())
+        );
     }
 
     #[test]
     fn test_build_modification_result() {
-        let pad = make_pad("Test", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_modification_result_value(
-            "Created",
-            &[dp],
-            &[],
-            OutputMode::Text,
-            PadzMode::Todos,
-            false,
-        );
+        let dp = make_display_pad(make_pad("Test", false), DisplayIndex::Regular(1));
+        let data = build_modification_view(&modification_result("Created", vec![dp], true));
 
         assert_eq!(
             data.get("start_message").and_then(|v| v.as_str()),
             Some("Created 1 pad...")
         );
+    }
+
+    #[test]
+    fn test_build_modification_result_shows_pin_marker() {
+        // A pinned pad keeps its marker when reported by a modification command.
+        let dp = make_display_pad(make_pad("Pinned", true), DisplayIndex::Pinned(2));
+        let data = build_modification_view(&modification_result("Pinned", vec![dp], false));
+
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(
+            pads[0].get("left_pin").and_then(|v| v.as_str()),
+            Some(PIN_MARKER)
+        );
+    }
+
+    #[test]
+    fn test_build_modification_result_unpinned_has_no_marker() {
+        let dp = make_display_pad(make_pad("Plain", false), DisplayIndex::Regular(1));
+        let data = build_modification_view(&modification_result("Created", vec![dp], false));
+
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(pads[0].get("left_pin").and_then(|v| v.as_str()), Some(""));
+    }
+
+    #[test]
+    fn test_build_modification_result_pluralizes() {
+        let pads = vec![
+            make_display_pad(make_pad("A", false), DisplayIndex::Regular(1)),
+            make_display_pad(make_pad("B", false), DisplayIndex::Regular(2)),
+        ];
+        let data = build_modification_view(&modification_result("Deleted", pads, false));
+
+        assert_eq!(
+            data.get("start_message").and_then(|v| v.as_str()),
+            Some("Deleted 2 pads...")
+        );
+    }
+
+    #[test]
+    fn test_build_modification_result_empty_has_no_start_message() {
+        let data = build_modification_view(&modification_result("Deleted", vec![], false));
+        assert_eq!(data.get("start_message").and_then(|v| v.as_str()), Some(""));
     }
 
     #[test]
@@ -887,118 +848,42 @@ mod tests {
 
     #[test]
     fn test_notes_mode_hides_status_icon() {
-        let pad = make_pad("Test Note", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Notes,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let dp = make_display_pad(make_pad("Test Note", false), DisplayIndex::Regular(1));
+        let data = build_list_view(&list_result(vec![dp], notes_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         assert_eq!(
             pads[0].get("status_icon").and_then(|v| v.as_str()),
             Some("")
         );
-        assert_eq!(data.get("col_status").and_then(|v| v.as_u64()), Some(0));
+        assert_eq!(row_col_status(&pads[0]), 0);
     }
 
     #[test]
     fn test_todos_mode_shows_status_icon() {
-        let pad = make_pad("Test Note", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let dp = make_display_pad(make_pad("Test Note", false), DisplayIndex::Regular(1));
+        let data = build_list_view(&list_result(vec![dp], todos_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         assert_eq!(
             pads[0].get("status_icon").and_then(|v| v.as_str()),
             Some(STATUS_PLANNED)
         );
-        assert_eq!(
-            data.get("col_status").and_then(|v| v.as_u64()),
-            Some(COL_STATUS as u64)
-        );
-    }
-
-    #[test]
-    fn test_show_status_flag_overrides_notes_mode() {
-        let pad = make_pad("Test Note", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Notes,
-                show_uuid: false,
-                filtered: false,
-                show_status: true,
-            },
-        );
-
-        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
-        assert_eq!(
-            pads[0].get("status_icon").and_then(|v| v.as_str()),
-            Some(STATUS_PLANNED)
-        );
-        assert_eq!(
-            data.get("col_status").and_then(|v| v.as_u64()),
-            Some(COL_STATUS as u64)
-        );
+        assert_eq!(row_col_status(&pads[0]), COL_STATUS as u64);
     }
 
     #[test]
     fn test_force_show_status_in_modification_result() {
-        let pad = make_pad("Test Note", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        // Notes mode with force_show_status=true should show status
-        let data = build_modification_result_value(
-            "Completed",
-            &[dp],
-            &[],
-            OutputMode::Text,
-            PadzMode::Notes,
-            true,
-        );
+        let dp = make_display_pad(make_pad("Test Note", false), DisplayIndex::Regular(1));
+        // A status-changing command in notes mode still shows status icons.
+        let data = build_modification_view(&modification_result("Completed", vec![dp], true));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         assert_eq!(
             pads[0].get("status_icon").and_then(|v| v.as_str()),
             Some(STATUS_PLANNED)
         );
-        assert_eq!(
-            data.get("col_status").and_then(|v| v.as_u64()),
-            Some(COL_STATUS as u64)
-        );
+        assert_eq!(row_col_status(&pads[0]), COL_STATUS as u64);
     }
 
     #[test]
@@ -1007,34 +892,8 @@ mod tests {
         let dp = make_display_pad(pad.clone(), DisplayIndex::Regular(1));
         let dp2 = make_display_pad(pad, DisplayIndex::Regular(1));
 
-        let notes_data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Notes,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
-        let todos_data = build_list_result_value(
-            &[dp2],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let notes_data = build_list_view(&list_result(vec![dp], notes_request()));
+        let todos_data = build_list_view(&list_result(vec![dp2], todos_request()));
 
         let notes_width = notes_data.get("pads").and_then(|v| v.as_array()).unwrap()[0]
             .get("title_width")
@@ -1065,24 +924,11 @@ mod tests {
 
         // Notes mode (no status column)
         let dp = make_display_pad(pad.clone(), DisplayIndex::Regular(1));
-        let data = build_list_result_value(
-            &[dp],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Notes,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let data = build_list_view(&list_result(vec![dp], notes_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         let title_width = pads[0].get("title_width").and_then(|v| v.as_u64()).unwrap() as usize;
-        let col_status = data.get("col_status").and_then(|v| v.as_u64()).unwrap() as usize;
+        let col_status = row_col_status(&pads[0]) as usize;
 
         let total = COL_LEFT_PIN + col_status + COL_INDEX + title_width + COL_TIME;
         let w = line_width();
@@ -1090,27 +936,14 @@ mod tests {
 
         // Todos mode (with status column)
         let dp2 = make_display_pad(pad, DisplayIndex::Regular(1));
-        let data2 = build_list_result_value(
-            &[dp2],
-            &[],
-            ListOptions {
-                peek: false,
-                show_deleted_help: false,
-                show_all_sections: false,
-                output_mode: OutputMode::Text,
-                mode: PadzMode::Todos,
-                show_uuid: false,
-                filtered: false,
-                show_status: false,
-            },
-        );
+        let data2 = build_list_view(&list_result(vec![dp2], todos_request()));
 
         let pads2 = data2.get("pads").and_then(|v| v.as_array()).unwrap();
         let title_width2 = pads2[0]
             .get("title_width")
             .and_then(|v| v.as_u64())
             .unwrap() as usize;
-        let col_status2 = data2.get("col_status").and_then(|v| v.as_u64()).unwrap() as usize;
+        let col_status2 = row_col_status(&pads2[0]) as usize;
 
         let total2 = COL_LEFT_PIN + col_status2 + COL_INDEX + title_width2 + COL_TIME;
         assert_eq!(total2, w, "Todos: columns sum {total2} != line_width {w}");
@@ -1129,19 +962,6 @@ mod tests {
         }
     }
 
-    fn default_list_options() -> ListOptions {
-        ListOptions {
-            peek: false,
-            show_deleted_help: false,
-            show_all_sections: false,
-            output_mode: OutputMode::Text,
-            mode: PadzMode::Todos,
-            show_uuid: false,
-            filtered: false,
-            show_status: false,
-        }
-    }
-
     #[test]
     fn test_build_list_nested_pad_produces_indent() {
         let child = make_display_pad(make_pad("Child Note", false), DisplayIndex::Regular(1));
@@ -1151,7 +971,7 @@ mod tests {
             vec![child],
         );
 
-        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let data = build_list_view(&list_result(vec![parent], todos_request()));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         // Should be flattened: parent + child = 2 entries
@@ -1178,7 +998,7 @@ mod tests {
             vec![child],
         );
 
-        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let data = build_list_view(&list_result(vec![parent], todos_request()));
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
 
         let parent_width = pads[0].get("title_width").and_then(|v| v.as_u64()).unwrap();
@@ -1206,7 +1026,7 @@ mod tests {
             vec![child],
         );
 
-        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let data = build_list_view(&list_result(vec![parent], todos_request()));
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
 
         assert_eq!(pads.len(), 3, "3-level tree should produce 3 entries");
@@ -1228,7 +1048,7 @@ mod tests {
             vec![child_b, child_a],
         );
 
-        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let data = build_list_view(&list_result(vec![parent], todos_request()));
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
 
         let titles: Vec<&str> = pads
@@ -1247,7 +1067,7 @@ mod tests {
             vec![child],
         );
 
-        let data = build_list_result_value(&[parent], &[], default_list_options());
+        let data = build_list_view(&list_result(vec![parent], todos_request()));
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
 
         let parent_pin = pads[0].get("left_pin").and_then(|v| v.as_str()).unwrap();
@@ -1259,17 +1079,8 @@ mod tests {
 
     #[test]
     fn test_modification_result_title_width_invariant() {
-        let pad = make_pad("Test", false);
-        let dp = make_display_pad(pad, DisplayIndex::Regular(1));
-
-        let data = build_modification_result_value(
-            "Created",
-            &[dp],
-            &[],
-            OutputMode::Text,
-            PadzMode::Notes,
-            false,
-        );
+        let dp = make_display_pad(make_pad("Test", false), DisplayIndex::Regular(1));
+        let data = build_modification_view(&modification_result("Created", vec![dp], false));
 
         let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
         let title_width = pads[0].get("title_width").and_then(|v| v.as_u64()).unwrap() as usize;
@@ -1280,5 +1091,47 @@ mod tests {
             total, w,
             "Modification result: columns sum {total} != line_width {w}"
         );
+    }
+
+    // --- Provider shape-matching -------------------------------------------------
+    //
+    // Each provider must claim only its own command's result. A provider that
+    // matched the wrong shape would inject a bogus view into an unrelated template.
+
+    #[test]
+    fn test_list_provider_rejects_modification_result() {
+        let dp = make_display_pad(make_pad("Test", false), DisplayIndex::Regular(1));
+        let data = serde_json::to_value(modification_result("Created", vec![dp], false)).unwrap();
+
+        assert!(
+            serde_json::from_value::<PadListResult>(data).is_err(),
+            "a modification result must not deserialize as a list result"
+        );
+    }
+
+    #[test]
+    fn test_modification_provider_rejects_list_result() {
+        let dp = make_display_pad(make_pad("Test", false), DisplayIndex::Regular(1));
+        let data = serde_json::to_value(list_result(vec![dp], todos_request())).unwrap();
+
+        assert!(
+            serde_json::from_value::<ModificationResult>(data).is_err(),
+            "a list result must not deserialize as a modification result"
+        );
+    }
+
+    #[test]
+    fn test_results_round_trip_through_serialization() {
+        // Providers only ever see the serialized handler value, so every result type
+        // must survive the round trip its provider performs.
+        let dp = make_display_pad(make_pad("Test", false), DisplayIndex::Regular(1));
+        let original = list_result(vec![dp], todos_request());
+
+        let data = serde_json::to_value(&original).unwrap();
+        let restored: PadListResult = serde_json::from_value(data).unwrap();
+
+        assert_eq!(restored.pads.len(), 1);
+        assert_eq!(restored.pads[0].pad.metadata.title, "Test");
+        assert_eq!(restored.request, todos_request());
     }
 }

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -272,6 +272,11 @@ struct RowLayout {
 /// Each row is self-contained — it carries its own column widths and line width — so
 /// that `_pad_line.jinja` needs nothing but the row itself and can be included from
 /// both the list and modification templates.
+///
+/// The row's nesting indent ships in two forms: `indent` (the literal spaces every
+/// partial prefixes its lines with) and `indent_width` (the same value as a number,
+/// which `_peek_content.jinja` adds to the `indent()` filter so a peek block's
+/// continuation lines line up with its own first line).
 fn base_pad_row(dp: &DisplayPad, layout: RowLayout) -> serde_json::Value {
     use serde_json::json;
 
@@ -294,6 +299,7 @@ fn base_pad_row(dp: &DisplayPad, layout: RowLayout) -> serde_json::Value {
 
     json!({
         "indent": " ".repeat(layout.indent_width),
+        "indent_width": layout.indent_width,
         "left_pin": "",
         "status_icon": status_icon,
         "index": format!("{}.", local_idx_str),
@@ -986,6 +992,92 @@ mod tests {
         assert_eq!(
             child_indent, "  ",
             "depth-1 child should have 2-space indent"
+        );
+    }
+
+    /// `_match_lines.jinja` and `_peek_content.jinja` prefix their lines with
+    /// `pad.indent`, so every row must carry it — including rows built for a
+    /// listing that requested peek previews.
+    #[test]
+    fn test_build_list_peek_rows_carry_indent_for_partials() {
+        let child = make_display_pad(make_pad("Child Note", false), DisplayIndex::Regular(1));
+        let parent = make_display_pad_with_children(
+            make_pad("Parent Note", false),
+            DisplayIndex::Regular(1),
+            vec![child],
+        );
+        let request = ListRequest {
+            peek: true,
+            ..Default::default()
+        };
+
+        let data = build_list_view(&list_result(vec![parent], request));
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+
+        for (row, expected) in pads.iter().zip(["", "  "]) {
+            let indent = row.get("indent").and_then(|v| v.as_str());
+            assert_eq!(
+                indent,
+                Some(expected),
+                "peek row must carry the indent its partials prefix with"
+            );
+        }
+    }
+
+    /// `_peek_content.jinja` feeds `indent_width` to the `indent()` filter so a
+    /// nested pad's continuation lines stay flush with its own first line. It must
+    /// therefore be present and agree with the `indent` string.
+    #[test]
+    fn test_build_list_row_indent_width_matches_indent_string() {
+        let grandchild = make_display_pad(make_pad("Grandchild", false), DisplayIndex::Regular(1));
+        let child = make_display_pad_with_children(
+            make_pad("Child", false),
+            DisplayIndex::Regular(1),
+            vec![grandchild],
+        );
+        let parent = make_display_pad_with_children(
+            make_pad("Parent", false),
+            DisplayIndex::Regular(1),
+            vec![child],
+        );
+
+        let data = build_list_view(&list_result(vec![parent], todos_request()));
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(pads.len(), 3, "parent + child + grandchild");
+
+        for (depth, row) in pads.iter().enumerate() {
+            let indent = row.get("indent").and_then(|v| v.as_str()).unwrap();
+            let indent_width = row
+                .get("indent_width")
+                .and_then(|v| v.as_u64())
+                .unwrap_or_else(|| panic!("row at depth {depth} must carry indent_width"));
+
+            assert_eq!(
+                indent_width as usize,
+                indent.len(),
+                "indent_width must agree with the indent string at depth {depth}"
+            );
+            assert_eq!(
+                indent_width,
+                depth as u64 * 2,
+                "each nesting level adds 2 columns"
+            );
+        }
+    }
+
+    /// Modification rows are flat, so their indent must stay zero-width — this pins
+    /// the `_pad_line.jinja` prefix for the modification path.
+    #[test]
+    fn test_build_modification_rows_have_zero_indent() {
+        let dp = make_display_pad(make_pad("Note", false), DisplayIndex::Regular(1));
+        let data = build_modification_view(&modification_result("Created", vec![dp], false));
+
+        let pads = data.get("pads").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(pads[0].get("indent").and_then(|v| v.as_str()), Some(""));
+        assert_eq!(
+            pads[0].get("indent_width").and_then(|v| v.as_u64()),
+            Some(0),
+            "modification rows are flat"
         );
     }
 

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -1,0 +1,131 @@
+//! # Typed handler results
+//!
+//! Every padz handler returns one of the types in this module (or `Output::Silent` /
+//! `Output::Binary`). A result is **mode-independent**: the same value is serialized
+//! once by standout and then either fed to a MiniJinja template (human modes) or
+//! emitted directly (structured modes). Handlers therefore never look at
+//! `OutputMode`, never branch on it, and never print.
+//!
+//! ## What belongs here
+//!
+//! These are CLI-only adapter types: they exist purely to establish the shell's
+//! result contract, so they live in the binary rather than in `padzapp`. The data
+//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`) is reusable domain data and
+//! stays in `padzapp`.
+//!
+//! ## Presentation is not in here
+//!
+//! Template-only fields — column widths, glyphs, index strings, relative timestamps,
+//! indentation — are **not** part of a result. They are derived at render time by the
+//! view builders in [`super::render`], which standout invokes only for human output.
+//! That is what keeps structured output free of terminal artifacts while still giving
+//! templates everything they need from the very same value.
+//!
+//! The `request` field on the list/modification results is the exception that proves
+//! the rule: it records *what the user asked to see* (peek previews, uuids, status
+//! icons), not how to draw it. It is a mode-independent fact about the invocation, so
+//! it is part of the result and visible in structured output.
+
+use padzapp::api::CmdMessage;
+use padzapp::index::DisplayPad;
+use serde::{Deserialize, Serialize};
+
+/// What the user asked a listing to show.
+///
+/// Consumed by [`super::render::build_list_view`] to decide which columns and
+/// previews to draw. Mode-independent: `--peek` means "include previews" whether the
+/// output ends up as a table or as JSON.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListRequest {
+    /// Show a content preview under each pad (`--peek`, or the `peek` command).
+    pub peek: bool,
+    /// Prefix titles with a short uuid (`--uuid`).
+    pub uuid: bool,
+    /// Show todo status icons (todos mode, or `--show-status`).
+    pub status: bool,
+    /// The listing was narrowed by ids/search/tags/status, so an empty result means
+    /// "nothing matched" rather than "no pads yet".
+    pub filtered: bool,
+    /// Append the deleted-pads help block (`--deleted` / `--archived`).
+    pub deleted_help: bool,
+    /// Group results under lifecycle section headers (`--all`).
+    pub sections: bool,
+}
+
+/// What the user asked a modification to show.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModificationRequest {
+    /// Show todo status icons (todos mode, or a status-changing command).
+    pub status: bool,
+}
+
+/// Pads matching a listing, in canonical display order.
+///
+/// Produced by `list`, `peek`, and `search`. `pads` keeps the canonical display
+/// identifiers assigned by `index_pads` — including pinned dual indexes and nested
+/// tree indexes — untouched.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PadListResult {
+    pub pads: Vec<DisplayPad>,
+    pub messages: Vec<CmdMessage>,
+    pub request: ListRequest,
+}
+
+/// The outcome of a command that changed pads.
+///
+/// `action` is the past-tense verb for the change ("Pinned", "Deleted", ...) and
+/// `pads` are the pads it affected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModificationResult {
+    pub action: String,
+    pub pads: Vec<DisplayPad>,
+    pub messages: Vec<CmdMessage>,
+    pub request: ModificationRequest,
+}
+
+/// A command whose whole result is user-facing messages.
+///
+/// Rendered by `messages.jinja`, which reads `CmdMessage` directly — no view
+/// derivation, so no view builder is registered for this shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessagesResult {
+    pub messages: Vec<CmdMessage>,
+}
+
+impl MessagesResult {
+    pub fn new(messages: Vec<CmdMessage>) -> Self {
+        Self { messages }
+    }
+}
+
+/// One pad's full content, as returned by `view`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PadContent {
+    /// Title, already carrying its tree indentation prefix in indented nesting mode.
+    pub title: String,
+    /// Body (content minus the title line), indented to match `title`.
+    pub content: String,
+    /// Depth in the pad tree; 0 for a root pad.
+    pub depth: usize,
+    /// Present only when `--uuid` was passed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+}
+
+/// Full content of the viewed pads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PadContentResult {
+    pub pads: Vec<PadContent>,
+}
+
+/// Filesystem paths of the selected pads, one per selector match.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathResult {
+    pub paths: Vec<String>,
+}
+
+/// UUIDs of the selected pads, one per selector match.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UuidResult {
+    pub uuids: Vec<String>,
+}

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -599,7 +599,7 @@ pub enum Commands {
 
     /// Print the file path to one or more pads
     #[command(display_order = 17)]
-    #[dispatch(pure)]
+    #[dispatch(pure, template = "path")]
     Path {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]
@@ -608,7 +608,7 @@ pub enum Commands {
 
     /// Print the UUID of one or more pads
     #[command(display_order = 17)]
-    #[dispatch(pure)]
+    #[dispatch(pure, template = "uuid")]
     Uuid {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]

--- a/crates/padz/src/cli/templates/_match_lines.jinja
+++ b/crates/padz/src/cli/templates/_match_lines.jinja
@@ -1,8 +1,8 @@
 {#- Search match lines for a pad -#}
-{#- Expects: pad.left_pad, pad.matches (list of {line_number, segments}), pad.more_matches_count -#}
+{#- Expects: pad.indent, pad.matches (list of {line_number, segments}), pad.more_matches_count -#}
 {%- for match in pad.matches -%}
-    {{ pad.left_pad }}    [line-number]{{ match.line_number }}L[/line-number] {% for seg in match.segments %}{{ seg.text | style_as(seg.style) }}{% endfor %}{{ "" | nl }}
+    {{ pad.indent }}    [line-number]{{ match.line_number }}L[/line-number] {% for seg in match.segments %}{{ seg.text | style_as(seg.style) }}{% endfor %}{{ "" | nl }}
 {%- endfor -%}
 {%- if pad.more_matches_count > 0 -%}
-    {{ pad.left_pad }}    [truncation]And {{ pad.more_matches_count }} more results[/truncation]{{ "" | nl }}
+    {{ pad.indent }}    [truncation]And {{ pad.more_matches_count }} more results[/truncation]{{ "" | nl }}
 {%- endif -%}

--- a/crates/padz/src/cli/templates/_pad_line.jinja
+++ b/crates/padz/src/cli/templates/_pad_line.jinja
@@ -1,5 +1,6 @@
 {#- Single pad line rendering using Tabular with sub-columns -#}
-{#- Expects: pad (PadLineData), peek (bool), col_* (column widths) -#}
+{#- Expects only `pad`: each row carries its own column widths and line width, so -#}
+{#- this partial is shared by the list and modification templates. -#}
 
 {#- Determine index style based on section type -#}
 {%- set index_style = "list-index" -%}
@@ -13,15 +14,15 @@
 {%- set title_style = "list-title" -%}
 {%- if pad.is_deleted -%}
   {%- set title_style = "deleted-title" -%}
-{%- elif peek -%}
+{%- elif pad.is_peek -%}
   {%- set title_style = "title" -%}
 {%- endif -%}
 
 {#- Define tabular layout with sub-columns for title+tags -#}
 {%- set t = tabular([
-    {"name": "left_pin", "width": col_left_pin, "style": "pinned"},
-    {"name": "status", "width": col_status, "style": "status-icon"},
-    {"name": "index", "width": col_index, "style": index_style},
+    {"name": "left_pin", "width": pad.cols.left_pin, "style": "pinned"},
+    {"name": "status", "width": pad.cols.status, "style": "status-icon"},
+    {"name": "index", "width": pad.cols.index, "style": index_style},
     {"name": "content", "width": pad.title_width, "sub_columns": {
         "columns": [
             {"width": "fill", "overflow": "truncate", "style": title_style},
@@ -29,8 +30,8 @@
         ],
         "separator": " "
     }},
-    {"name": "time", "width": col_time, "align": "right", "style": "time"}
-], width=line_width) -%}
+    {"name": "time", "width": pad.cols.time, "align": "right", "style": "time"}
+], width=pad.line_width) -%}
 
 {#- Render the row with indent prefix -#}
 {{- pad.indent -}}

--- a/crates/padz/src/cli/templates/_peek_content.jinja
+++ b/crates/padz/src/cli/templates/_peek_content.jinja
@@ -1,13 +1,14 @@
 {#- Peek content preview for a pad -#}
-{#- Expects: pad.left_pad, pad.peek (PeekResult with opening_lines, truncated_count, closing_lines) -#}
+{#- Expects: pad.indent, pad.indent_width, pad.peek (PeekResult with opening_lines, truncated_count, closing_lines) -#}
+{#- indent() carries pad.indent_width too, so a nested pad's continuation lines stay flush with its first line. -#}
 {{ "" | nl }}
-    {{ pad.left_pad }}    [preview]{{ pad.peek.opening_lines | indent(8) }}[/preview]{{ "" | nl }}
+    {{ pad.indent }}    [preview]{{ pad.peek.opening_lines | indent(8 + pad.indent_width) }}[/preview]{{ "" | nl }}
 {%- if pad.peek.truncated_count -%}
 {{ "" | nl }}
-    {{ pad.left_pad }}                      [truncation]... {{ pad.peek.truncated_count }} lines not shown ...[/truncation]{{ "" | nl }}
+    {{ pad.indent }}                      [truncation]... {{ pad.peek.truncated_count }} lines not shown ...[/truncation]{{ "" | nl }}
 {{ "" | nl }}
 {%- endif -%}
 {%- if pad.peek.closing_lines -%}
-    {{ pad.left_pad }}    [preview]{{ pad.peek.closing_lines | indent(8) }}[/preview]{{ "" | nl }}
+    {{ pad.indent }}    [preview]{{ pad.peek.closing_lines | indent(8 + pad.indent_width) }}[/preview]{{ "" | nl }}
 {%- endif -%}
 {{ "" | nl }}

--- a/crates/padz/src/cli/templates/list.jinja
+++ b/crates/padz/src/cli/templates/list.jinja
@@ -1,10 +1,13 @@
-{%- if empty_filtered -%}
+{#- Listing output. `list_view` is derived at render time from the handler's -#}
+{#- PadListResult; see cli::render. -#}
+{%- set view = list_view -%}
+{%- if view.empty_filtered -%}
 [info]No matching pads.[/info]{{ "" | nl -}}
-{%- elif empty -%}
+{%- elif view.empty -%}
 [empty-message]No pads yet, create one with `padz create`[/empty-message]{{ "" | nl -}}
-{{ help_text }}
+{{ view.help_text }}
 {%- else -%}
-{%- for pad in pads -%}
+{%- for pad in view.pads -%}
 {%- if pad.is_section_header -%}
 [section-header]{{ pad.section_title }}[/section-header]{{ "" | nl }}
 {%- elif pad.is_separator -%}
@@ -18,10 +21,10 @@
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}
-{%- if deleted_help -%}
+{%- if view.deleted_help -%}
 {%- include "_deleted_help.jinja" -%}
 {%- endif -%}
 {#- Trailing messages (info, warnings, errors from API) -#}
-{%- for msg in trailing_messages -%}
+{%- for msg in view.trailing_messages -%}
 {{ msg.content | style_as(msg.style) }}{{ "" | nl }}
 {%- endfor -%}

--- a/crates/padz/src/cli/templates/messages.jinja
+++ b/crates/padz/src/cli/templates/messages.jinja
@@ -1,3 +1,6 @@
+{#- Commands whose whole result is user-facing messages (MessagesResult). -#}
+{#- A message's semantic style is its level, which CmdMessage serializes lowercase -#}
+{#- ("info", "success", "warning", "error") to match the theme's class names. -#}
 {% for msg in messages -%}
-{{ msg.content | style_as(msg.style) }}
+{{ msg.content | style_as(msg.level) }}
 {% endfor %}

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -1,17 +1,18 @@
-{#- Unified rendering for modification commands -#}
-{#- Expects: start_message, pads (list of PadLineData), trailing_messages, peek (bool), col_* -#}
+{#- Unified rendering for modification commands. `modification_view` is derived at -#}
+{#- render time from the handler's ModificationResult; see cli::render. -#}
+{%- set view = modification_view -%}
 
 {#- Start message -#}
-{%- if start_message -%}
-[info]{{ start_message }}[/info]{{ "" | nl }}
+{%- if view.start_message -%}
+[info]{{ view.start_message }}[/info]{{ "" | nl }}
 {%- endif -%}
 
 {#- Affected pads list -#}
-{%- for pad in pads -%}
+{%- for pad in view.pads -%}
 {%- include "_pad_line.jinja" -%}
 {%- endfor -%}
 
 {#- Trailing messages (info, warnings, errors) -#}
-{%- for msg in trailing_messages -%}
+{%- for msg in view.trailing_messages -%}
 {{ msg.content | style_as(msg.style) }}{{ "" | nl }}
 {%- endfor -%}

--- a/crates/padz/src/cli/templates/path.jinja
+++ b/crates/padz/src/cli/templates/path.jinja
@@ -1,0 +1,4 @@
+{#- One pad file path per line. -#}
+{% for path in paths -%}
+{{ path }}{{ "" | nl }}
+{%- endfor -%}

--- a/crates/padz/src/cli/templates/uuid.jinja
+++ b/crates/padz/src/cli/templates/uuid.jinja
@@ -1,0 +1,4 @@
+{#- One pad UUID per line. -#}
+{% for uuid in uuids -%}
+{{ uuid }}{{ "" | nl }}
+{%- endfor -%}

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -63,7 +63,7 @@
 use crate::error::{PadzError, Result};
 use crate::index::DisplayPad;
 use crate::model::Scope;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Controls how nested (parent/child) pads are rendered.
@@ -126,7 +126,7 @@ impl PadzPaths {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageLevel {
     Info,
@@ -135,7 +135,7 @@ pub enum MessageLevel {
     Error,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CmdMessage {
     pub level: MessageLevel,
     pub content: String,

--- a/crates/padzapp/src/index.rs
+++ b/crates/padzapp/src/index.rs
@@ -47,7 +47,7 @@
 
 use crate::config::OrderingKey;
 use crate::model::Pad;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -80,7 +80,7 @@ pub fn current_ordering_key() -> OrderingKey {
 }
 
 /// A segment of text in a search match, either plain text or a matched term.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "text")]
 pub enum MatchSegment {
     Plain(String),
@@ -88,14 +88,14 @@ pub enum MatchSegment {
 }
 
 /// A line containing a search match.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchMatch {
     pub line_number: usize, // 0 for title, 1+ for content lines
     pub segments: Vec<MatchSegment>,
 }
 
 /// A user-facing index for a pad.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value")]
 pub enum DisplayIndex {
     Pinned(usize),
@@ -146,7 +146,7 @@ impl std::fmt::Display for PadSelector {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DisplayPad {
     pub pad: Pad,
     pub index: DisplayIndex,

--- a/crates/padzapp/src/peek.rs
+++ b/crates/padzapp/src/peek.rs
@@ -3,9 +3,9 @@
 //! This module handles the formatting of pad content for "peek" views.
 //! It truncates content based on configurable line limits while stripping blank lines.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeekResult {
     pub opening_lines: String,
     pub truncated_count: Option<usize>,


### PR DESCRIPTION
Implements #192 (for #192). Part of the STD01 epic (#190), landing on `STD01/umbrella` on top of the WS01 baseline (#198).

## Context

### Why this approach

The issue's binding constraint is that **the same serialized handler value must feed both the human and the structured path** — while existing text output _and_ existing JSON semantics stay stable. Those pull against each other: today's JSON is the clean domain shape (`pads`/`messages`), but today's templates need a presentation-enriched shape (column widths, glyphs, `time_ago`). Whatever the handler returns, one of the two paths gets the wrong thing.

Standout resolves this at the render layer, so that's where I put the seam:

- Handlers return a typed result (`cli/result.rs`) and nothing else. Standout serializes it **once**; structured modes emit it as-is, human modes render a template with it. Criterion 3 then holds _by construction_ rather than by discipline.
- Template-only derivation moved into **context providers** (`AppBuilder::context_fn`, wired in `cli/commands.rs`, built in `cli/render.rs`). Standout resolves providers only on the template path — so `title_width`, `status_icon`, `time_ago`, `line_width` reach templates but never reach JSON. `list.jinja` reads `list_view`, `modification_result.jinja` reads `modification_view`; every other template reads the result directly.
- `OutputMode` is gone from handlers and durable state. It survives only in `setup.rs` (flag extraction) and `commands.rs` (passed to `dispatch`) — i.e. exactly the "render/app execution concerns" the issue's verification allows. `render.rs` no longer mentions it at all.

Providers get the serialized result as JSON, so each deserializes back into its typed result and returns `undefined` on a non-matching shape (hence the new `Deserialize` derives on `DisplayPad`/`CmdMessage`/`PeekResult` and friends). Since a template only reads its own command's provider, a non-match is simply unused — and two tests pin that the two result shapes can't be mistaken for each other.

### The `request` field — the one judgement call worth your attention

`--peek`, `--uuid`, `--show-status`, `--all` and "was this listing filtered?" have to reach the template somehow. Standout gives a context provider **no** access to `ArgMatches`, so the only channel is the handler result. So each list/modification result carries a small `request` object, and it shows up in JSON:

```json
{ "pads": [], "messages": [], "request": { "peek": false, "uuid": false } }
```

My reasoning: this records _what the user asked to see_, not _how to draw it_ — a mode-independent fact about the invocation, meaningful to a JSON consumer. The genuinely template-only fields stay out of structured output entirely (a test asserts that). If you'd rather this be shaped differently, WS03 owns the intentional structured contract per command and is the natural place to settle it — but I didn't want to hide the call.

### Behaviour: verified against the WS01 baseline

I built the WS01 baseline binary and diffed both binaries across list/peek/uuid/show-status, search (incl. match lines), view, pin/unpin, complete/reopen, `--all` sections, delete/restore, tags, doctor, path, uuid, copy, and empty states, in `text`, `term-debug` and `json`.

**`--output text`: byte-identical.** Two intentional deltas otherwise:

1. **`term-debug` only — messages commands gain their semantic colour.** `messages.jinja` asked for `msg.style`, but `CmdMessage` serializes `level`, so `doctor`/`tag list`/etc. have been rendering _unstyled_ all along; `copy` looked right only because it hand-built its own JSON. Unifying onto one typed result makes that inconsistency unrepresentable, so I rendered `msg.level` — the style the data actually carries and the template always intended. Text mode is unchanged; `copy` is unchanged; the others gain the colour they should have had. The alternative (keep reading `msg.style`) would have _removed_ `copy`'s colour — a regression rather than a fix.
2. **JSON — repairs forced by criterion 2.** `path`/`uuid` no longer print from their handlers, so they now emit real JSON (`{"paths":[…]}` / `{"uuids":[…]}`) instead of raw lines leaking through structured mode. `delete --completed` with nothing to delete returned a template-ish `{"start_message":"","pads":[],"trailing_messages":[…]}` even in JSON; it now returns the clean result shape. `copy`'s message moves from `{"style":"info"}` to the standard `{"level":"info"}`.

The diff harness also caught a real bug I'd introduced: the pin marker vanished from modification rows. Fixed, with regression tests both ways.

### Tests

708 pass (was 695). New: direct typed-handler tests calling the functions `#[handler]` preserves — list/search, view, pin/complete/delete, path, uuid — asserting typed `Output` values with no `ArgMatches`, no dispatch, no renderer. Plus a test that the handler value carries no template-only fields, and provider shape-matching tests. `render.rs`'s existing tests were retargeted onto the typed view builders. (These found a real defect: I'd passed `view`'s flags in the wrong order.)

### Out of scope — please don't ask for these here

- **WS03**: yaml/xml/csv mode selection and the per-command structured contract (incl. where `request` lands).
- **WS07**: moving wording/pluralization/glyph/layout policy into templates + the CSS migration. `render.rs` still builds template-ready JSON trees in Rust — deliberately. WS02 only _relocated_ that derivation out of handlers into the render layer; thinning it is WS07's job.
- **WS04/05/06**: padzapp CLI-freedom, declarative input chains, broad test migration.

Known edge: `path.jinja` runs paths through style-tag processing, so a path containing `[...]` could be mangled where `println!` was literal. Extremely unlikely, and WS03 owns path/uuid's output contract.

### Notes for the reviewer

- `crates/padz/Cargo.toml` gains a direct `minijinja = "2"` dep — needed to type the context providers standout hands to MiniJinja. Cargo unifies it with standout-render's copy.
- The `Deserialize` derives in `padzapp` are on types that already crossed the serialize boundary; no domain redesign.
- Both providers are resolved on every human render (two cheap serde round-trips). Noted rather than optimised.


## Shepherd brief — round 1

- **PR and Context:** PR #199; re-read this full `## Context` and the current open thread before acting.
- **Issue:** #192, under epic #190, on the WS01 baseline #198.
- **Verify commands:** `pixi run test`; then commit/push so hooks run the lint gate. Run focused text/term-debug regression coverage for search match lines and peek indentation.
- **Governing docs:** issue #192 coordinator brief; `/Users/adebert/.agents/skills/standout/SKILL.md` with handler/render/testing references; repository `padz-output` and `padz-display-identifiers` skills.
- **Decision boundaries:** fix-or-push-back and resolve the one open thread; sweep every pad-row builder for the same missing-layout-field class. Preserve text output, canonical display IDs, typed mode-independent handler data, and the WS03/WS07 scope cuts. Do not redesign results or structured contracts in this review fix.
