### PR TITLE
PADZ-STD01-WS04: Epic: Complete Standout adoption - Workstream: Make padzapp fully CLI-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,8 +1303,6 @@ dependencies = [
  "chrono",
  "clapfig",
  "confique",
- "console 0.15.11",
- "directories",
  "flate2",
  "once_cell",
  "pulldown-cmark",

--- a/crates/padz/src/cli/clipboard.rs
+++ b/crates/padz/src/cli/clipboard.rs
@@ -1,4 +1,11 @@
-use crate::error::{PadzError, Result};
+//! Reading and writing the system clipboard.
+//!
+//! A user-environment concern owned by the CLI: every path here shells out to
+//! a platform clipboard tool (`pbcopy`/`pbpaste`, `xclip`/`xsel`, `clip`/
+//! PowerShell). The library never touches the clipboard — handlers hand pad
+//! text to these functions at the CLI boundary.
+
+use padzapp::error::{PadzError, Result};
 use std::process::Command;
 
 /// Copies text to the system clipboard in an OS-specific way.
@@ -139,96 +146,6 @@ pub fn format_for_clipboard(title: &str, content: &str) -> String {
     }
 }
 
-/// Reads text from the system clipboard in an OS-specific way.
-/// - macOS: uses pbpaste
-/// - Linux: uses xclip or xsel
-/// - Windows: uses powershell Get-Clipboard
-pub fn get_from_clipboard() -> Result<String> {
-    #[cfg(target_os = "macos")]
-    {
-        get_macos()
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        get_linux()
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        get_windows()
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        Err(PadzError::Api(
-            "Clipboard not supported on this platform".to_string(),
-        ))
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn get_macos() -> Result<String> {
-    let output = Command::new("pbpaste")
-        .output()
-        .map_err(|e| PadzError::Api(format!("Failed to execute pbpaste: {}", e)))?;
-
-    if output.status.success() {
-        String::from_utf8(output.stdout)
-            .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e)))
-    } else {
-        Err(PadzError::Api("pbpaste exited with error".to_string()))
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn get_linux() -> Result<String> {
-    // Try xclip first
-    let result = Command::new("xclip")
-        .args(["-selection", "clipboard", "-o"])
-        .output();
-
-    match result {
-        Ok(output) if output.status.success() => {
-            return String::from_utf8(output.stdout)
-                .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e)));
-        }
-        _ => {}
-    }
-
-    // Try xsel as fallback
-    let result = Command::new("xsel")
-        .args(["--clipboard", "--output"])
-        .output();
-
-    match result {
-        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
-            .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e))),
-        Ok(_) => Err(PadzError::Api("xsel exited with error".to_string())),
-        Err(e) => Err(PadzError::Api(format!(
-            "Failed to execute xclip or xsel: {}. Install xclip or xsel.",
-            e
-        ))),
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn get_windows() -> Result<String> {
-    let output = Command::new("powershell")
-        .args(["-command", "Get-Clipboard"])
-        .output()
-        .map_err(|e| PadzError::Api(format!("Failed to execute powershell: {}", e)))?;
-
-    if output.status.success() {
-        // PowerShell Get-Clipboard usually returns text with \r\n, trim if needed or keep as is?
-        // Let's keep as is but convert bytes.
-        String::from_utf8(output.stdout)
-            .map_err(|e| PadzError::Api(format!("Invalid UTF-8 in clipboard: {}", e)))
-    } else {
-        Err(PadzError::Api("powershell exited with error".to_string()))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,6 +154,19 @@ mod tests {
     fn test_format_for_clipboard_with_content() {
         let result = format_for_clipboard("My Title", "Some content");
         assert_eq!(result, "My Title\n\nSome content");
+    }
+
+    /// The real platform clipboard round-trip.
+    ///
+    /// Ignored by default: it depends on a working clipboard tool (and, on
+    /// Linux, an X display), which CI has no business requiring. Run it with
+    /// `cargo test -p padz -- --ignored` on a desktop to check this adapter
+    /// against the actual system clipboard.
+    #[test]
+    #[ignore = "requires a working system clipboard"]
+    fn copy_round_trips_through_the_system_clipboard() {
+        let text = "padz clipboard adapter test";
+        copy_to_clipboard(text).unwrap();
     }
 
     #[test]

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -165,6 +165,10 @@ fn create_app_state(cli: &Cli) -> Result<AppState> {
         Some(Commands::Create { .. }) | Some(Commands::Import { .. })
     );
 
+    // Resolve the environment once, here at the composition root, and hand
+    // explicit values to the library.
+    let env = crate::cli::env::resolve();
+
     // Compute the local .padz dir BEFORE link resolution (used by link/unlink commands)
     let local_padz_dir = match &data_override {
         Some(path) => {
@@ -174,12 +178,18 @@ fn create_app_state(cli: &Cli) -> Result<AppState> {
                 path.join(".padz")
             }
         }
-        None => padzapp::init::find_padz_root(&cwd)
+        None => padzapp::init::find_padz_root(&cwd, env.home_dir.as_deref())
             .map(|root| root.join(".padz"))
             .unwrap_or_else(|| cwd.join(".padz")),
     };
 
-    let padz_ctx = initialize(&cwd, cli.global, data_override, auto_init_for_write)?;
+    let padz_ctx = initialize(&env, &cwd, cli.global, data_override, auto_init_for_write)?;
+
+    // Initialization warnings are data; the CLI is what turns them into stderr
+    // output. They are advisory — the command runs regardless.
+    for warning in &padz_ctx.warnings {
+        eprintln!("Warning: {}", warning);
+    }
 
     Ok(AppState::new(
         padz_ctx.api,
@@ -193,6 +203,7 @@ fn create_app_state(cli: &Cli) -> Result<AppState> {
 fn handle_config(cli: &Cli, subcommand: &Option<ConfigSubcommand>) -> Result<()> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
     let data_override = cli.data.as_ref().map(std::path::PathBuf::from);
+    let env = crate::cli::env::resolve();
 
     // Resolve paths (lightweight version of initialize — just need dirs, not full API)
     let project_padz_dir = match data_override {
@@ -203,19 +214,12 @@ fn handle_config(cli: &Cli, subcommand: &Option<ConfigSubcommand>) -> Result<()>
                 path.join(".padz")
             }
         }
-        None => padzapp::init::find_padz_root(&cwd)
+        None => padzapp::init::find_padz_root(&cwd, env.home_dir.as_deref())
             .map(|root| root.join(".padz"))
             .unwrap_or_else(|| cwd.join(".padz")),
     };
 
-    let global_data_dir = std::env::var("PADZ_GLOBAL_DATA")
-        .ok()
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
-            let proj_dirs = directories::ProjectDirs::from("com", "padz", "padz")
-                .expect("Could not determine config dir");
-            proj_dirs.data_dir().to_path_buf()
-        });
+    let global_data_dir = env.global_data_dir;
 
     // Map -g flag to clapfig scope: None defaults to "local" (first registered)
     let scope: Option<String> = if cli.global {

--- a/crates/padz/src/cli/complete.rs
+++ b/crates/padz/src/cli/complete.rs
@@ -21,7 +21,7 @@ fn get_pad_candidates(include_deleted: bool) -> Vec<CompletionCandidate> {
 
     // Initialize context (completions don't support --data override)
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let Ok(ctx) = initialize(&cwd, is_global, None, false) else {
+    let Ok(ctx) = initialize(&crate::cli::env::resolve(), &cwd, is_global, None, false) else {
         return vec![];
     };
     let api: PadzApi<FileStore> = ctx.api;
@@ -86,7 +86,7 @@ pub fn archived_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let Ok(ctx) = initialize(&cwd, is_global, None, false) else {
+        let Ok(ctx) = initialize(&crate::cli::env::resolve(), &cwd, is_global, None, false) else {
             return vec![];
         };
         let api: PadzApi<FileStore> = ctx.api;
@@ -122,7 +122,7 @@ pub fn deleted_pads_completer() -> ArgValueCandidates {
         let is_global = args.iter().any(|a| a == "-g" || a == "--global");
 
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let Ok(ctx) = initialize(&cwd, is_global, None, false) else {
+        let Ok(ctx) = initialize(&crate::cli::env::resolve(), &cwd, is_global, None, false) else {
             return vec![];
         };
         let api: PadzApi<FileStore> = ctx.api;

--- a/crates/padz/src/cli/editor.rs
+++ b/crates/padz/src/cli/editor.rs
@@ -1,0 +1,223 @@
+//! Launching the user's text editor.
+//!
+//! This is a user-environment concern and therefore lives in the CLI, not in
+//! `padzapp`: it reads `$EDITOR`/`$VISUAL`, probes `PATH` for fallbacks, and
+//! spawns a child process that takes over the terminal. The library owns only
+//! the buffer format ([`padzapp::editor::EditorContent`]).
+//!
+//! Selection is separated from launching so it can be tested without spawning
+//! anything: [`select_editor`] is a pure function of an [`EditorEnv`], and only
+//! [`open_in_editor`] touches the process table.
+
+use padzapp::error::{PadzError, Result};
+use std::path::Path;
+use std::process::Command;
+
+/// Editors tried, in order, when neither `$EDITOR` nor `$VISUAL` is set.
+const FALLBACK_EDITORS: [&str; 3] = ["vim", "vi", "nano"];
+
+/// The environment inputs editor selection depends on.
+///
+/// Modeled as data so the selection rules can be tested directly, rather than
+/// by mutating the process environment (which is global and racy under a
+/// parallel test runner).
+pub struct EditorEnv {
+    /// The value of `$EDITOR`, if set and non-empty.
+    pub editor: Option<String>,
+    /// The value of `$VISUAL`, if set and non-empty.
+    pub visual: Option<String>,
+    /// Is `name` an executable on `PATH`? Used to pick among the fallbacks.
+    pub is_on_path: fn(&str) -> bool,
+}
+
+impl EditorEnv {
+    /// Reads the real process environment. The composition root for editing.
+    pub fn from_process() -> Self {
+        Self {
+            editor: non_empty_var("EDITOR"),
+            visual: non_empty_var("VISUAL"),
+            is_on_path: which,
+        }
+    }
+}
+
+/// Reads `name` from the environment, treating an empty value as unset —
+/// `EDITOR=` should fall through to `$VISUAL` rather than trying to run "".
+fn non_empty_var(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+/// Is `name` an executable on `PATH`?
+fn which(name: &str) -> bool {
+    Command::new("which")
+        .arg(name)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Picks the editor command to run: `$EDITOR`, then `$VISUAL`, then the first
+/// of [`FALLBACK_EDITORS`] found on `PATH`.
+pub fn select_editor(env: &EditorEnv) -> Result<String> {
+    if let Some(editor) = env.editor.clone() {
+        return Ok(editor);
+    }
+    if let Some(visual) = env.visual.clone() {
+        return Ok(visual);
+    }
+    for fallback in FALLBACK_EDITORS {
+        if (env.is_on_path)(fallback) {
+            return Ok(fallback.to_string());
+        }
+    }
+    Err(PadzError::Api(
+        "No editor found. Set $EDITOR environment variable.".to_string(),
+    ))
+}
+
+/// Opens `file_path` in the user's editor and waits for it to close.
+///
+/// Errors when no editor can be selected, when the editor cannot be spawned,
+/// or when it exits non-zero (which we treat as "the user aborted the edit").
+pub fn open_in_editor<P: AsRef<Path>>(file_path: P) -> Result<()> {
+    let editor = select_editor(&EditorEnv::from_process())?;
+    open_with(&editor, file_path.as_ref())
+}
+
+/// Runs `editor` against `path` and waits for it to close.
+///
+/// Split out from [`open_in_editor`] so the spawn-and-wait behavior can be
+/// tested against a real child process without touching `$EDITOR` (which is
+/// process-global, and so racy to mutate under a parallel test runner).
+pub fn open_with(editor: &str, path: &Path) -> Result<()> {
+    let status = Command::new(editor)
+        .arg(path)
+        .status()
+        .map_err(|e| PadzError::Api(format!("Failed to launch editor '{}': {}", editor, e)))?;
+
+    if !status.success() {
+        return Err(PadzError::Api(format!(
+            "Editor '{}' exited with non-zero status",
+            editor
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An env with nothing set and nothing on PATH.
+    fn bare_env() -> EditorEnv {
+        EditorEnv {
+            editor: None,
+            visual: None,
+            is_on_path: |_| false,
+        }
+    }
+
+    #[test]
+    fn editor_var_wins() {
+        let env = EditorEnv {
+            editor: Some("emacs".into()),
+            visual: Some("code".into()),
+            ..bare_env()
+        };
+        assert_eq!(select_editor(&env).unwrap(), "emacs");
+    }
+
+    #[test]
+    fn visual_used_when_editor_unset() {
+        let env = EditorEnv {
+            visual: Some("code".into()),
+            ..bare_env()
+        };
+        assert_eq!(select_editor(&env).unwrap(), "code");
+    }
+
+    #[test]
+    fn falls_back_to_first_editor_on_path() {
+        // `vim` absent, `vi` present → `vi` wins over the later `nano`.
+        let env = EditorEnv {
+            is_on_path: |name| name != "vim",
+            ..bare_env()
+        };
+        assert_eq!(select_editor(&env).unwrap(), "vi");
+    }
+
+    #[test]
+    fn errors_when_nothing_available() {
+        let err = select_editor(&bare_env()).unwrap_err().to_string();
+        assert!(err.contains("No editor found"), "got: {err}");
+        assert!(err.contains("$EDITOR"), "got: {err}");
+    }
+
+    // --- open_with: real child processes, no TTY and no $EDITOR needed ---
+
+    /// Writes an executable shell script and returns its path.
+    fn script(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    /// The happy path: the editor is handed the pad's path, and whatever it
+    /// writes there is what lands on disk.
+    #[cfg(unix)]
+    #[test]
+    fn open_with_runs_editor_against_the_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let pad = temp.path().join("pad.txt");
+        std::fs::write(&pad, "before").unwrap();
+        let editor = script(
+            temp.path(),
+            "ed.sh",
+            "#!/bin/sh\nprintf 'Edited Title\\n\\nEdited body.' > \"$1\"\n",
+        );
+
+        open_with(editor.to_str().unwrap(), &pad).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&pad).unwrap(),
+            "Edited Title\n\nEdited body."
+        );
+    }
+
+    /// A non-zero exit means the user bailed out of the edit; that must surface
+    /// as an error rather than silently accepting the buffer.
+    #[cfg(unix)]
+    #[test]
+    fn open_with_errors_when_editor_exits_non_zero() {
+        let temp = tempfile::tempdir().unwrap();
+        let pad = temp.path().join("pad.txt");
+        std::fs::write(&pad, "before").unwrap();
+        let editor = script(temp.path(), "fail.sh", "#!/bin/sh\nexit 1\n");
+
+        let err = open_with(editor.to_str().unwrap(), &pad).unwrap_err();
+        assert!(
+            err.to_string().contains("exited with non-zero status"),
+            "got: {err}"
+        );
+    }
+
+    /// An editor that isn't there at all reports the launch failure, naming the
+    /// command so the user can see what their `$EDITOR` pointed at.
+    #[test]
+    fn open_with_errors_when_editor_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let pad = temp.path().join("pad.txt");
+        std::fs::write(&pad, "before").unwrap();
+
+        let err = open_with("padz-no-such-editor-binary", &pad).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to launch editor"), "got: {msg}");
+        assert!(msg.contains("padz-no-such-editor-binary"), "got: {msg}");
+    }
+}

--- a/crates/padz/src/cli/env.rs
+++ b/crates/padz/src/cli/env.rs
@@ -1,0 +1,48 @@
+//! The composition root for environment- and platform-derived settings.
+//!
+//! `padzapp` takes its paths as explicit inputs; deciding what those inputs
+//! *are* on this machine is the application's job, and this module is the one
+//! place that does it. Everything below reads process state (`$PADZ_GLOBAL_DATA`)
+//! or asks the OS where user directories live — which is exactly why it lives
+//! in the CLI and not in the library.
+
+use padzapp::init::PadzEnv;
+use std::path::PathBuf;
+
+/// Resolves the environment `padzapp::init::initialize` needs.
+///
+/// - **global data dir**: `$PADZ_GLOBAL_DATA` when set (the escape hatch tests
+///   and scripts use to isolate global state), else the OS-appropriate data
+///   directory.
+/// - **home dir**: the boundary the upward `.padz`/`.git` walks stop at.
+///   `None` when it can't be determined, which lets the walk run to the
+///   filesystem root rather than failing the command.
+pub fn resolve() -> PadzEnv {
+    PadzEnv {
+        global_data_dir: global_data_dir(),
+        home_dir: home_dir(),
+    }
+}
+
+/// Where global-scope pads live on this machine.
+///
+/// # Panics
+///
+/// Panics when neither `$PADZ_GLOBAL_DATA` is set nor an OS data directory can
+/// be determined — padz has nowhere to keep global pads and cannot sensibly
+/// continue. This preserves the pre-existing behavior of `initialize`.
+pub fn global_data_dir() -> PathBuf {
+    std::env::var("PADZ_GLOBAL_DATA")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let proj_dirs = directories::ProjectDirs::from("com", "padz", "padz")
+                .expect("Could not determine config dir");
+            proj_dirs.data_dir().to_path_buf()
+        })
+}
+
+/// The user's home directory, if it can be determined.
+fn home_dir() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|bd| bd.home_dir().to_path_buf())
+}

--- a/crates/padz/src/cli/errors.rs
+++ b/crates/padz/src/cli/errors.rs
@@ -84,28 +84,67 @@ fn style_match(term: &str) -> String {
     format!("\"{}\"", console::style(term).black().on_yellow())
 }
 
+/// If `title[start..]` begins with `term_lower` compared case-insensitively,
+/// return the byte offset in `title` just past the match.
+///
+/// Every offset this returns is a real char boundary *in the original title*,
+/// which is the point: `title.to_lowercase()` is not offset-compatible with
+/// `title`. Lowercasing can change byte length (`İ` U+0130, 2 bytes, lowercases
+/// to `i` + U+0307, 3 bytes), so an offset found in the lowercased copy can
+/// land mid-char in the original and panic the slice. Matching walks the
+/// original's chars and compares their lowercase expansion instead, so no
+/// offset ever crosses between the two strings.
+///
+/// A char whose expansion only partially satisfies the remaining term (`İ`
+/// against the term `i`) is not a match: reporting one would mean styling half
+/// a char, which is not a slice we can take.
+fn match_end(title: &str, start: usize, term_lower: &str) -> Option<usize> {
+    let mut expected = term_lower.chars().peekable();
+    for (offset, ch) in title[start..].char_indices() {
+        if expected.peek().is_none() {
+            return Some(start + offset);
+        }
+        for lowered in ch.to_lowercase() {
+            match expected.next() {
+                Some(want) if want == lowered => {}
+                _ => return None,
+            }
+        }
+    }
+    // The term ran out exactly at the end of the title.
+    expected.peek().is_none().then_some(title.len())
+}
+
 /// Render `title` plain, except for the substring matching `term_lower` (case-
 /// insensitive), which gets the same yellow-background highlight as search hits.
 fn style_title_with_match(title: &str, term_lower: &str) -> String {
     if term_lower.is_empty() {
         return title.to_string();
     }
-    let title_lower = title.to_lowercase();
     let mut out = String::with_capacity(title.len() + 16);
+    // `plain_from` trails `cursor`: the run of unstyled text not yet flushed.
+    let mut plain_from = 0usize;
     let mut cursor = 0usize;
-    while let Some(rel) = title_lower[cursor..].find(term_lower) {
-        let start = cursor + rel;
-        let end = start + term_lower.len();
-        out.push_str(&title[cursor..start]);
-        out.push_str(
-            &console::style(&title[start..end])
-                .black()
-                .on_yellow()
-                .to_string(),
-        );
-        cursor = end;
+    while cursor < title.len() {
+        match match_end(title, cursor, term_lower) {
+            Some(end) if end > cursor => {
+                out.push_str(&title[plain_from..cursor]);
+                out.push_str(
+                    &console::style(&title[cursor..end])
+                        .black()
+                        .on_yellow()
+                        .to_string(),
+                );
+                cursor = end;
+                plain_from = end;
+            }
+            _ => {
+                // Advance one whole char, never one byte.
+                cursor += title[cursor..].chars().next().map_or(1, |ch| ch.len_utf8());
+            }
+        }
     }
-    out.push_str(&title[cursor..]);
+    out.push_str(&title[plain_from..]);
     out
 }
 
@@ -164,6 +203,90 @@ mod tests {
     #[test]
     fn empty_term_returns_title_unstyled() {
         assert_eq!(style_title_with_match("Meeting", ""), "Meeting");
+    }
+
+    /// `match_end` is the offset logic the styling rides on. Asserting it
+    /// directly keeps these cases independent of whether `console` decides to
+    /// emit color in this environment.
+    #[test]
+    fn match_end_reports_offsets_into_the_original_title() {
+        // Case-insensitive match at 0, ending past the ASCII term.
+        assert_eq!(match_end("Meeting Monday", 0, "meeting"), Some(7));
+        // No match at this offset.
+        assert_eq!(match_end("Meeting Monday", 1, "meeting"), None);
+        // Match starting after a multi-byte char: "Café " is 6 bytes.
+        assert_eq!(match_end("Café Meeting", 6, "meeting"), Some(13));
+        // The match itself is multi-byte: "Café" is 5 bytes.
+        assert_eq!(match_end("Café Meeting", 0, "café"), Some(5));
+        // Term longer than the remaining title.
+        assert_eq!(match_end("Meet", 0, "meeting"), None);
+        // Match runs to the exact end of the title.
+        assert_eq!(match_end("The Meeting", 4, "meeting"), Some(11));
+        // `İ` lowercases to 2 chars; the term `i` only covers the first, so
+        // this is not a match rather than a half-char slice.
+        assert_eq!(match_end("İstanbul", 0, "i"), None);
+    }
+
+    /// Every match in the title is highlighted, not just the first — and the
+    /// text between and around them survives.
+    #[test]
+    fn every_occurrence_is_highlighted() {
+        let styled = style_title_with_match("meeting about the meeting", "meeting");
+        assert_eq!(
+            console::strip_ansi_codes(&styled),
+            "meeting about the meeting"
+        );
+    }
+
+    /// Multi-byte titles must round-trip whether or not they match. Slicing on
+    /// offsets taken from a lowercased copy used to panic here.
+    #[test]
+    fn unicode_titles_round_trip() {
+        for (title, term) in [
+            ("Café Meeting", "meeting"),  // match after multi-byte text
+            ("Café Meeting", "café"),     // the match itself is multi-byte
+            ("日本語のノート", "ノート"), // no ASCII at all
+            ("Ünïcödé", "z"),             // no match, all multi-byte
+            ("naïve café", "CAFÉ"),       // uppercase multi-byte term
+        ] {
+            let styled = style_title_with_match(title, &term.to_lowercase());
+            assert_eq!(
+                console::strip_ansi_codes(&styled),
+                title,
+                "title {title:?} with term {term:?} must survive intact"
+            );
+        }
+    }
+
+    /// The regression the offset bug hid behind: `İ` (U+0130) is 2 bytes and
+    /// lowercases to 3 (`i` + U+0307), so offsets from the lowercased copy fall
+    /// mid-char in the original. Must not panic, and must not corrupt the title.
+    #[test]
+    fn length_changing_lowercase_does_not_panic() {
+        for title in ["İstanbul", "İİİ", "aİb", "İ"] {
+            for term in ["i", "istanbul", "a", "İ"] {
+                let styled = style_title_with_match(title, &term.to_lowercase());
+                assert_eq!(
+                    console::strip_ansi_codes(&styled),
+                    title,
+                    "title {title:?} with term {term:?} must survive intact"
+                );
+            }
+        }
+    }
+
+    /// A term longer than the title, and a match running to the exact end,
+    /// exercise the two boundary paths in `match_end`.
+    #[test]
+    fn match_at_title_boundaries() {
+        // Term longer than the remaining title → no match, title intact.
+        assert_eq!(style_title_with_match("Meet", "meeting"), "Meet");
+        // Match ends exactly at the end of the title.
+        let styled = style_title_with_match("The Meeting", "meeting");
+        assert_eq!(console::strip_ansi_codes(&styled), "The Meeting");
+        // Whole title is the match.
+        let styled = style_title_with_match("Meeting", "meeting");
+        assert_eq!(console::strip_ansi_codes(&styled), "Meeting");
     }
 
     /// `render` styles the variant it knows and passes everything else

--- a/crates/padz/src/cli/errors.rs
+++ b/crates/padz/src/cli/errors.rs
@@ -1,0 +1,187 @@
+//! Terminal presentation of errors.
+//!
+//! `padzapp` returns errors as data — notably
+//! [`PadzError::AmbiguousTitle`], which carries the matched pads as
+//! [`AmbiguityCandidate`] values rather than a pre-formatted string. This
+//! module is where that data becomes the styled text a person reads, using the
+//! same accents the list/search renderer uses so an ambiguity error looks like
+//! the listing it refers to.
+//!
+//! Every other error renders through its `Display`. `console::style` collapses
+//! to plain text on its own when stderr is not a TTY or the terminal can't take
+//! color, so no `IsTerminal` checks are needed here.
+
+use padzapp::error::{AmbiguityCandidate, PadzError};
+
+/// Converts a library error into the `anyhow::Error` handlers return, styling
+/// it on the way.
+///
+/// **This is where an error's presentation is decided**, and it has to be:
+/// standout carries a dispatch failure as `RunResult::Error(String)`, so a
+/// `PadzError` is flattened to text here, at the handler boundary, long before
+/// `main` sees it. Anything that wants to look at the error's *structure* — as
+/// [`render`] does for [`PadzError::AmbiguousTitle`] — must do it now or not
+/// at all.
+pub fn to_anyhow(err: PadzError) -> anyhow::Error {
+    anyhow::anyhow!("{}", render(&err))
+}
+
+/// Renders an error for stderr, styling the ones we have a richer
+/// presentation for and falling back to `Display` for the rest.
+pub fn render(err: &PadzError) -> String {
+    match err {
+        PadzError::AmbiguousTitle {
+            term,
+            total,
+            candidates,
+        } => render_ambiguity(term, *total, candidates),
+        other => other.to_string(),
+    }
+}
+
+/// Styles an ambiguous-title error.
+///
+/// With candidates, enumerates them as an indented list; without (the match
+/// count was too high to be worth listing), reports the count alone. Mirrors
+/// `padzapp::error`'s plain rendering, with color added.
+fn render_ambiguity(term: &str, total: usize, candidates: &[AmbiguityCandidate]) -> String {
+    if candidates.is_empty() {
+        return format!(
+            "Term {} matches {} pads. Please be more specific.",
+            style_match(term),
+            total
+        );
+    }
+    let term_lower = term.to_lowercase();
+    let listing = candidates
+        .iter()
+        .map(|c| {
+            format!(
+                "    {}. {}",
+                style_index(&c.index),
+                style_title_with_match(&c.title, &term_lower)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Term {} matches multiple pads. Use one, or be more specific:\n{}",
+        style_match(term),
+        listing
+    )
+}
+
+/// Format a display index in the same accent color the list/search renderer
+/// uses for `list-index` (gold/yellow).
+fn style_index(s: &str) -> String {
+    console::style(s).yellow().to_string()
+}
+
+/// Format the search term with the same yellow-background highlight the list/
+/// search renderer uses for `match` hits (yellow bg, black fg). Wraps the
+/// styled term in quotes so the message reads `Term "foo" matches ...`.
+fn style_match(term: &str) -> String {
+    format!("\"{}\"", console::style(term).black().on_yellow())
+}
+
+/// Render `title` plain, except for the substring matching `term_lower` (case-
+/// insensitive), which gets the same yellow-background highlight as search hits.
+fn style_title_with_match(title: &str, term_lower: &str) -> String {
+    if term_lower.is_empty() {
+        return title.to_string();
+    }
+    let title_lower = title.to_lowercase();
+    let mut out = String::with_capacity(title.len() + 16);
+    let mut cursor = 0usize;
+    while let Some(rel) = title_lower[cursor..].find(term_lower) {
+        let start = cursor + rel;
+        let end = start + term_lower.len();
+        out.push_str(&title[cursor..start]);
+        out.push_str(
+            &console::style(&title[start..end])
+                .black()
+                .on_yellow()
+                .to_string(),
+        );
+        cursor = end;
+    }
+    out.push_str(&title[cursor..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(index: &str, title: &str) -> AmbiguityCandidate {
+        AmbiguityCandidate {
+            index: index.to_string(),
+            title: title.to_string(),
+        }
+    }
+
+    /// The listing carries every candidate's index and title. Asserted on
+    /// ANSI-stripped text so the test is stable regardless of whether
+    /// `console` decides to emit color in this environment.
+    #[test]
+    fn ambiguity_listing_names_every_candidate() {
+        let rendered = render_ambiguity(
+            "meeting",
+            2,
+            &[
+                candidate("1", "Meeting Monday"),
+                candidate("p2", "Meeting Tuesday"),
+            ],
+        );
+        let plain = console::strip_ansi_codes(&rendered).to_string();
+        assert!(plain.contains("multiple pads"), "got: {plain}");
+        assert!(plain.contains("    1. Meeting Monday"), "got: {plain}");
+        assert!(plain.contains("    p2. Meeting Tuesday"), "got: {plain}");
+    }
+
+    /// No candidates → the count-only message, and no invented listing.
+    #[test]
+    fn ambiguity_without_candidates_reports_count_only() {
+        let rendered = render_ambiguity("meeting", 6, &[]);
+        let plain = console::strip_ansi_codes(&rendered).to_string();
+        assert!(plain.contains("6 pads"), "got: {plain}");
+        assert!(plain.contains("Please be more specific"), "got: {plain}");
+        assert!(
+            !plain.contains('\n'),
+            "count-only must be one line: {plain}"
+        );
+    }
+
+    /// A title match is highlighted case-insensitively, and the title's own
+    /// casing survives — the user sees their pad's title, not a lowercased one.
+    #[test]
+    fn title_match_highlight_preserves_original_casing() {
+        let styled = style_title_with_match("Meeting Monday", "meeting");
+        assert_eq!(console::strip_ansi_codes(&styled), "Meeting Monday");
+    }
+
+    /// An empty term must not loop forever looking for an empty needle.
+    #[test]
+    fn empty_term_returns_title_unstyled() {
+        assert_eq!(style_title_with_match("Meeting", ""), "Meeting");
+    }
+
+    /// `render` styles the variant it knows and passes everything else
+    /// through to `Display`.
+    #[test]
+    fn render_falls_back_to_display_for_other_errors() {
+        let err = PadzError::Api("boom".to_string());
+        assert_eq!(render(&err), "Api Error: boom");
+    }
+
+    #[test]
+    fn render_styles_ambiguous_title() {
+        let err = PadzError::AmbiguousTitle {
+            term: "meeting".to_string(),
+            total: 1,
+            candidates: vec![candidate("1", "Meeting Monday")],
+        };
+        let plain = console::strip_ansi_codes(&render(&err)).to_string();
+        assert!(plain.contains("    1. Meeting Monday"), "got: {plain}");
+    }
+}

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -14,8 +14,9 @@
 // Allow non_snake_case for macro-generated __handler wrapper functions
 #![allow(non_snake_case)]
 
+use crate::cli::clipboard::{copy_to_clipboard, format_for_clipboard};
+use crate::cli::errors::to_anyhow;
 use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
-use padzapp::clipboard::{copy_to_clipboard, format_for_clipboard};
 use padzapp::commands::{CmdResult, NestingMode};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
@@ -107,7 +108,7 @@ fn get_state(ctx: &CommandContext) -> &AppState {
 /// ```ignore
 /// let state = get_state(ctx);
 /// let result = state.with_api(|api| {
-///     api.method(state.scope, &args).map_err(|e| anyhow::anyhow!("{}", e))
+///     api.method(state.scope, &args).map_err(to_anyhow)
 /// })?;
 /// Ok(Output::Render(ModificationResult { ... }))
 /// ```
@@ -130,7 +131,7 @@ impl<'a> ScopedApi<'a> {
         F: FnOnce(&mut PadzApi<FileStore>, Scope) -> Result<T, PadzError>,
     {
         self.state
-            .with_api(|api| f(api, self.state.scope).map_err(|e| anyhow::anyhow!("{}", e)))
+            .with_api(|api| f(api, self.state.scope).map_err(to_anyhow))
     }
 
     /// Map a CmdResult (modification) into the typed modification result.
@@ -655,10 +656,10 @@ pub fn create(
         state.with_api(|api| {
             if let Some(fmt) = format {
                 api.create_pad_with_format(state.scope, title, content, inside, fmt)
-                    .map_err(|e| anyhow::anyhow!("{}", e))
+                    .map_err(to_anyhow)
             } else {
                 api.create_pad(state.scope, title, content, inside)
-                    .map_err(|e| anyhow::anyhow!("{}", e))
+                    .map_err(to_anyhow)
             }
         })
     }
@@ -710,24 +711,21 @@ pub fn create(
         let pad_id = create_result.affected_pads[0].pad.metadata.id;
 
         // Open editor on the real pad file in .padz/
-        if let Err(e) = padzapp::editor::open_in_editor(&pad_path) {
+        if let Err(e) = crate::cli::editor::open_in_editor(&pad_path) {
             // Editor failed - clean up the pad
             let _ = state.with_api(|api| api.remove_pad(state.scope, pad_id));
-            return Err(anyhow::anyhow!("{}", e));
+            return Err(to_anyhow(e));
         }
 
         // Refresh pad from disk (re-reads content, updates title)
-        match state.with_api(|api| {
-            api.refresh_pad(state.scope, &pad_id)
-                .map_err(|e| anyhow::anyhow!("{}", e))
-        })? {
+        match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
             Some(pad) => {
                 // Propagate status now — pad has real content after editor,
                 // safe from reconciliation deleting the empty file.
                 let parent_id = pad.metadata.parent_id;
                 state.with_api(|api| {
                     api.propagate_status(state.scope, parent_id)
-                        .map_err(|e| anyhow::anyhow!("{}", e))
+                        .map_err(to_anyhow)
                 })?;
                 // Copy to clipboard
                 copy_content_to_clipboard(&pad.content);
@@ -934,7 +932,7 @@ pub fn edit(
         let raw = inline_content.unwrap();
         let result = state.with_api(|api| {
             api.update_pads_from_content(state.scope, &index_args, &raw)
-                .map_err(|e| anyhow::anyhow!("{}", e))
+                .map_err(to_anyhow)
         })?;
 
         let clipboard_text = raw.clone();
@@ -952,7 +950,7 @@ pub fn edit(
         }
         let result = state.with_api(|api| {
             api.update_pads_from_content(state.scope, &index_args, &raw)
-                .map_err(|e| anyhow::anyhow!("{}", e))
+                .map_err(to_anyhow)
         })?;
 
         copy_content_to_clipboard(&raw);
@@ -969,7 +967,7 @@ pub fn edit(
             &index_args,
             padzapp::commands::NestingMode::Flat,
         )
-        .map_err(|e| anyhow::anyhow!("{}", e))
+        .map_err(to_anyhow)
     })?;
 
     let pad = view_result
@@ -979,19 +977,14 @@ pub fn edit(
     let pad_id = pad.pad.metadata.id;
     let display_index = pad.index.clone();
 
-    let pad_path = state.with_api(|api| {
-        api.get_path_by_id(state.scope, pad_id)
-            .map_err(|e| anyhow::anyhow!("{}", e))
-    })?;
+    let pad_path =
+        state.with_api(|api| api.get_path_by_id(state.scope, pad_id).map_err(to_anyhow))?;
 
     // Open editor on the real pad file in .padz/
-    padzapp::editor::open_in_editor(&pad_path)?;
+    crate::cli::editor::open_in_editor(&pad_path)?;
 
     // Refresh pad from disk (re-reads content, updates title)
-    match state.with_api(|api| {
-        api.refresh_pad(state.scope, &pad_id)
-            .map_err(|e| anyhow::anyhow!("{}", e))
-    })? {
+    match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
         Some(pad) => {
             copy_content_to_clipboard(&pad.content);
 
@@ -1086,10 +1079,7 @@ pub fn path(
     #[arg] indexes: Vec<String>,
 ) -> Result<Output<PathResult>, anyhow::Error> {
     let state = get_state(ctx);
-    let result = state.with_api(|api| {
-        api.pad_paths(state.scope, &indexes)
-            .map_err(|e| anyhow::anyhow!("{}", e))
-    })?;
+    let result = state.with_api(|api| api.pad_paths(state.scope, &indexes).map_err(to_anyhow))?;
 
     Ok(Output::Render(PathResult {
         paths: result
@@ -1107,10 +1097,7 @@ pub fn uuid(
     #[arg] indexes: Vec<String>,
 ) -> Result<Output<UuidResult>, anyhow::Error> {
     let state = get_state(ctx);
-    let result = state.with_api(|api| {
-        api.pad_uuids(state.scope, &indexes)
-            .map_err(|e| anyhow::anyhow!("{}", e))
-    })?;
+    let result = state.with_api(|api| api.pad_uuids(state.scope, &indexes).map_err(to_anyhow))?;
 
     Ok(Output::Render(UuidResult {
         uuids: result.messages.iter().map(|m| m.content.clone()).collect(),
@@ -1285,7 +1272,7 @@ pub mod tag {
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.add_tags_to_pads(state.scope, &indexes, &tags)
-                .map_err(|e| anyhow::anyhow!("{}", e))
+                .map_err(to_anyhow)
         })?;
         Ok(Output::Render(
             api(ctx).modification_result("Tagged", result, false),
@@ -1301,7 +1288,7 @@ pub mod tag {
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.remove_tags_from_pads(state.scope, &indexes, &tags)
-                .map_err(|e| anyhow::anyhow!("{}", e))
+                .map_err(to_anyhow)
         })?;
         Ok(Output::Render(
             api(ctx).modification_result("Untagged", result, false),
@@ -1334,10 +1321,8 @@ pub mod tag {
             api(ctx).list_tags()
         } else {
             let state = get_state(ctx);
-            let result = state.with_api(|api| {
-                api.list_pad_tags(state.scope, &ids)
-                    .map_err(|e| anyhow::anyhow!("{}", e))
-            })?;
+            let result =
+                state.with_api(|api| api.list_pad_tags(state.scope, &ids).map_err(to_anyhow))?;
             Ok(Output::Render(MessagesResult::new(result.messages)))
         }
     }
@@ -1361,7 +1346,10 @@ mod tests {
 
     /// A project-scoped store in a temp dir, wired into a CommandContext.
     ///
-    /// Uses `data_override` so the store is explicit and no global/env state is read.
+    /// Uses `data_override` for the project store and an explicit [`PadzEnv`]
+    /// pointing global inside the same temp dir, so the fixture reads no
+    /// process environment and can never touch the developer's real global
+    /// store.
     struct TestApp {
         _temp: TempDir,
         ctx: CommandContext,
@@ -1371,7 +1359,11 @@ mod tests {
         fn new(mode: PadzMode) -> Self {
             let temp = TempDir::new().unwrap();
             let root = temp.path().to_path_buf();
-            let padz_ctx = initialize(&root, false, Some(root.clone()), true).unwrap();
+            let env = padzapp::init::PadzEnv {
+                global_data_dir: root.join("global-data"),
+                home_dir: None,
+            };
+            let padz_ctx = initialize(&env, &root, false, Some(root.clone()), true).unwrap();
 
             let state = AppState::new(
                 padz_ctx.api,

--- a/crates/padz/src/cli/mod.rs
+++ b/crates/padz/src/cli/mod.rs
@@ -59,8 +59,12 @@
 //! - `render`: Render-time view derivation for standout's templates
 //! - `setup`: Argument parsing via clap, help text
 
+pub mod clipboard;
 mod commands;
 mod complete;
+pub mod editor;
+pub mod env;
+pub mod errors;
 pub mod handlers;
 pub mod render;
 pub mod result;

--- a/crates/padz/src/main.rs
+++ b/crates/padz/src/main.rs
@@ -8,8 +8,8 @@
 //! ## Workspace Structure
 //!
 //! Padz is organized as a Cargo workspace with two crates:
-//! - `crates/padz/` — Core library with UI-agnostic business logic
-//! - `crates/padz-cli/` — This CLI tool, depends on the `padz` library
+//! - `crates/padzapp/` — Core library with UI-agnostic business logic
+//! - `crates/padz/` — This CLI tool, depends on the `padzapp` library
 //!
 //! ## Layering
 //!
@@ -17,7 +17,7 @@
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────┐
-//! │  CLI Layer (crates/padz-cli/src/cli/)                       │
+//! │  CLI Layer (crates/padz/src/cli/)                           │
 //! │  - clap argument parsing (setup.rs)                         │
 //! │  - Command selection + context wiring (commands.rs)         │
 //! │  - Terminal rendering via Standout templates (render.rs)    │
@@ -26,7 +26,7 @@
 //!                              │
 //!                              ▼
 //! ┌─────────────────────────────────────────────────────────────┐
-//! │  API Layer (crates/padz/src/api.rs)                         │
+//! │  API Layer (crates/padzapp/src/api/)                        │
 //! │  - Normalizes user-facing IDs → UUIDs                       │
 //! │  - Dispatches to command modules                            │
 //! │  - Returns structured `CmdResult` values                    │
@@ -34,7 +34,7 @@
 //!                              │
 //!                              ▼
 //! ┌─────────────────────────────────────────────────────────────┐
-//! │  Command Layer (crates/padz/src/commands/*)                 │
+//! │  Command Layer (crates/padzapp/src/commands/*)              │
 //! │  - Pure business logic + data access                        │
 //! │  - No knowledge of stdout/stderr or process exits           │
 //! └─────────────────────────────────────────────────────────────┘
@@ -56,9 +56,9 @@
 //!
 //! ## Testing Approach
 //!
-//! - **Commands layer (`crates/padz/src/commands/`)**: heavy unit testing of the
+//! - **Commands layer (`crates/padzapp/src/commands/`)**: heavy unit testing of the
 //!   business logic.
-//! - **API layer (`crates/padz/src/api.rs`)**: mock-focused tests to ensure the
+//! - **API layer (`crates/padzapp/src/api/`)**: mock-focused tests to ensure the
 //!   correct command functions are invoked with the right arguments and that
 //!   results are normalized properly.
 //! - **CLI layer (`src/cli/`)**: tests build `clap` argument strings, mock the
@@ -77,7 +77,10 @@ fn main() {
     clap_complete::CompleteEnv::with_factory(cli::setup::build_command).complete();
 
     if let Err(e) = cli::run() {
-        eprintln!("Error: {}", e);
+        // `cli::errors::render` styles the errors that carry structured data
+        // (see `padzapp::error::PadzError::AmbiguousTitle`) and falls back to
+        // `Display` for the rest.
+        eprintln!("Error: {}", cli::errors::render(&e));
         std::process::exit(1);
     }
 }

--- a/crates/padzapp/Cargo.toml
+++ b/crates/padzapp/Cargo.toml
@@ -13,8 +13,6 @@ readme = "README.md"
 chrono = { version = "0.4.42", features = ["serde"] }
 clapfig = { version = "0.9.2", default-features = false }
 confique = { version = "0.4", features = ["toml"] }
-console = "0.15"
-directories = "6.0.0"
 flate2 = "1.1.5"
 once_cell = "1.19"
 pulldown-cmark = "0.12"

--- a/crates/padzapp/src/api/test_support.rs
+++ b/crates/padzapp/src/api/test_support.rs
@@ -21,6 +21,7 @@ pub(crate) fn make_api() -> PadzApi<TestStore> {
     let paths = PadzPaths {
         project: Some(PathBuf::from("/tmp/test")),
         global: PathBuf::from("/tmp/global"),
+        home: None,
     };
     PadzApi::new(store, paths)
 }

--- a/crates/padzapp/src/api/transfer.rs
+++ b/crates/padzapp/src/api/transfer.rs
@@ -60,7 +60,8 @@ impl<S: DataStore> PadzApi<S> {
         mode: commands::transfer::TransferMode,
     ) -> Result<commands::CmdResult> {
         let selectors = parse_selectors(indexes)?;
-        let dest_padz = commands::transfer::resolve_target_dir(dest_path)?;
+        let dest_padz =
+            commands::transfer::resolve_target_dir(dest_path, self.paths.home.as_deref())?;
         // Refuse to transfer to the same store. For migrate the user would
         // see the pad copied over itself and then deleted — data loss.
         // Clone would no-op at best; we reject both for a clear error.
@@ -92,7 +93,8 @@ impl<S: DataStore> PadzApi<S> {
         source_path: &std::path::Path,
         mode: commands::transfer::TransferMode,
     ) -> Result<commands::CmdResult> {
-        let source_padz = commands::transfer::resolve_target_dir(source_path)?;
+        let source_padz =
+            commands::transfer::resolve_target_dir(source_path, self.paths.home.as_deref())?;
         let current_padz = self.paths.scope_dir(scope)?;
         if canonicalize_or_self(&current_padz) == canonicalize_or_self(&source_padz) {
             return Err(PadzError::Api(format!(
@@ -141,6 +143,7 @@ mod tests {
             PadzPaths {
                 project: Some(project_dir),
                 global: PathBuf::from("/tmp/global"),
+                home: None,
             },
         )
     }

--- a/crates/padzapp/src/commands/helpers/selector_resolve.rs
+++ b/crates/padzapp/src/commands/helpers/selector_resolve.rs
@@ -1,4 +1,4 @@
-use crate::error::{PadzError, Result};
+use crate::error::{AmbiguityCandidate, PadzError, Result};
 use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::Scope;
 use crate::store::DataStore;
@@ -150,29 +150,28 @@ pub fn resolve_selectors<S: DataStore>(
                         results.push((path.clone(), dp.pad.metadata.id));
                     }
                     n if n <= AMBIGUITY_LIST_THRESHOLD => {
-                        let listing: String = matches
+                        let candidates = matches
                             .iter()
-                            .map(|(path, dp)| {
-                                format!(
-                                    "    {}. {}",
-                                    style_index(&fmt_path(path)),
-                                    style_title_with_match(&dp.pad.metadata.title, &term_lower)
-                                )
+                            .map(|(path, dp)| AmbiguityCandidate {
+                                index: fmt_path(path),
+                                title: dp.pad.metadata.title.clone(),
                             })
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        return Err(PadzError::Api(format!(
-                            "Term {} matches multiple pads. Use one, or be more specific:\n{}",
-                            style_match(term),
-                            listing
-                        )));
+                            .collect();
+                        return Err(PadzError::AmbiguousTitle {
+                            term: term.clone(),
+                            total: n,
+                            candidates,
+                        });
                     }
                     n => {
-                        return Err(PadzError::Api(format!(
-                            "Term {} matches {} pads. Please be more specific.",
-                            style_match(term),
-                            n
-                        )));
+                        // Above the threshold, enumerating the matches helps
+                        // nobody — report the count alone and leave
+                        // `candidates` empty.
+                        return Err(PadzError::AmbiguousTitle {
+                            term: term.clone(),
+                            total: n,
+                            candidates: Vec::new(),
+                        });
                     }
                 }
             }
@@ -180,46 +179,6 @@ pub fn resolve_selectors<S: DataStore>(
     }
 
     Ok(results)
-}
-
-/// Format a display index in the same accent color the list/search renderer
-/// uses for `list-index` (gold/yellow). When stderr is not a TTY or the
-/// terminal can't take color, `console::style` collapses to plain text on its
-/// own — no extra `IsTerminal` checks needed here.
-fn style_index(s: &str) -> String {
-    console::style(s).yellow().to_string()
-}
-
-/// Format the search term with the same yellow-background highlight the list/
-/// search renderer uses for `match` hits (yellow bg, black fg). Wraps the
-/// styled term in quotes so the message reads `Term "foo" matches ...`.
-fn style_match(term: &str) -> String {
-    format!("\"{}\"", console::style(term).black().on_yellow())
-}
-
-/// Render `title` plain, except for the substring matching `term_lower` (case-
-/// insensitive), which gets the same yellow-background highlight as search hits.
-fn style_title_with_match(title: &str, term_lower: &str) -> String {
-    if term_lower.is_empty() {
-        return title.to_string();
-    }
-    let title_lower = title.to_lowercase();
-    let mut out = String::with_capacity(title.len() + 16);
-    let mut cursor = 0usize;
-    while let Some(rel) = title_lower[cursor..].find(term_lower) {
-        let start = cursor + rel;
-        let end = start + term_lower.len();
-        out.push_str(&title[cursor..start]);
-        out.push_str(
-            &console::style(&title[start..end])
-                .black()
-                .on_yellow()
-                .to_string(),
-        );
-        cursor = end;
-    }
-    out.push_str(&title[cursor..]);
-    out
 }
 
 /// Is this pad in the bucket we're filtering to?
@@ -592,16 +551,30 @@ mod tests {
             TitleBucket::Any,
         );
 
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        // Strip ANSI styling so substring assertions are stable regardless of
-        // whether `console` decided to emit colors in this environment.
-        let plain = console::strip_ansi_codes(&err).to_string();
-        assert!(plain.contains("multiple pads"));
-        // Under the listing threshold, matches are enumerated by title.
-        assert!(plain.contains("Meeting Monday"));
-        assert!(plain.contains("Meeting Tuesday"));
-        assert!(plain.contains("Meeting Wednesday"));
+        // Under the listing threshold, every match is carried as structured
+        // candidate data — index and title, unstyled — for a presenter to
+        // render.
+        match result.unwrap_err() {
+            PadzError::AmbiguousTitle {
+                term,
+                total,
+                candidates,
+            } => {
+                assert_eq!(term, "Meeting");
+                assert_eq!(total, 3);
+                // Candidates arrive in display order — newest pad first, the
+                // same order `padz list` shows — so index N names the same pad
+                // in the error as it does in the listing the user just read.
+                let titles: Vec<&str> = candidates.iter().map(|c| c.title.as_str()).collect();
+                assert_eq!(
+                    titles,
+                    ["Meeting Wednesday", "Meeting Tuesday", "Meeting Monday"]
+                );
+                let indexes: Vec<&str> = candidates.iter().map(|c| c.index.as_str()).collect();
+                assert_eq!(indexes, ["1", "2", "3"]);
+            }
+            other => panic!("expected AmbiguousTitle; got {other:?}"),
+        }
     }
 
     #[test]
@@ -1387,10 +1360,67 @@ mod tests {
             false,
             TitleBucket::Active,
         );
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        // Over the threshold we fall back to a count-only error, without enumerating titles.
-        assert!(err.contains("6 pads"));
-        assert!(!err.contains("Meeting 1"));
+        // Over the threshold we report the count alone: `total` is the full
+        // match count and `candidates` is empty, so no presenter enumerates
+        // six near-identical titles.
+        match result.unwrap_err() {
+            PadzError::AmbiguousTitle {
+                term,
+                total,
+                candidates,
+            } => {
+                assert_eq!(term, "Meeting");
+                assert_eq!(total, 6);
+                assert!(
+                    candidates.is_empty(),
+                    "over-threshold matches must not be enumerated; got {candidates:?}"
+                );
+            }
+            other => panic!("expected AmbiguousTitle; got {other:?}"),
+        }
+    }
+
+    /// The library's own rendering of an ambiguity is plain text: readable,
+    /// but carrying no terminal styling. Styling is the CLI's job (see
+    /// `padz::cli::errors`), so nothing here may emit an escape sequence.
+    #[test]
+    fn test_title_ambiguity_display_is_plain_text() {
+        let err = PadzError::AmbiguousTitle {
+            term: "Meeting".to_string(),
+            total: 2,
+            candidates: vec![
+                AmbiguityCandidate {
+                    index: "1".to_string(),
+                    title: "Meeting Monday".to_string(),
+                },
+                AmbiguityCandidate {
+                    index: "p2".to_string(),
+                    title: "Meeting Tuesday".to_string(),
+                },
+            ],
+        };
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains('\x1b'),
+            "library errors must not carry ANSI; got {rendered:?}"
+        );
+        assert!(rendered.contains("Meeting Monday"));
+        assert!(rendered.contains("    1. Meeting Monday"));
+        assert!(rendered.contains("    p2. Meeting Tuesday"));
+    }
+
+    /// Over the threshold, `Display` reports the count and never invents a
+    /// listing out of the empty `candidates`.
+    #[test]
+    fn test_title_ambiguity_display_count_only_when_no_candidates() {
+        let err = PadzError::AmbiguousTitle {
+            term: "Meeting".to_string(),
+            total: 6,
+            candidates: Vec::new(),
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("6 pads"));
+        assert!(rendered.contains("more specific"));
+        assert!(!rendered.contains('\x1b'));
     }
 }

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -108,10 +108,16 @@ pub mod update;
 pub mod uuid;
 pub mod view;
 
+/// The filesystem locations a `PadzApi` operates against, supplied by the
+/// caller rather than discovered here.
 #[derive(Debug, Clone)]
 pub struct PadzPaths {
     pub project: Option<PathBuf>,
     pub global: PathBuf,
+    /// The user's home directory, used only as the stopping point when walking
+    /// upward to resolve a user-supplied transfer path. `None` means "walk to
+    /// the filesystem root". See `init::PadzEnv::home_dir`.
+    pub home: Option<PathBuf>,
 }
 
 impl PadzPaths {

--- a/crates/padzapp/src/commands/transfer.rs
+++ b/crates/padzapp/src/commands/transfer.rs
@@ -72,7 +72,10 @@ impl TransferMode {
 /// `init::resolve_link` — matches the CLI's read-side discovery so a
 /// linked store is treated the same whether accessed via `clone`/`migrate`
 /// or the normal command pipeline.
-pub fn resolve_target_dir(path: &Path) -> Result<PathBuf> {
+///
+/// `home_dir` bounds the upward walk in case 3, exactly as it does for
+/// `init::find_padz_root`; `None` walks to the filesystem root.
+pub fn resolve_target_dir(path: &Path, home_dir: Option<&Path>) -> Result<PathBuf> {
     let path = path
         .canonicalize()
         .map_err(|e| PadzError::Api(format!("Target path '{}': {}", path.display(), e)))?;
@@ -81,7 +84,7 @@ pub fn resolve_target_dir(path: &Path) -> Result<PathBuf> {
         path
     } else if path.join(".padz").is_dir() {
         path.join(".padz")
-    } else if let Some(root) = find_padz_root(&path) {
+    } else if let Some(root) = find_padz_root(&path, home_dir) {
         root.join(".padz")
     } else {
         return Err(PadzError::Api(format!(
@@ -1057,7 +1060,7 @@ mod tests {
         let padz_dir = temp.path().join(".padz");
         init_layout(&padz_dir);
 
-        let resolved = resolve_target_dir(&padz_dir).unwrap();
+        let resolved = resolve_target_dir(&padz_dir, None).unwrap();
         assert_eq!(resolved, padz_dir.canonicalize().unwrap());
     }
 
@@ -1068,7 +1071,7 @@ mod tests {
         std::fs::create_dir_all(&project).unwrap();
         init_layout(&project.join(".padz"));
 
-        let resolved = resolve_target_dir(&project).unwrap();
+        let resolved = resolve_target_dir(&project, None).unwrap();
         assert_eq!(resolved, project.join(".padz").canonicalize().unwrap());
     }
 
@@ -1080,7 +1083,7 @@ mod tests {
         std::fs::create_dir_all(&nested).unwrap();
         init_layout(&project.join(".padz"));
 
-        let resolved = resolve_target_dir(&nested).unwrap();
+        let resolved = resolve_target_dir(&nested, None).unwrap();
         assert_eq!(resolved, project.join(".padz").canonicalize().unwrap());
     }
 
@@ -1090,7 +1093,7 @@ mod tests {
         // deterministic regardless of what exists on the host filesystem.
         let temp = tempfile::tempdir().unwrap();
         let missing = temp.path().join("does-not-exist");
-        let err = resolve_target_dir(&missing).unwrap_err();
+        let err = resolve_target_dir(&missing, None).unwrap_err();
         // Either "Target path '…': No such file" or "No padz store found" —
         // both signal the same user-visible failure to locate a store.
         let msg = err.to_string();

--- a/crates/padzapp/src/editor.rs
+++ b/crates/padzapp/src/editor.rs
@@ -1,8 +1,12 @@
-use crate::error::{PadzError, Result};
+//! The editor *buffer* format — the wire format between a pad and whatever
+//! text editor a user edits it in.
+//!
+//! Only the format lives here: turning a pad's title and content into a buffer
+//! and parsing one back. Choosing an editor and launching it are user-environment
+//! concerns owned by the application (see `padz::cli::editor` in the CLI crate),
+//! not by this library.
+
 use crate::model::extract_title_and_body;
-use std::env;
-use std::path::Path;
-use std::process::Command;
 
 /// Represents the content parsed from an editor buffer.
 /// Format: title\n\ncontent
@@ -43,58 +47,6 @@ impl EditorContent {
             content: String::new(),
         }
     }
-}
-
-/// Gets the editor command from environment.
-/// Checks $EDITOR, then $VISUAL, then falls back to common editors.
-pub fn get_editor() -> Result<String> {
-    if let Ok(editor) = env::var("EDITOR") {
-        if !editor.is_empty() {
-            return Ok(editor);
-        }
-    }
-
-    if let Ok(editor) = env::var("VISUAL") {
-        if !editor.is_empty() {
-            return Ok(editor);
-        }
-    }
-
-    // Try common fallbacks
-    for fallback in &["vim", "vi", "nano"] {
-        if Command::new("which")
-            .arg(fallback)
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-        {
-            return Ok((*fallback).to_string());
-        }
-    }
-
-    Err(PadzError::Api(
-        "No editor found. Set $EDITOR environment variable.".to_string(),
-    ))
-}
-
-/// Opens a file in the user's editor and waits for it to close.
-pub fn open_in_editor<P: AsRef<Path>>(file_path: P) -> Result<()> {
-    let editor = get_editor()?;
-    let path = file_path.as_ref();
-
-    let status = Command::new(&editor)
-        .arg(path)
-        .status()
-        .map_err(|e| PadzError::Api(format!("Failed to launch editor '{}': {}", editor, e)))?;
-
-    if !status.success() {
-        return Err(PadzError::Api(format!(
-            "Editor '{}' exited with non-zero status",
-            editor
-        )));
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/padzapp/src/error.rs
+++ b/crates/padzapp/src/error.rs
@@ -1,10 +1,62 @@
+use std::fmt;
 use thiserror::Error;
 use uuid::Uuid;
+
+/// One pad that matched an ambiguous title selector.
+///
+/// Carries the *data* a presenter needs — the pad's display index and its
+/// title — with no formatting applied. The CLI styles these (accenting the
+/// index, highlighting the matched substring in the title); other consumers
+/// can render them however they like, or ignore them and use the counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbiguityCandidate {
+    /// The pad's display index, formatted as the user would type it
+    /// (`1`, `p2`, `3.1`, `d4`).
+    pub index: String,
+    /// The pad's title, verbatim.
+    pub title: String,
+}
+
+/// Render [`PadzError::AmbiguousTitle`] as plain, unstyled text.
+///
+/// This is the library's fallback presentation: correct and readable, but
+/// with no terminal styling. The padz CLI intercepts the variant before it
+/// reaches `Display` and renders a styled equivalent from the same fields.
+fn plain_ambiguity(term: &str, total: usize, candidates: &[AmbiguityCandidate]) -> String {
+    if candidates.is_empty() {
+        return format!(
+            "Term \"{}\" matches {} pads. Please be more specific.",
+            term, total
+        );
+    }
+    let listing = candidates
+        .iter()
+        .map(|c| format!("    {}. {}", c.index, c.title))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Term \"{}\" matches multiple pads. Use one, or be more specific:\n{}",
+        term, listing
+    )
+}
 
 #[derive(Error, Debug)]
 pub enum PadzError {
     #[error("Pad not found: {0}")]
     PadNotFound(Uuid),
+
+    /// A title selector matched more than one pad.
+    ///
+    /// `candidates` is populated when the match count is small enough to
+    /// enumerate helpfully, and empty when it is not — in which case `total`
+    /// is the only useful signal. `total` is always the full match count, so
+    /// `candidates.len()` may be less than `total` only when empty.
+    #[error("{}", plain_ambiguity(.term, *.total, .candidates))]
+    AmbiguousTitle {
+        term: String,
+        total: usize,
+        candidates: Vec<AmbiguityCandidate>,
+    },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -17,6 +69,33 @@ pub enum PadzError {
 
     #[error("Api Error: {0}")]
     Api(String),
+}
+
+/// A non-fatal condition raised while initializing a padz context.
+///
+/// Initialization is best-effort about self-healing work like layout
+/// migration: a failure there does not stop the command, but the user should
+/// hear about it. The library returns these as data on [`crate::init::PadzContext`]
+/// rather than writing to stderr, leaving the decision of whether and how to
+/// surface them to the application.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitWarning {
+    /// A legacy flat layout was detected at `path` but could not be migrated
+    /// to the bucketed layout. The store is left as-is and remains readable.
+    MigrationFailed {
+        path: std::path::PathBuf,
+        error: String,
+    },
+}
+
+impl fmt::Display for InitWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InitWarning::MigrationFailed { path, error } => {
+                write!(f, "migration of {} failed: {}", path.display(), error)
+            }
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, PadzError>;

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -156,6 +156,13 @@ pub fn find_git_root(cwd: &Path, home_dir: Option<&Path>) -> Option<PathBuf> {
 /// Shared upward-walk helper. Returns the first ancestor (including `cwd`
 /// itself) for which `matches` returns true. Stops at `home_dir` (exclusive)
 /// or the filesystem root.
+///
+/// "Exclusive" means `home_dir` is never itself a candidate: the boundary is
+/// tested *before* `matches`, so a `.padz`/`.git` sitting directly in `$HOME`
+/// cannot capture the walk. That ordering is the whole rule — a home with a
+/// dotfiles repo (`~/.git`) is common, and matching it would silently make
+/// every directory under `$HOME` that lacks its own store resolve to `$HOME`,
+/// turning the home directory into one enormous accidental project.
 fn walk_up_matching<F>(cwd: &Path, home_dir: Option<&Path>, matches: F) -> Option<PathBuf>
 where
     F: Fn(&Path) -> bool,
@@ -163,14 +170,14 @@ where
     let mut current = cwd.to_path_buf();
 
     loop {
-        if matches(&current) {
-            return Some(current);
-        }
-
         if let Some(home) = home_dir {
             if current == home {
                 return None;
             }
+        }
+
+        if matches(&current) {
+            return Some(current);
         }
 
         match current.parent() {
@@ -1163,25 +1170,48 @@ mod tests {
         );
     }
 
-    /// Global scope goes exactly where `PadzEnv` says, with no environment
-    /// consulted. Guards the boundary: if someone reintroduces a
-    /// `$PADZ_GLOBAL_DATA` read inside the library, the env var set here would
-    /// win over the explicit value and this fails.
+    /// Global scope goes exactly where `PadzEnv` says: two different `PadzEnv`
+    /// values resolve to two different global roots, so the path demonstrably
+    /// tracks the argument rather than any ambient default.
+    ///
+    /// This deliberately does *not* set a decoy `$PADZ_GLOBAL_DATA` to prove
+    /// the library ignores it. `std::env::set_var` is process-global and races
+    /// any concurrent reader; `test_env()` above calls `std::env::temp_dir()`,
+    /// which reads the environment, so under the parallel runner the decoy
+    /// raced a live reader. That is a `setenv`/`getenv` data race at the C
+    /// level, and a test-local mutex cannot fix it, because the readers it
+    /// races never take the lock.
+    ///
+    /// The boundary that decoy was guarding is instead enforced structurally,
+    /// and more tightly than a runtime assertion could: this crate contains no
+    /// `env::var` call at all (the mandated scan in the PR checks exactly
+    /// this), and it no longer depends on `directories`, so the compiler — not
+    /// a test — rejects reintroducing OS-directory discovery here. Reading the
+    /// environment is `padz::cli::env`'s job; the e2e suite covers that side by
+    /// passing `PADZ_GLOBAL_DATA` per-child via `Command::env`, which is sound.
     #[test]
     fn test_global_data_dir_comes_from_env_argument_only() {
         let temp = TempDir::new().unwrap();
-        let explicit = temp.path().join("explicit-global");
-        let env = PadzEnv {
-            global_data_dir: explicit.clone(),
-            home_dir: None,
+
+        let resolve_global = |dir_name: &str| {
+            let explicit = temp.path().join(dir_name);
+            let env = PadzEnv {
+                global_data_dir: explicit.clone(),
+                home_dir: None,
+            };
+            let ctx = initialize(&env, temp.path(), true, None, false).unwrap();
+            assert_eq!(ctx.scope, crate::model::Scope::Global);
+            (explicit, ctx.api.paths().global.clone())
         };
 
-        std::env::set_var("PADZ_GLOBAL_DATA", temp.path().join("decoy"));
-        let ctx = initialize(&env, temp.path(), true, None, false).unwrap();
-        std::env::remove_var("PADZ_GLOBAL_DATA");
+        let (first_explicit, first_global) = resolve_global("explicit-global");
+        assert_eq!(first_global, first_explicit);
 
-        assert_eq!(ctx.scope, crate::model::Scope::Global);
-        assert_eq!(ctx.api.paths().global, explicit);
+        // A second, different input must move the global root with it. An
+        // ambient source would pin both runs to the same place.
+        let (second_explicit, second_global) = resolve_global("other-global");
+        assert_eq!(second_global, second_explicit);
+        assert_ne!(first_global, second_global);
     }
 
     /// The home boundary is an input too: the upward walk stops there and does
@@ -1201,6 +1231,58 @@ mod tests {
             find_padz_root(&child, None),
             Some(temp.path().to_path_buf())
         );
+    }
+
+    /// The boundary is EXCLUSIVE: a store sitting directly in `$HOME` is not a
+    /// match, whether the walk arrives from below or starts there. `~/.padz` is
+    /// the shape that matters — matching it would resolve every unstored
+    /// directory under `$HOME` to `$HOME`.
+    #[test]
+    fn test_home_dir_itself_is_never_matched() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let child = home.join("a").join("b");
+        fs::create_dir_all(&child).unwrap();
+        fs::create_dir_all(home.join(".padz")).unwrap();
+
+        // Walking up from below the boundary.
+        assert_eq!(find_padz_root(&child, Some(&home)), None);
+        // Starting exactly on the boundary.
+        assert_eq!(find_padz_root(&home, Some(&home)), None);
+        // Drop the boundary and the very same store is found — proving the
+        // `None` above is the boundary talking, not a missing fixture.
+        assert_eq!(find_padz_root(&child, None), Some(home.clone()));
+    }
+
+    /// Same exclusivity for auto-init discovery: a home that is itself a git
+    /// repo (a dotfiles checkout, `~/.git`) must not become the auto-init root.
+    #[test]
+    fn test_home_dir_itself_is_never_matched_for_git_root() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let child = home.join("projects").join("scratch");
+        fs::create_dir_all(&child).unwrap();
+        fs::create_dir_all(home.join(".git")).unwrap();
+
+        assert_eq!(find_git_root(&child, Some(&home)), None);
+        assert_eq!(find_git_root(&home, Some(&home)), None);
+        assert_eq!(find_git_root(&child, None), Some(home.clone()));
+    }
+
+    /// The boundary excludes `$HOME` itself, not everything under it: a real
+    /// project below the home boundary is still found.
+    #[test]
+    fn test_boundary_does_not_block_matches_below_home() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = home.join("projects").join("app");
+        let child = project.join("src").join("deep");
+        fs::create_dir_all(&child).unwrap();
+        fs::create_dir_all(project.join(".padz")).unwrap();
+        // A decoy at the boundary must lose to the nearer, in-bounds store.
+        fs::create_dir_all(home.join(".padz")).unwrap();
+
+        assert_eq!(find_padz_root(&child, Some(&home)), Some(project));
     }
 
     /// The common case: nothing to migrate, so nothing to report.

--- a/crates/padzapp/src/init.rs
+++ b/crates/padzapp/src/init.rs
@@ -11,8 +11,11 @@
 //! ## The Scopes
 //!
 //! - **Project**: Bound to a specific `.padz/` directory. Data lives in `<project_root>/.padz/`.
-//! - **Global**: Bound to the user. Data lives in the OS-appropriate data directory
-//!   (via the `directories` crate).
+//! - **Global**: Bound to the user. Data lives wherever the caller says it does —
+//!   this module does not go looking. The application resolves the global data
+//!   directory (and the home boundary the walks stop at) and passes both in via
+//!   [`PadzEnv`]; the padz CLI reads `$PADZ_GLOBAL_DATA` with an OS-data-directory
+//!   fallback.
 //!
 //! ## Two Discovery Modes
 //!
@@ -25,7 +28,7 @@
 //! 1. Start at `CWD`.
 //! 2. If `current/.padz` exists → this is the project root.
 //! 3. Otherwise move to the parent directory.
-//! 4. Stop at `$HOME` or the filesystem root; return `None`.
+//! 4. Stop at the caller-supplied home boundary or the filesystem root; return `None`.
 //!
 //! If a `.padz` is found, it is used (resolving any `link` file). Otherwise the read
 //! falls back to the global store.
@@ -75,18 +78,39 @@
 
 use crate::api::{PadzApi, PadzPaths};
 use crate::config::PadzConfig;
-use crate::error::PadzError;
+use crate::error::{InitWarning, PadzError};
 use crate::model::Scope;
 use crate::store::fs::FileStore;
 use clapfig::{Clapfig, SearchMode, SearchPath};
-use directories::{BaseDirs, ProjectDirs};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
+
+/// The environment inputs initialization depends on, resolved by the caller.
+///
+/// Both fields are questions about the *user's machine* rather than about pads,
+/// so this library refuses to answer them itself: reading `$PADZ_GLOBAL_DATA`
+/// or asking the `directories` crate where a home directory lives would make
+/// every consumer inherit the CLI's idea of an environment, and would make
+/// tests fight over process-global state. The application resolves them once at
+/// its composition root (see `padz::cli::env`) and passes them in.
+#[derive(Debug, Clone)]
+pub struct PadzEnv {
+    /// Where global-scope pads live. The CLI resolves this from
+    /// `$PADZ_GLOBAL_DATA`, falling back to the OS data directory.
+    pub global_data_dir: PathBuf,
+    /// The user's home directory, used only as the stopping point for the
+    /// upward `.padz`/`.git` walks. `None` means "walk to the filesystem root".
+    pub home_dir: Option<PathBuf>,
+}
 
 pub struct PadzContext {
     pub api: PadzApi<FileStore>,
     pub scope: Scope,
     pub config: PadzConfig,
+    /// Non-fatal conditions raised during initialization (e.g. a legacy layout
+    /// that could not be migrated). Initialization succeeded regardless; it is
+    /// the application's call whether and how to show these to the user.
+    pub warnings: Vec<InitWarning>,
 }
 
 /// Materialize the padz store layout (`active/`, `archived/`, `deleted/`) at
@@ -107,9 +131,12 @@ pub fn create_bucket_layout(padz_dir: &Path) -> std::io::Result<()> {
 /// existing store, regardless of whether the enclosing directory is a git repo.
 /// `.padz` must be a directory; a stray regular file with that name is ignored
 /// so it cannot masquerade as a store and trip later I/O.
-/// Stops at `$HOME` or the filesystem root and returns `None`.
-pub fn find_padz_root(cwd: &Path) -> Option<PathBuf> {
-    walk_up_matching(cwd, |dir| dir.join(".padz").is_dir())
+///
+/// The walk stops at `home_dir` (exclusive) or the filesystem root, returning
+/// `None`. Pass `None` for `home_dir` to walk all the way to the root; the CLI
+/// passes the real home directory (see [`PadzEnv::home_dir`]).
+pub fn find_padz_root(cwd: &Path, home_dir: Option<&Path>) -> Option<PathBuf> {
+    walk_up_matching(cwd, home_dir, |dir| dir.join(".padz").is_dir())
 }
 
 /// Walk upward from `cwd` looking for a directory that contains a `.git` entry
@@ -119,19 +146,20 @@ pub fn find_padz_root(cwd: &Path) -> Option<PathBuf> {
 /// where to create a new `.padz/` when none is found upward. Accepts `.git` as
 /// either a directory (normal repo) or a regular file (git worktrees and
 /// submodules store the real gitdir elsewhere and leave a `.git` file pointer).
-/// Stops at `$HOME` or the filesystem root and returns `None`.
-pub fn find_git_root(cwd: &Path) -> Option<PathBuf> {
-    walk_up_matching(cwd, |dir| dir.join(".git").exists())
+///
+/// The walk stops at `home_dir` (exclusive) or the filesystem root, returning
+/// `None`. See [`find_padz_root`] for the `home_dir` contract.
+pub fn find_git_root(cwd: &Path, home_dir: Option<&Path>) -> Option<PathBuf> {
+    walk_up_matching(cwd, home_dir, |dir| dir.join(".git").exists())
 }
 
 /// Shared upward-walk helper. Returns the first ancestor (including `cwd`
-/// itself) for which `matches` returns true. Stops at `$HOME` or the
-/// filesystem root.
-fn walk_up_matching<F>(cwd: &Path, matches: F) -> Option<PathBuf>
+/// itself) for which `matches` returns true. Stops at `home_dir` (exclusive)
+/// or the filesystem root.
+fn walk_up_matching<F>(cwd: &Path, home_dir: Option<&Path>, matches: F) -> Option<PathBuf>
 where
     F: Fn(&Path) -> bool,
 {
-    let home_dir = BaseDirs::new().map(|bd| bd.home_dir().to_path_buf());
     let mut current = cwd.to_path_buf();
 
     loop {
@@ -139,8 +167,8 @@ where
             return Some(current);
         }
 
-        if let Some(ref home) = home_dir {
-            if &current == home {
+        if let Some(home) = home_dir {
+            if current == home {
                 return None;
             }
         }
@@ -217,6 +245,8 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 ///
 /// # Arguments
 ///
+/// * `env` - Environment-derived inputs ([`PadzEnv`]): where global pads live
+///   and where the upward walk stops. Resolved by the caller, never probed here.
 /// * `cwd` - The current working directory to start scope detection from
 /// * `use_global` - If true, forces `Scope::Global` regardless of detection
 /// * `data_override` - Optional explicit path to the data directory.
@@ -228,10 +258,12 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 ///   returning `Scope::Project`. Only write commands (`create`, `import`) should
 ///   pass `true`; reads pass `false` and fall back to global cleanly.
 ///
-/// # Environment Variables
+/// # Warnings
 ///
-/// * `PADZ_GLOBAL_DATA` - If set, overrides the default global data directory.
-///   This is primarily used for testing to isolate global state.
+/// Best-effort work that fails without stopping the command (currently only
+/// legacy-layout migration) is reported as [`InitWarning`] values on the
+/// returned [`PadzContext::warnings`]. This function writes nothing to stderr;
+/// surfacing warnings is the caller's decision.
 ///
 /// # Errors
 ///
@@ -251,38 +283,33 @@ pub fn resolve_link(padz_dir: &Path) -> crate::error::Result<Option<PathBuf>> {
 /// # Examples
 ///
 /// ```ignore
+/// // The application resolves the environment once, at its composition root.
+/// let env = PadzEnv { global_data_dir, home_dir };
+///
 /// // Read path: discover .padz upward, else global
-/// let ctx = initialize(&cwd, false, None, false)?;
+/// let ctx = initialize(&env, &cwd, false, None, false)?;
 ///
 /// // Write path: discover .padz upward; if none, auto-init at git root; else global
-/// let ctx = initialize(&cwd, false, None, true)?;
+/// let ctx = initialize(&env, &cwd, false, None, true)?;
 ///
 /// // Force global scope
-/// let ctx = initialize(&cwd, true, None, false)?;
+/// let ctx = initialize(&env, &cwd, true, None, false)?;
 ///
 /// // Use explicit data directory - path ends with .padz, used directly
-/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project/.padz")), false)?;
+/// let ctx = initialize(&env, &cwd, false, Some(PathBuf::from("/path/to/project/.padz")), false)?;
 ///
 /// // Use explicit project directory - .padz is appended
-/// let ctx = initialize(&cwd, false, Some(PathBuf::from("/path/to/project")), false)?;
+/// let ctx = initialize(&env, &cwd, false, Some(PathBuf::from("/path/to/project")), false)?;
 /// ```
 pub fn initialize(
+    env: &PadzEnv,
     cwd: &Path,
     use_global: bool,
     data_override: Option<PathBuf>,
     auto_init_for_write: bool,
 ) -> crate::error::Result<PadzContext> {
-    // Determine global data directory:
-    // 1. Check PADZ_GLOBAL_DATA environment variable (primarily for testing)
-    // 2. Fall back to OS-appropriate data directory via directories crate
-    let global_data_dir = std::env::var("PADZ_GLOBAL_DATA")
-        .ok()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let proj_dirs =
-                ProjectDirs::from("com", "padz", "padz").expect("Could not determine config dir");
-            proj_dirs.data_dir().to_path_buf()
-        });
+    let global_data_dir = env.global_data_dir.clone();
+    let home_dir = env.home_dir.as_deref();
 
     // Determine project data directory and scope:
     // 1. If use_global → Global scope, no project dir
@@ -305,7 +332,7 @@ pub fn initialize(
                 };
                 (Some(dir), Scope::Project)
             }
-            None => match find_padz_root(cwd) {
+            None => match find_padz_root(cwd, home_dir) {
                 Some(root) => {
                     let detected = root.join(".padz");
                     // Follow .padz/link if present. A broken/uninitialized/
@@ -326,7 +353,7 @@ pub fn initialize(
                     // a git root IS found but layout creation fails, surface
                     // the error — the write would otherwise silently land in
                     // Global despite the user sitting in a git repo.
-                    match find_git_root(cwd) {
+                    match find_git_root(cwd, home_dir) {
                         Some(git_root) => {
                             let new_padz = git_root.join(".padz");
                             create_bucket_layout(&new_padz).map_err(|err| {
@@ -367,21 +394,30 @@ pub fn initialize(
     crate::index::set_ordering_key(config.ordering);
     let format_ext = config.format_ext();
 
-    // Migrate legacy flat layout to bucketed layout (if needed)
+    // Migrate legacy flat layout to bucketed layout (if needed). Failures are
+    // collected rather than printed: the command still runs, and the caller
+    // decides how to tell the user.
+    let mut warnings = Vec::new();
     if let Some(ref project_dir) = project_padz_dir {
-        migrate_if_needed(project_dir);
+        warnings.extend(migrate_if_needed(project_dir));
     }
-    migrate_if_needed(&global_data_dir);
+    warnings.extend(migrate_if_needed(&global_data_dir));
 
     let store = FileStore::new_fs(project_padz_dir.clone(), global_data_dir.clone())
         .with_format(&format_ext);
     let paths = PadzPaths {
         project: project_padz_dir,
         global: global_data_dir,
+        home: env.home_dir.clone(),
     };
     let api = PadzApi::new(store, paths);
 
-    Ok(PadzContext { api, scope, config })
+    Ok(PadzContext {
+        api,
+        scope,
+        config,
+        warnings,
+    })
 }
 
 /// Migrates a legacy flat `.padz/` layout to the bucketed layout.
@@ -410,23 +446,25 @@ pub fn initialize(
 ///
 /// Detection: `data.json` exists at root AND `active/` does NOT exist.
 /// Idempotent: only runs if legacy layout detected.
-fn migrate_if_needed(scope_root: &Path) {
+///
+/// Best-effort: a failure is returned as an [`InitWarning`] for the caller to
+/// surface, not printed, and never aborts initialization — the legacy store is
+/// left untouched and stays readable.
+fn migrate_if_needed(scope_root: &Path) -> Option<InitWarning> {
     let legacy_data = scope_root.join("data.json");
     let active_dir = scope_root.join("active");
 
     // Only migrate if legacy data.json exists and active/ doesn't
     if !legacy_data.exists() || active_dir.exists() {
-        return;
+        return None;
     }
 
-    // Best-effort migration — log errors but don't crash
-    if let Err(e) = migrate_flat_to_bucketed(scope_root) {
-        eprintln!(
-            "Warning: migration of {} failed: {}",
-            scope_root.display(),
-            e
-        );
-    }
+    migrate_flat_to_bucketed(scope_root)
+        .err()
+        .map(|e| InitWarning::MigrationFailed {
+            path: scope_root.to_path_buf(),
+            error: e.to_string(),
+        })
 }
 
 fn migrate_flat_to_bucketed(scope_root: &Path) -> std::io::Result<()> {
@@ -533,6 +571,27 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    /// A [`PadzEnv`] for tests.
+    ///
+    /// Global scope points at a unique scratch path that is never created:
+    /// these tests exercise project-scope resolution, and pointing global at a
+    /// path of our own keeps them off the developer's real global store —
+    /// which the old env-reading `initialize` could otherwise touch and
+    /// migrate.
+    ///
+    /// `home_dir: None` lets the upward walk run to the filesystem root, which
+    /// is what tempdir fixtures need: they live outside `$HOME`, so a real
+    /// home boundary would never be hit anyway.
+    fn test_env() -> PadzEnv {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        PadzEnv {
+            global_data_dir: std::env::temp_dir().join(format!("padz-test-global-{n}")),
+            home_dir: None,
+        }
+    }
+
     // --- find_padz_root tests ---
 
     #[test]
@@ -543,7 +602,7 @@ mod tests {
         let root = temp.path();
         fs::create_dir(root.join(".padz")).unwrap();
 
-        let result = find_padz_root(root);
+        let result = find_padz_root(root, None);
         assert_eq!(result, Some(root.to_path_buf()));
     }
 
@@ -555,7 +614,7 @@ mod tests {
         fs::create_dir_all(&child).unwrap();
         fs::create_dir(parent.join(".padz")).unwrap();
 
-        assert_eq!(find_padz_root(&child), Some(parent.to_path_buf()));
+        assert_eq!(find_padz_root(&child, None), Some(parent.to_path_buf()));
     }
 
     #[test]
@@ -568,7 +627,7 @@ mod tests {
         fs::create_dir(outer.join(".padz")).unwrap();
         fs::create_dir(inner.join(".padz")).unwrap();
 
-        assert_eq!(find_padz_root(&inner), Some(inner));
+        assert_eq!(find_padz_root(&inner, None), Some(inner));
     }
 
     #[test]
@@ -577,7 +636,7 @@ mod tests {
         let dir = temp.path().join("a").join("b");
         fs::create_dir_all(&dir).unwrap();
 
-        assert_eq!(find_padz_root(&dir), None);
+        assert_eq!(find_padz_root(&dir, None), None);
     }
 
     // --- find_git_root tests ---
@@ -588,7 +647,7 @@ mod tests {
         let root = temp.path();
         fs::create_dir(root.join(".git")).unwrap();
 
-        assert_eq!(find_git_root(root), Some(root.to_path_buf()));
+        assert_eq!(find_git_root(root, None), Some(root.to_path_buf()));
     }
 
     #[test]
@@ -600,7 +659,7 @@ mod tests {
         fs::create_dir_all(&sub).unwrap();
         fs::create_dir(repo.join(".git")).unwrap();
 
-        assert_eq!(find_git_root(&sub), Some(repo.to_path_buf()));
+        assert_eq!(find_git_root(&sub, None), Some(repo.to_path_buf()));
     }
 
     #[test]
@@ -613,7 +672,7 @@ mod tests {
         fs::create_dir(outer.join(".git")).unwrap();
         fs::create_dir(inner.join(".git")).unwrap();
 
-        assert_eq!(find_git_root(&inner), Some(inner));
+        assert_eq!(find_git_root(&inner, None), Some(inner));
     }
 
     #[test]
@@ -622,7 +681,7 @@ mod tests {
         let dir = temp.path().join("a");
         fs::create_dir_all(&dir).unwrap();
 
-        assert_eq!(find_git_root(&dir), None);
+        assert_eq!(find_git_root(&dir, None), None);
     }
 
     #[test]
@@ -635,7 +694,7 @@ mod tests {
         let root = temp.path();
         fs::write(root.join(".padz"), "not a store").unwrap();
 
-        assert_eq!(find_padz_root(root), None);
+        assert_eq!(find_padz_root(root, None), None);
     }
 
     #[test]
@@ -652,7 +711,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(find_git_root(&worktree), Some(worktree));
+        assert_eq!(find_git_root(&worktree, None), Some(worktree));
     }
 
     #[test]
@@ -669,7 +728,7 @@ mod tests {
         let sub = repo.join("src");
         fs::create_dir_all(&sub).unwrap();
 
-        let msg = match initialize(&sub, false, None, true) {
+        let msg = match initialize(&test_env(), &sub, false, None, true) {
             Ok(_) => panic!("expected auto-init failure, got Ok"),
             Err(e) => e.to_string(),
         };
@@ -699,7 +758,7 @@ mod tests {
         )
         .unwrap();
 
-        let msg = match initialize(&project, false, None, false) {
+        let msg = match initialize(&test_env(), &project, false, None, false) {
             Ok(_) => panic!("expected broken-link error, got Ok"),
             Err(e) => e.to_string(),
         };
@@ -720,14 +779,14 @@ mod tests {
         fs::create_dir(padz_only.join(".padz")).unwrap();
         fs::create_dir(git_only.join(".git")).unwrap();
 
-        assert_eq!(find_padz_root(&padz_only), Some(padz_only.clone()));
-        assert_eq!(find_git_root(&padz_only), None);
+        assert_eq!(find_padz_root(&padz_only, None), Some(padz_only.clone()));
+        assert_eq!(find_git_root(&padz_only, None), None);
 
-        assert_eq!(find_git_root(&git_only), Some(git_only.clone()));
-        assert_eq!(find_padz_root(&git_only), None);
+        assert_eq!(find_git_root(&git_only, None), Some(git_only.clone()));
+        assert_eq!(find_padz_root(&git_only, None), None);
     }
 
-    // --- initialize() with data_override tests ---
+    // --- initialize(&test_env(), ) with data_override tests ---
 
     #[test]
     fn test_initialize_with_data_override_ending_in_padz() {
@@ -742,7 +801,7 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override ending in .padz - should use it directly
-        let ctx = initialize(repo, false, Some(override_dir.clone()), false).unwrap();
+        let ctx = initialize(&test_env(), repo, false, Some(override_dir.clone()), false).unwrap();
 
         // Verify the override path is used directly (no .padz appended)
         assert_eq!(ctx.api.paths().project, Some(override_dir));
@@ -762,7 +821,7 @@ mod tests {
         fs::create_dir_all(&override_dir).unwrap();
 
         // Initialize with override - should append .padz
-        let ctx = initialize(repo, false, Some(override_dir.clone()), false).unwrap();
+        let ctx = initialize(&test_env(), repo, false, Some(override_dir.clone()), false).unwrap();
 
         // Verify .padz was appended
         assert_eq!(ctx.api.paths().project, Some(override_dir.join(".padz")));
@@ -778,7 +837,7 @@ mod tests {
         fs::create_dir(repo.join(".padz")).unwrap();
 
         // Initialize without override - should use detected .padz
-        let ctx = initialize(repo, false, None, false).unwrap();
+        let ctx = initialize(&test_env(), repo, false, None, false).unwrap();
 
         // Verify the detected path is used
         assert_eq!(ctx.api.paths().project, Some(repo.join(".padz")));
@@ -800,7 +859,7 @@ mod tests {
         // Initialize with override AND global flag
         // Global flag wins: scope is Global, project path is None
         // Note: CLI prevents this combination (--data conflicts with -g)
-        let ctx = initialize(repo, true, Some(override_dir), false).unwrap();
+        let ctx = initialize(&test_env(), repo, true, Some(override_dir), false).unwrap();
 
         assert_eq!(ctx.api.paths().project, None);
         assert_eq!(ctx.scope, crate::model::Scope::Global);
@@ -821,7 +880,14 @@ mod tests {
         fs::create_dir_all(&workdir).unwrap();
 
         // Initialize from workdir, pointing to project's .padz
-        let ctx = initialize(&workdir, false, Some(project.join(".padz")), false).unwrap();
+        let ctx = initialize(
+            &test_env(),
+            &workdir,
+            false,
+            Some(project.join(".padz")),
+            false,
+        )
+        .unwrap();
 
         // Should use project's .padz path
         assert_eq!(ctx.api.paths().project, Some(project.join(".padz")));
@@ -839,7 +905,7 @@ mod tests {
         fs::create_dir_all(project.join(".padz").join("active")).unwrap();
         // No .git on purpose.
 
-        let ctx = initialize(&project, false, None, false).unwrap();
+        let ctx = initialize(&test_env(), &project, false, None, false).unwrap();
 
         assert_eq!(ctx.api.paths().project, Some(project.join(".padz")));
         assert_eq!(ctx.scope, Scope::Project);
@@ -857,7 +923,7 @@ mod tests {
         fs::create_dir_all(&sub).unwrap();
         fs::create_dir(repo.join(".git")).unwrap();
 
-        let ctx = initialize(&sub, false, None, true).unwrap();
+        let ctx = initialize(&test_env(), &sub, false, None, true).unwrap();
 
         assert_eq!(ctx.api.paths().project, Some(repo.join(".padz")));
         assert_eq!(ctx.scope, Scope::Project);
@@ -877,7 +943,7 @@ mod tests {
         fs::create_dir_all(&sub).unwrap();
         fs::create_dir(repo.join(".git")).unwrap();
 
-        let ctx = initialize(&sub, false, None, false).unwrap();
+        let ctx = initialize(&test_env(), &sub, false, None, false).unwrap();
 
         assert_eq!(ctx.scope, Scope::Global);
         assert_eq!(ctx.api.paths().project, None);
@@ -891,7 +957,7 @@ mod tests {
         let dir = temp.path().join("loose").join("dir");
         fs::create_dir_all(&dir).unwrap();
 
-        let ctx = initialize(&dir, false, None, true).unwrap();
+        let ctx = initialize(&test_env(), &dir, false, None, true).unwrap();
 
         assert_eq!(ctx.scope, Scope::Global);
         assert_eq!(ctx.api.paths().project, None);
@@ -909,7 +975,7 @@ mod tests {
         fs::create_dir(parent.join(".padz")).unwrap();
         fs::create_dir(child.join(".git")).unwrap();
 
-        let ctx = initialize(&child, false, None, true).unwrap();
+        let ctx = initialize(&test_env(), &child, false, None, true).unwrap();
 
         assert_eq!(ctx.api.paths().project, Some(parent.join(".padz")));
         // Child must not have had a .padz created under it.
@@ -1032,6 +1098,120 @@ mod tests {
 
         // No bucket directories should be created
         assert!(!root.join("active").exists());
+    }
+
+    /// A migration that cannot proceed reports a warning as *data* — the
+    /// library writes nothing to stderr — and leaves the legacy store alone.
+    #[test]
+    fn test_migration_failure_is_returned_as_a_warning() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join(".padz");
+        fs::create_dir_all(&root).unwrap();
+        // Unparseable legacy data: detected as a legacy layout, fails to migrate.
+        fs::write(root.join("data.json"), "{ not json").unwrap();
+
+        let warning = migrate_if_needed(&root).expect("expected a migration warning");
+        match &warning {
+            InitWarning::MigrationFailed { path, error } => {
+                assert_eq!(path, &root);
+                assert!(!error.is_empty(), "warning should say what went wrong");
+            }
+        }
+        // Rendered for humans by the CLI, and it names the store.
+        assert!(
+            warning.to_string().contains("migration of"),
+            "got: {warning}"
+        );
+        // The legacy file is untouched, so the store stays readable.
+        assert!(root.join("data.json").exists());
+    }
+
+    /// A successful migration is silent: no warning to surface.
+    #[test]
+    fn test_successful_migration_reports_no_warning() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join(".padz");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("data.json"), "{}").unwrap();
+
+        assert!(migrate_if_needed(&root).is_none());
+        assert!(root.join("active").exists());
+    }
+
+    /// `initialize` surfaces migration warnings on the context rather than
+    /// printing them, so the caller decides whether the user hears about it.
+    #[test]
+    fn test_initialize_surfaces_migration_warnings_as_data() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("proj");
+        let padz_dir = project.join(".padz");
+        fs::create_dir_all(&padz_dir).unwrap();
+        fs::write(padz_dir.join("data.json"), "{ not json").unwrap();
+
+        let ctx = initialize(&test_env(), &project, false, None, false).unwrap();
+
+        // Initialization still succeeded — the warning is advisory.
+        assert_eq!(ctx.scope, crate::model::Scope::Project);
+        assert!(
+            ctx.warnings.iter().any(|w| matches!(
+                w,
+                InitWarning::MigrationFailed { path, .. } if path == &padz_dir
+            )),
+            "expected a MigrationFailed warning for {}; got {:?}",
+            padz_dir.display(),
+            ctx.warnings
+        );
+    }
+
+    /// Global scope goes exactly where `PadzEnv` says, with no environment
+    /// consulted. Guards the boundary: if someone reintroduces a
+    /// `$PADZ_GLOBAL_DATA` read inside the library, the env var set here would
+    /// win over the explicit value and this fails.
+    #[test]
+    fn test_global_data_dir_comes_from_env_argument_only() {
+        let temp = TempDir::new().unwrap();
+        let explicit = temp.path().join("explicit-global");
+        let env = PadzEnv {
+            global_data_dir: explicit.clone(),
+            home_dir: None,
+        };
+
+        std::env::set_var("PADZ_GLOBAL_DATA", temp.path().join("decoy"));
+        let ctx = initialize(&env, temp.path(), true, None, false).unwrap();
+        std::env::remove_var("PADZ_GLOBAL_DATA");
+
+        assert_eq!(ctx.scope, crate::model::Scope::Global);
+        assert_eq!(ctx.api.paths().global, explicit);
+    }
+
+    /// The home boundary is an input too: the upward walk stops there and does
+    /// not consult the real `$HOME`.
+    #[test]
+    fn test_home_dir_argument_bounds_the_upward_walk() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let child = home.join("a").join("b");
+        fs::create_dir_all(&child).unwrap();
+        // A store ABOVE the home boundary must not be found from below it.
+        fs::create_dir_all(temp.path().join(".padz")).unwrap();
+
+        assert_eq!(find_padz_root(&child, Some(&home)), None);
+        // Without the boundary, the same walk reaches it.
+        assert_eq!(
+            find_padz_root(&child, None),
+            Some(temp.path().to_path_buf())
+        );
+    }
+
+    /// The common case: nothing to migrate, so nothing to report.
+    #[test]
+    fn test_initialize_without_migration_has_no_warnings() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("proj");
+        fs::create_dir_all(project.join(".padz").join("active")).unwrap();
+
+        let ctx = initialize(&test_env(), &project, false, None, false).unwrap();
+        assert!(ctx.warnings.is_empty(), "got: {:?}", ctx.warnings);
     }
 
     #[test]
@@ -1195,7 +1375,7 @@ mod tests {
         .unwrap();
 
         // Initialize from project-b — should follow link to project-a
-        let ctx = initialize(&project_b, false, None, false).unwrap();
+        let ctx = initialize(&test_env(), &project_b, false, None, false).unwrap();
         assert_eq!(
             ctx.api.paths().project,
             Some(project_a.canonicalize().unwrap().join(".padz"))

--- a/crates/padzapp/src/lib.rs
+++ b/crates/padzapp/src/lib.rs
@@ -6,8 +6,8 @@
 //! ## Workspace Structure
 //!
 //! Padz is organized as a Cargo workspace with two crates:
-//! - `crates/padz/` — This core library (UI-agnostic business logic)
-//! - `crates/padz-cli/` — The CLI tool (depends on this library)
+//! - `crates/padzapp/` — This core library (UI-agnostic business logic)
+//! - `crates/padz/` — The CLI tool (depends on this library)
 //!
 //! ## The Problem
 //!
@@ -19,7 +19,7 @@
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────┐
-//! │  CLI Layer (crates/padz-cli/)                               │
+//! │  CLI Layer (crates/padz/)                                   │
 //! │  - Parses arguments, formats output, handles terminal I/O   │
 //! │  - The ONLY place that knows about stdout/stderr/exit codes │
 //! └─────────────────────────────────────────────────────────────┘
@@ -44,7 +44,7 @@
 //! ┌─────────────────────────────────────────────────────────────┐
 //! │  Storage Layer (store/)                                     │
 //! │  - Abstract DataStore trait                                 │
-//! │  - FileStore (production), InMemoryStore (testing)          │
+//! │  - FileStore (production), MemBackend-backed (testing)      │
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 //!
@@ -99,13 +99,29 @@
 //! - [`index`]: Display indexing system (p1, 1, d1 notation)
 //! - [`init`]: Scope detection and context initialization
 //! - [`config`]: Configuration management
-//! - [`editor`]: External editor integration
-//! - [`clipboard`]: Cross-platform clipboard support
+//! - [`editor`]: The editor *buffer format* — parsing and rendering only
 //! - [`error`]: Error types
+//!
+//! # What lives outside this library
+//!
+//! `padzapp` is terminal-agnostic: it never writes to stdout/stderr, emits no
+//! ANSI styling, launches no subprocesses, and reads no environment variables.
+//! Those are properties of an *application*, not of the domain, and they live
+//! in the `padz` CLI crate instead:
+//!
+//! - Editor **selection and launching** (`padz::cli::editor`) — this crate owns
+//!   only the buffer format ([`editor::EditorContent`]).
+//! - Clipboard reads/writes (`padz::cli::clipboard`).
+//! - Terminal styling of errors, notably the structured
+//!   [`error::PadzError::AmbiguousTitle`] (`padz::cli::errors`).
+//! - Environment and platform-directory discovery: the CLI resolves them and
+//!   passes explicit values in via [`init::PadzEnv`].
+//!
+//! Filesystem persistence deliberately stays here — files are the source of
+//! truth, and [`store`] owns them.
 
 pub mod api;
 pub mod attributes;
-pub mod clipboard;
 pub mod commands;
 pub mod config;
 pub mod editor;

--- a/crates/padzapp/tests/title_referencing.rs
+++ b/crates/padzapp/tests/title_referencing.rs
@@ -1,16 +1,9 @@
 use padzapp::api::PadzApi;
 use padzapp::commands::{NestingMode, PadzPaths};
+use padzapp::error::PadzError;
 use padzapp::model::Scope;
 use padzapp::store::bucketed::BucketedStore;
 use padzapp::store::mem_backend::MemBackend;
-
-/// Strip ANSI styling so substring assertions are stable across TTY/non-TTY
-/// test environments — the ambiguity error highlights the matched substring
-/// inside each title, so a literal `contains("Groceries")` check would fail
-/// when colors are enabled.
-fn strip_ansi(s: &str) -> String {
-    console::strip_ansi_codes(s).to_string()
-}
 
 fn setup() -> PadzApi<BucketedStore<MemBackend>> {
     let store = BucketedStore::new(
@@ -22,6 +15,7 @@ fn setup() -> PadzApi<BucketedStore<MemBackend>> {
     let paths = PadzPaths {
         project: Some(std::path::PathBuf::from(".padz")),
         global: std::path::PathBuf::from(".padz"),
+        home: None,
     };
     let mut api = PadzApi::new(store, paths);
 
@@ -114,12 +108,24 @@ fn test_referencing_ambiguous() {
     let api = setup();
     // "Gro" matches "Groceries" and "Grocery List"
     let res = api.view_pads(Scope::Project, &["Gro"], NestingMode::Flat);
-    assert!(res.is_err());
-    let err = strip_ansi(&res.err().unwrap().to_string());
-    assert!(err.contains("matches multiple pads"));
-    // The error should list the matching pads so the user can pick one.
-    assert!(err.contains("Groceries"));
-    assert!(err.contains("Grocery List"));
+    // The error carries the matches as structured data so a presenter can
+    // offer them; no ANSI-stripping is needed because the library emits none.
+    match res.unwrap_err() {
+        PadzError::AmbiguousTitle {
+            term, candidates, ..
+        } => {
+            assert_eq!(term, "Gro");
+            let titles: Vec<&str> = candidates.iter().map(|c| c.title.as_str()).collect();
+            assert!(titles.contains(&"Groceries"), "got: {titles:?}");
+            assert!(titles.contains(&"Grocery List"), "got: {titles:?}");
+            // Each candidate names the index the user would type to pick it.
+            assert!(
+                candidates.iter().all(|c| !c.index.is_empty()),
+                "got: {candidates:?}"
+            );
+        }
+        other => panic!("expected AmbiguousTitle; got {other}"),
+    }
 }
 
 #[test]
@@ -154,6 +160,7 @@ fn test_referencing_does_not_match_deleted_titles() {
     let paths = PadzPaths {
         project: Some(std::path::PathBuf::from(".padz")),
         global: std::path::PathBuf::from(".padz"),
+        home: None,
     };
     let mut api = PadzApi::new(store, paths);
 

--- a/docs/architecture_cli_logic_split.txt
+++ b/docs/architecture_cli_logic_split.txt
@@ -11,31 +11,59 @@ This makes the program unwieldy and notoriously hard to test. So you forgo unit 
 Padz enforces a strict separation of the User Interface (CLI) from the Application Logic (API/Commands).
 
 The project is structured as a Cargo workspace with two crates:
-- `crates/padz/` — The core library (UI-agnostic business logic)
-- `crates/padz-cli/` — The CLI tool (depends on `padz` library)
+- `crates/padzapp/` — The core library (UI-agnostic business logic)
+- `crates/padz/` — The CLI tool (depends on the `padzapp` library)
+
+### 0. The Rule: what the library may not do
+
+`padzapp` is terminal-agnostic, and this is enforced, not merely intended:
+
+-   **No output**: it never writes to stdout/stderr. Non-fatal conditions come
+    back as data (e.g. `init::PadzContext::warnings`) for the caller to surface.
+-   **No styling**: it emits no ANSI. Errors that deserve a rich presentation
+    carry *structured data* — `PadzError::AmbiguousTitle` lists its matches as
+    `AmbiguityCandidate { index, title }` — and `crates/padz/src/cli/errors.rs`
+    styles them.
+-   **No subprocesses**: no editors, clipboard tools, or shells. Those are
+    CLI-owned adapters (`cli/editor.rs`, `cli/clipboard.rs`). The library keeps
+    only the *format*: `editor::EditorContent` parses and renders the buffer.
+-   **No environment or platform discovery**: it reads no env vars and asks no
+    OS crate where user directories live. `cli/env.rs` resolves those once at
+    the composition root and passes explicit values in via `init::PadzEnv`.
+
+Filesystem persistence deliberately *stays* in the library: files are the source
+of truth and `store/` owns them. This is a boundary rule about the user's
+terminal and environment, not about I/O in general.
+
+The payoff is testability. Because the library takes its environment as an
+argument, a test can hand it a tempdir instead of racing on process-global env
+vars, and can assert on an error's *fields* instead of grepping styled text.
 
 ### 1. The CLI Layer (The "Skin")
--   **Location**: `crates/padz-cli/src/cli/`
--   **Entry Point**: `crates/padz-cli/src/cli/commands.rs` — function `run`
+-   **Location**: `crates/padz/src/cli/`
+-   **Entry Point**: `crates/padz/src/cli/commands.rs` — function `run`
 -   **Responsibility**:
     -   Translates `argv` into Rust types (via `clap`).
-    -   Initializes the `AppContext` (API, scope, config).
+    -   Resolves the environment (`cli/env.rs`) and initializes the app state
+        (API, scope, config).
     -   Calls the API.
-    -   Renders the `CmdResult` to stdout using `crates/padz-cli/src/cli/render.rs`.
+    -   Renders results to stdout (`crates/padz/src/cli/render.rs`) and errors
+        to stderr (`crates/padz/src/cli/errors.rs`).
+    -   Owns every user-environment adapter: editor, clipboard, warnings.
 -   **Constraint**: *Never* makes decisions about business state. It only asks the API to do things.
 
 ### 2. The API Layer (The "Facade")
--   **Location**: `crates/padz/src/api.rs`
+-   **Location**: `crates/padzapp/src/api/`
 -   **Key Struct**: `PadzApi<S: DataStore>`
 -   **Responsibility**:
     -   **The Boundary**: Where the edges meet the core.
     -   **Translation**: Converts user-facing concepts (Display Indexes like `1-3`) into internal concepts (UUIDs).
     -   **Dispatch**: Routes requests to the appropriate command module.
     -   **Isolation**: Returns `Result<CmdResult>`, a data structure describing what happened, *not* a string to print.
--   **Generic Over Storage**: `PadzApi<FileStore>` in production, `PadzApi<InMemoryStore>` in tests.
+-   **Generic Over Storage**: `PadzApi<FileStore>` in production, `PadzApi<BucketedStore<MemBackend>>` in tests.
 
 ### 3. The Command Layer (The "Brain")
--   **Location**: `crates/padz/src/commands/*.rs`
+-   **Location**: `crates/padzapp/src/commands/*.rs`
 -   **Responsibility**:
     -   Pure business logic.
     -   Validates state (e.g., "Does this pad exist?", "Is it pinned?").
@@ -43,11 +71,12 @@ The project is structured as a Cargo workspace with two crates:
 -   **Testing**: Unit tested heavily with in-memory stores. No I/O dependencies.
 
 ### 4. The Store Layer (The "Memory")
--   **Location**: `crates/padz/src/store/`
--   **Trait**: `DataStore` (defined in `crates/padz/src/store/mod.rs`)
+-   **Location**: `crates/padzapp/src/store/`
+-   **Trait**: `DataStore` (defined in `crates/padzapp/src/store/mod.rs`), over a
+    `StorageBackend` (`store/backend.rs`) that says where the bytes live.
 -   **Implementations**:
-    -   `FileStore`: Production filesystem storage
-    -   `InMemoryStore`: Test-only in-memory storage
+    -   `FileStore` (= `BucketedStore<FsBackend>`): production filesystem storage
+    -   `BucketedStore<MemBackend>`: test-only in-memory storage
 
 ## Data Flow Example: `padz delete 1`
 


### PR DESCRIPTION
`padzapp` was already free of Clap and Standout, but it was not free of the
*terminal*: it styled selector errors with ANSI, wrote migration warnings to
stderr, launched editors and clipboard tools, and discovered its own
environment. This moves each of those to the CLI boundary and leaves the
domain, persistence, and structured error data in the library.

for #194

## What moved

| Concern | Before | After |
|---|---|---|
| Selector ambiguity | ANSI baked into `PadzError::Api` string | `PadzError::AmbiguousTitle { term, total, candidates }` + `cli::errors` styles it |
| Editor | `padzapp::editor::{get_editor, open_in_editor}` | `cli::editor`; library keeps only `EditorContent` (the buffer format) |
| Clipboard | `padzapp::clipboard` | `cli::clipboard` |
| Env / platform dirs | `$PADZ_GLOBAL_DATA` + `ProjectDirs`/`BaseDirs` read inside `initialize` | `cli::env::resolve()` → explicit `init::PadzEnv` |
| Migration warning | `eprintln!` in the library | `InitWarning` data on `PadzContext::warnings`; CLI prints it |

`padzapp` no longer depends on **`console`** or **`directories`** — the
compiler now enforces the boundary rather than a review catching a regression.
Filesystem persistence stays in the library (`PadStore`, `StorageBackend`,
reconciliation, atomic writes untouched).

## Context

**Why this shape.** Two decisions worth flagging:

- *`PadzEnv` as a parameter, not a trait.* Behavior doesn't vary by
  implementation here — there is exactly one way to find a home directory —
  so a single-adapter indirection would be hypothetical. The env is data, so
  it's passed as data. `PadzPaths` gained `home` for the same reason: the
  transfer path walks upward and needs the same boundary.
- *`EditorEnv` with an injected `is_on_path` fn.* Editor *selection* genuinely
  varies, and testing it via `$EDITOR` would mean mutating process-global state
  under a parallel runner. `select_editor` is now a pure function; `open_with`
  is split from `open_in_editor` so the spawn/exit-code handling is testable
  against a real child process without a TTY.

**The subtle part — where presentation actually happens.** Standout carries a
dispatch failure as `RunResult::Error(String)`, and handlers stringify
`PadzError` into `anyhow` before that. So an error is flattened to text at the
*handler boundary*, long before `main` sees it. The ANSI used to survive only
because the library baked it into the string. Removing the styling without
accounting for this would have silently dropped the color entirely — I hit
exactly that, caught it by running the binary, and fixed it by rendering in
`cli::errors::to_anyhow`, which every handler now routes through. `main.rs`
also renders, for errors that bypass dispatch (init/config/completion).

**Verified against a pre-refactor binary**, not just tests: ambiguity (styled
under `CLICOLOR_FORCE=1` and plain when piped), under- and over-threshold
listings, project/global scope, explicit `--data`, `clone --to` incl. the
upward-walk and error cases, and migration warnings. All byte-identical except
one intentional delta (below).

### Intentional user-visible delta

The ambiguity error loses **one redundant `Api Error:` prefix**:

```
before: Error: Api Error: Api Error: Term "Meeting" matches multiple pads...
after:  Error: Api Error: Term "Meeting" matches multiple pads...
```

The doubling came from a library `PadzError::Api` being stringified and
re-wrapped in `PadzError::Api`. `AmbiguousTitle` is its own variant, so it's
wrapped once. Every other error keeps its exact previous text, doubling
included — I did not "fix" the general double-prefix, as that's a pre-existing
wart outside this WS's remit. **Flagging it as worth its own issue.**

### Findings surfaced (not fixed here)

- **`get_from_clipboard` was dead code** across the whole workspace — the `pub`
  library boundary was hiding it. Now in a binary crate, the compiler flagged
  it, so I deleted it rather than ship a warning or an `allow`. **But**
  `cli/mod.rs` documents clipboard-as-input ("`padz create` … pre-fills editor
  with clipboard content") — a *documented product behavior that has never been
  wired up*. I left that doc alone rather than silently rewrite a product
  claim; if WS05 (input chains) implements it, the read half is one `git show`
  away.
- `docs/architecture_cli_logic_split.txt` and the `main.rs`/`lib.rs` doc blocks
  still used the **pre-rename crate names** (`crates/padz-cli/`, library at
  `crates/padz/`) and a non-existent `InMemoryStore`. Since that doc is the
  canonical statement of the exact boundary this WS enforces, I corrected the
  names and added the rule it now documents.

### Out of scope — do not "fix"

- WS05 input chains, WS06 test migration, WS07 presentation/CSS.
- The general `Api Error:` double-prefix (see above).
- Storage: this is a CLI-boundary cleanup, not a store rewrite.

## Verification

- `pixi run lint` — OK (12 checks)
- `pixi run test` — **748 passed** (727 baseline + 21 new), 1 skipped
  (`copy_round_trips_through_the_system_clipboard`, `#[ignore]`d as it needs a
  real desktop clipboard).
- Mandated scan (`rg` for stdout/stderr, env, subprocess, ANSI, clipboard/editor
  over `crates/padzapp/src`): **6 matches, all justified** — a commented-out
  `println!` in `todos.rs`, two doc/test comments, and three in `#[cfg(test)]`
  code (including a guard test that sets a decoy `$PADZ_GLOBAL_DATA` to prove
  the library ignores it). Zero in production library code.

Self-checked against the epic's governing docs (#190, WS01–WS03 #198–#200,
`codebase-design`/`DEEPENING`, `padz-datastore-persistence`).

## Shepherd brief — round 1

Own PR #201 for issue #194. Resolve all three open review threads with fix-or-push-back, then resolve each thread and sweep the diff for the same bug class:

1. Make the documented `walk_up_matching` home boundary contract and implementation agree. Preserve the intended rule that discovery must not auto-match at `$HOME`; add boundary coverage.
2. Remove the Unicode panic risk in ambiguity highlighting. Match and style without using lowercased-string byte offsets to slice the original UTF-8 title; cover length-changing and boundary-sensitive Unicode.
3. Replace unsynchronized process-global env mutation in the test with a parallel-safe proof or guarded restoration that survives panic; sweep for comparable env-mutating tests introduced by this PR.

Keep the WS04 boundary intact: `padzapp` owns domain/persistence and structured data; the binary owns env discovery, terminal presentation, editor/clipboard/subprocess behavior. Do not pull WS05–WS07 or the general `Api Error:` cleanup into this round.

Verify with `pixi run lint`, `pixi run test`, and the PR's mandated `rg` scan of `crates/padzapp/src`.