### PR TITLE
PADZ-STD01-WS05: Epic: Complete Standout adoption - Workstream: Make input and cross-cutting CLI behavior declarative

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -27,7 +27,6 @@ use padzapp::error::Result;
 use padzapp::init::initialize;
 use standout::cli::{App, RunResult};
 use standout::{embed_styles, embed_templates};
-use std::io::IsTerminal;
 
 pub fn run() -> Result<()> {
     // parse_cli() uses standout's App which handles
@@ -51,15 +50,14 @@ pub fn run() -> Result<()> {
     // Initialize app state for handlers
     let app_state = create_app_state(&cli)?;
 
-    // Determine effective args: handle naked invocation by injecting synthetic command
+    // Determine effective args: handle naked invocation by injecting synthetic command.
+    // Which command a bare `padz` means is decided by `cli::input::naked_command`
+    // (see its docs for why standout's `default_command` cannot express it).
     let args: Vec<String> = if cli.command.is_none() {
-        // Naked padz: list if interactive, create if piped
-        let synthetic_cmd = if !std::io::stdin().is_terminal() {
-            "create"
-        } else {
-            "list"
-        };
-        vec!["padz".to_string(), synthetic_cmd.to_string()]
+        vec![
+            "padz".to_string(),
+            super::input::naked_command_from_process().to_string(),
+        ]
     } else {
         std::env::args().collect()
     };

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -16,16 +16,16 @@
 
 use crate::cli::clipboard::{copy_to_clipboard, format_for_clipboard};
 use crate::cli::errors::to_anyhow;
+use crate::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
 use padzapp::commands::{CmdResult, NestingMode};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
 use padzapp::model::{extract_title_and_body, Scope};
 use padzapp::store::fs::FileStore;
-use standout::cli::{CommandContext, Output};
+use standout::cli::{CommandContext, CommandContextInput, Output};
 use standout_macros::handler;
 use std::cell::RefCell;
-use std::io::IsTerminal;
 
 use super::result::{
     ListRequest, MessagesResult, ModificationRequest, ModificationResult, PadContent,
@@ -578,25 +578,14 @@ fn indent_lines(text: &str, prefix: &str) -> String {
         .join("\n")
 }
 
-/// Try to read content from piped stdin.
-/// Returns None if stdin is a terminal (interactive), Some if piped.
-fn try_read_stdin() -> Result<Option<String>, anyhow::Error> {
-    use std::io::Read;
-    if std::io::stdin().is_terminal() {
-        return Ok(None);
-    }
-    let mut content = String::new();
-    std::io::stdin()
-        .read_to_string(&mut content)
-        .map_err(|e| anyhow::anyhow!("Failed to read stdin: {}", e))?;
-    Ok(Some(content.trim().to_string()))
-}
-
 /// Split a list of args into index selectors and trailing content words.
 ///
 /// Index patterns are: digits, pN, dN, N.N, N-N, pN-pN etc.
 /// Once an arg fails to parse as an index, everything from that point is content.
-fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<String>) {
+///
+/// Shared with [`crate::cli::input`], whose edit source decides whether the
+/// trailing words make a quick-edit and so must split them the same way.
+pub(crate) fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<String>) {
     use padzapp::index::parse_index_or_range;
 
     let mut indexes = Vec::new();
@@ -627,16 +616,22 @@ fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<String>) {
 // Core commands
 // =============================================================================
 
+/// Create a pad.
+///
+/// Where the text comes from — args, piped stdin, or the editor — is *not*
+/// decided here: `cli::input`'s chain resolves it before dispatch and this
+/// handler matches on the resulting [`RequestContent`]. The `editor` /
+/// `no_editor` flags are part of that chain's availability rules, so they are
+/// not read here either.
 #[handler]
 pub fn create(
     #[ctx] ctx: &CommandContext,
-    #[flag] editor: bool,
-    #[flag(name = "no_editor")] no_editor: bool,
     #[arg] inside: Option<String>,
     #[arg] format: Option<String>,
     #[arg] title: Vec<String>,
 ) -> Result<Output<ModificationResult>, anyhow::Error> {
     let state = get_state(ctx);
+    let content = ctx.input::<RequestContent>(CREATE_CONTENT)?;
     let title_arg = if title.is_empty() {
         None
     } else {
@@ -664,86 +659,90 @@ pub fn create(
         })
     }
 
-    // --editor forces interactive editor; --no-editor forces skip;
-    // default: todos mode with title args skips editor
-    let skip_editor =
-        !editor && (no_editor || (state.mode == PadzMode::Todos && title_arg.is_some()));
-
-    let result = if skip_editor {
-        // Quick-create: use args directly, no editor
-        let raw_text = title_arg.unwrap_or_default();
-        // Convert literal \n sequences to real newlines
-        let expanded = raw_text.replace("\\n", "\n");
-        let (title, body) =
-            extract_title_and_body(&expanded).unwrap_or_else(|| (String::new(), String::new()));
-        let result = do_create(state, title.clone(), body.clone(), inside, format_ref)?;
-        // Propagate status now — content is non-empty, safe from reconciliation
-        let parent_id = result.affected_pads[0].pad.metadata.parent_id;
-        state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
-        // Copy to clipboard
-        let clipboard_text = format_for_clipboard(&title, &body);
-        let _ = copy_to_clipboard(&clipboard_text);
-        result
-    } else if let Some(raw) = try_read_stdin()? {
-        // Piped content from stdin
-        if raw.is_empty() {
-            return Ok(Output::Render(aborted_create()));
-        }
-        let parsed = padzapp::editor::EditorContent::from_buffer(&raw);
-        // Determine title: title_arg override > parsed title > empty
-        let final_title = match (&title_arg, parsed.title.is_empty()) {
-            (Some(t), _) => t.clone(),  // CLI title always wins
-            (_, false) => parsed.title, // parsed has title, no CLI override
-            (None, true) => String::new(),
-        };
-        let result = do_create(state, final_title, parsed.content, inside, format_ref)?;
-        // Propagate status now — content is non-empty, safe from reconciliation
-        let parent_id = result.affected_pads[0].pad.metadata.parent_id;
-        state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
-        // Copy to clipboard
-        copy_content_to_clipboard(&raw);
-        result
-    } else {
-        // Interactive: create pad first, then open real file in editor
-        let initial_title = title_arg.clone().unwrap_or_default();
-        let create_result = do_create(state, initial_title, String::new(), inside, format_ref)?;
-        let pad_path = create_result.pad_paths[0].clone();
-        let pad_id = create_result.affected_pads[0].pad.metadata.id;
-
-        // Open editor on the real pad file in .padz/
-        if let Err(e) = crate::cli::editor::open_in_editor(&pad_path) {
-            // Editor failed - clean up the pad
-            let _ = state.with_api(|api| api.remove_pad(state.scope, pad_id));
-            return Err(to_anyhow(e));
+    let result = match content {
+        // Quick-create: args used directly, no editor. The chain already joined
+        // the args and expanded literal `\n`.
+        RequestContent::Direct(expanded) => {
+            let (title, body) =
+                extract_title_and_body(expanded).unwrap_or_else(|| (String::new(), String::new()));
+            let result = do_create(state, title.clone(), body.clone(), inside, format_ref)?;
+            // Propagate status now — content is non-empty, safe from reconciliation
+            let parent_id = result.affected_pads[0].pad.metadata.parent_id;
+            state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
+            // Copy to clipboard
+            let clipboard_text = format_for_clipboard(&title, &body);
+            let _ = copy_to_clipboard(&clipboard_text);
+            result
         }
 
-        // Refresh pad from disk (re-reads content, updates title)
-        match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
-            Some(pad) => {
-                // Propagate status now — pad has real content after editor,
-                // safe from reconciliation deleting the empty file.
-                let parent_id = pad.metadata.parent_id;
-                state.with_api(|api| {
-                    api.propagate_status(state.scope, parent_id)
-                        .map_err(to_anyhow)
-                })?;
-                // Copy to clipboard
-                copy_content_to_clipboard(&pad.content);
-                // Build result
-                let display_pad = padzapp::index::DisplayPad {
-                    pad,
-                    index: padzapp::index::DisplayIndex::Regular(1),
-                    matches: None,
-                    children: Vec::new(),
-                };
-                CmdResult {
-                    affected_pads: vec![display_pad],
-                    ..Default::default()
-                }
+        // Piped content from stdin.
+        RequestContent::Piped(raw) => {
+            let parsed = padzapp::editor::EditorContent::from_buffer(raw);
+            // Determine title: title_arg override > parsed title > empty
+            let final_title = match (&title_arg, parsed.title.is_empty()) {
+                (Some(t), _) => t.clone(),  // CLI title always wins
+                (_, false) => parsed.title, // parsed has title, no CLI override
+                (None, true) => String::new(),
+            };
+            let result = do_create(state, final_title, parsed.content, inside, format_ref)?;
+            // Propagate status now — content is non-empty, safe from reconciliation
+            let parent_id = result.affected_pads[0].pad.metadata.parent_id;
+            state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
+            // Copy to clipboard
+            copy_content_to_clipboard(raw);
+            result
+        }
+
+        // An empty pipe is an abort: no pad, no editor.
+        RequestContent::PipedEmpty => return Ok(Output::Render(aborted_create())),
+
+        // Interactive: create pad first, then open real file in editor.
+        //
+        // This arm is why the chain stops at a decision rather than resolving a
+        // string through standout's `EditorSource`: the editor runs against the
+        // pad's real file in `.padz/`, and a failed launch must delete the pad
+        // that was created to hold it.
+        RequestContent::Editor => {
+            let initial_title = title_arg.clone().unwrap_or_default();
+            let create_result = do_create(state, initial_title, String::new(), inside, format_ref)?;
+            let pad_path = create_result.pad_paths[0].clone();
+            let pad_id = create_result.affected_pads[0].pad.metadata.id;
+
+            // Open editor on the real pad file in .padz/
+            if let Err(e) = crate::cli::editor::open_in_editor(&pad_path) {
+                // Editor failed - clean up the pad
+                let _ = state.with_api(|api| api.remove_pad(state.scope, pad_id));
+                return Err(to_anyhow(e));
             }
-            None => {
-                // Empty file - user aborted
-                return Ok(Output::Render(aborted_create()));
+
+            // Refresh pad from disk (re-reads content, updates title)
+            match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
+                Some(pad) => {
+                    // Propagate status now — pad has real content after editor,
+                    // safe from reconciliation deleting the empty file.
+                    let parent_id = pad.metadata.parent_id;
+                    state.with_api(|api| {
+                        api.propagate_status(state.scope, parent_id)
+                            .map_err(to_anyhow)
+                    })?;
+                    // Copy to clipboard
+                    copy_content_to_clipboard(&pad.content);
+                    // Build result
+                    let display_pad = padzapp::index::DisplayPad {
+                        pad,
+                        index: padzapp::index::DisplayIndex::Regular(1),
+                        matches: None,
+                        children: Vec::new(),
+                    };
+                    CmdResult {
+                        affected_pads: vec![display_pad],
+                        ..Default::default()
+                    }
+                }
+                None => {
+                    // Empty file - user aborted
+                    return Ok(Output::Render(aborted_create()));
+                }
             }
         }
     };
@@ -902,62 +901,62 @@ pub fn copy(
     api(ctx).copy_pads(&indexes, nesting)
 }
 
+/// Edit a pad.
+///
+/// Like [`create`], the content source is resolved before dispatch by
+/// `cli::input`'s chain; this handler only splits the index selectors out of
+/// the positional args and acts on the resolved decision.
 #[handler]
 pub fn edit(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
 ) -> Result<Output<ModificationResult>, anyhow::Error> {
     let state = get_state(ctx);
+    let content = ctx.input::<RequestContent>(EDIT_CONTENT)?;
 
     // Split args into index selectors and trailing content words.
     // Index patterns: digits, pN, dN, N.N, N-N, pN-pN, etc.
-    let (index_args, content_words) = split_indexes_and_content(&indexes);
+    // Only the selectors matter here; the trailing words already reached the
+    // input chain, which decided whether they are a quick-edit.
+    let (index_args, _) = split_indexes_and_content(&indexes);
 
     if index_args.is_empty() {
         return Err(anyhow::anyhow!("No pad index provided"));
     }
 
-    // In todos mode, trailing content words become a quick-edit (skip editor)
-    let inline_content = if !content_words.is_empty() {
-        let raw_text = content_words.join(" ");
-        let expanded = raw_text.replace("\\n", "\n");
-        Some(expanded)
-    } else {
-        None
+    // Writes `raw` to every selected pad.
+    let update = |raw: &str| -> Result<CmdResult, anyhow::Error> {
+        state.with_api(|api| {
+            api.update_pads_from_content(state.scope, &index_args, raw)
+                .map_err(to_anyhow)
+        })
     };
 
-    let skip_editor = state.mode == PadzMode::Todos && inline_content.is_some();
-
-    if skip_editor {
-        let raw = inline_content.unwrap();
-        let result = state.with_api(|api| {
-            api.update_pads_from_content(state.scope, &index_args, &raw)
-                .map_err(to_anyhow)
-        })?;
-
-        let clipboard_text = raw.clone();
-        let _ = copy_to_clipboard(&clipboard_text);
-
-        return Ok(Output::Render(
-            api(ctx).modification_result("Updated", result, false),
-        ));
-    }
-
-    // Check for piped stdin
-    if let Some(raw) = try_read_stdin()? {
-        if raw.is_empty() {
-            return Err(anyhow::anyhow!("Aborted: empty content"));
+    match content {
+        // Quick-edit (todos mode, inline words): the raw text is copied as typed.
+        RequestContent::Direct(raw) => {
+            let result = update(raw)?;
+            let _ = copy_to_clipboard(raw);
+            return Ok(Output::Render(
+                api(ctx).modification_result("Updated", result, false),
+            ));
         }
-        let result = state.with_api(|api| {
-            api.update_pads_from_content(state.scope, &index_args, &raw)
-                .map_err(to_anyhow)
-        })?;
 
-        copy_content_to_clipboard(&raw);
+        // Piped content is copied in the pad's title/body shape.
+        RequestContent::Piped(raw) => {
+            let result = update(raw)?;
+            copy_content_to_clipboard(raw);
+            return Ok(Output::Render(
+                api(ctx).modification_result("Updated", result, false),
+            ));
+        }
 
-        return Ok(Output::Render(
-            api(ctx).modification_result("Updated", result, false),
-        ));
+        // An empty pipe aborts the edit outright — unlike create, which reports
+        // the abort as a warning, this has always been an error.
+        RequestContent::PipedEmpty => return Err(anyhow::anyhow!("Aborted: empty content")),
+
+        // Fall through to the interactive editor below.
+        RequestContent::Editor => {}
     }
 
     // Interactive editor: open real pad file

--- a/crates/padz/src/cli/input.rs
+++ b/crates/padz/src/cli/input.rs
@@ -1,0 +1,640 @@
+//! Request-scoped input resolution for `create`/`edit`, and naked invocation.
+//!
+//! # Why this module exists
+//!
+//! Deciding *where a pad's text comes from* is a shell concern, not a domain
+//! one: it depends on flags, on whether stdin is a pipe, and on whether a
+//! terminal is attached. That decision used to live inside the `create` and
+//! `edit` handlers, which read stdin and probed `is_terminal()` directly. It
+//! now happens here, before dispatch, and the handlers receive one resolved,
+//! typed [`RequestContent`] telling them what to do.
+//!
+//! The precedence itself is expressed as a Standout [`InputChain`]: each source
+//! declares when it is available, the chain tries them in order, and the
+//! `.default(...)` arm is the editor. Reading the chain is reading the policy.
+//!
+//! # The precedence (unchanged from before this module existed)
+//!
+//! For `create`:
+//!
+//! 1. **Direct** — the title args, used verbatim with the editor skipped. Only
+//!    when `--no-editor` is set, or todos mode was given title args, and never
+//!    when `--editor` forces the editor. **Stdin is not read at all on this
+//!    path**, even when something is piped.
+//! 2. **Piped** — non-empty piped stdin.
+//! 3. **PipedEmpty** — stdin was piped but empty; the user aborted.
+//! 4. **Editor** — nothing else offered content, so open the editor.
+//!
+//! For `edit` the same shape holds; only the Direct rule differs (todos mode
+//! with trailing content words after the index selectors).
+//!
+//! # What is deliberately *not* a Standout primitive here
+//!
+//! - **`StdinSource`**: the framework source returns `None` for empty piped
+//!   input, which in a chain means "fall through to the next source". Padz
+//!   must *abort* on an empty pipe instead — falling through would silently
+//!   open an editor where padz used to abort. So [`PipedSource`] reuses the
+//!   framework's [`StdinReader`] seam (and therefore its test overrides) but
+//!   owns the empty-input semantics, surfacing them as
+//!   [`RequestContent::PipedEmpty`] rather than swallowing them.
+//! - **`EditorSource`**: the framework source edits a scratch buffer and hands
+//!   back a string. Padz creates the pad first and opens the editor on the real
+//!   file in `.padz/`, then refreshes from disk — and on failure deletes the
+//!   half-created pad. Those are pad-lifecycle concerns the handler must own,
+//!   so the chain resolves to [`RequestContent::Editor`] and stops there; it
+//!   does not try to launch anything.
+//! - **`ClipboardSource`**: padz does not, and did not, read the clipboard as a
+//!   create/edit input source. See [`naked_command`]'s sibling note in
+//!   `cli::mod` docs — the clipboard is written to after a pad is saved, never
+//!   read from to prefill one.
+//! - **`App::default_command`**: it names one static command, but padz's naked
+//!   invocation picks between two depending on whether stdin is piped. See
+//!   [`naked_command`].
+
+use clap::ArgMatches;
+use padzapp::config::PadzMode;
+use standout::cli::{get_deepest_matches, CommandContext, HookError};
+use standout::input::env::{DefaultStdin, StdinReader};
+use standout::input::{InputChain, InputCollector, InputError, Inputs};
+use std::sync::Arc;
+
+// `split_indexes_and_content` is the handlers' own arg-splitting rule; the edit
+// source must apply the same one to know whether trailing words are content.
+use super::handlers::{split_indexes_and_content, AppState};
+
+/// The name the `create` content input is registered and looked up under.
+pub const CREATE_CONTENT: &str = "create_content";
+
+/// The name the `edit` content input is registered and looked up under.
+pub const EDIT_CONTENT: &str = "edit_content";
+
+/// Where a create/edit request's text comes from, resolved before dispatch.
+///
+/// This is the whole of what the handlers learn about the shell: they match on
+/// it instead of probing stdin themselves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestContent {
+    /// Text taken verbatim from the command line; the editor is skipped.
+    ///
+    /// Carries the args already joined and with literal `\n` expanded, exactly
+    /// as the quick-create/quick-edit paths always did.
+    Direct(String),
+    /// Non-empty text read from piped stdin (trimmed).
+    Piped(String),
+    /// Stdin was piped but held nothing but whitespace — the user aborted.
+    ///
+    /// Distinct from [`RequestContent::Editor`] on purpose: an empty pipe is an
+    /// abort, not an invitation to open an editor on a non-interactive stdin.
+    PipedEmpty,
+    /// No non-interactive source offered text; open the editor on the pad file.
+    Editor,
+}
+
+// =============================================================================
+// Sources
+// =============================================================================
+
+/// The `create` quick-path source: title args used verbatim, editor skipped.
+///
+/// Availability mirrors the original `skip_editor` rule exactly:
+/// `!--editor && (--no-editor || (todos mode && title args present))`.
+struct CreateDirectSource {
+    mode: PadzMode,
+}
+
+impl InputCollector<RequestContent> for CreateDirectSource {
+    // "argument" (not "args"): `InputChain::try_source` maps the *name string*
+    // to an `InputSourceKind`, and anything it does not recognize silently
+    // becomes `Default`. This spelling is what reports the value as `Arg`.
+    fn name(&self) -> &'static str {
+        "argument"
+    }
+
+    fn is_available(&self, matches: &ArgMatches) -> bool {
+        let editor = flag(matches, "editor");
+        let no_editor = flag(matches, "no_editor");
+        let has_title = !title_args(matches).is_empty();
+        !editor && (no_editor || (self.mode == PadzMode::Todos && has_title))
+    }
+
+    fn collect(&self, matches: &ArgMatches) -> Result<Option<RequestContent>, InputError> {
+        let raw = title_args(matches).join(" ");
+        Ok(Some(RequestContent::Direct(expand_newlines(&raw))))
+    }
+}
+
+/// The `edit` quick-path source: trailing content words in todos mode.
+///
+/// `edit`'s positional args mix index selectors and content words, so
+/// availability depends on the same split the handler uses for the selectors.
+struct EditDirectSource {
+    mode: PadzMode,
+}
+
+impl EditDirectSource {
+    /// The trailing content words, when todos mode makes them a quick-edit.
+    fn inline_content(&self, matches: &ArgMatches) -> Option<String> {
+        if self.mode != PadzMode::Todos {
+            return None;
+        }
+        let (_, content_words) = split_indexes_and_content(&index_args(matches));
+        if content_words.is_empty() {
+            return None;
+        }
+        Some(expand_newlines(&content_words.join(" ")))
+    }
+}
+
+impl InputCollector<RequestContent> for EditDirectSource {
+    // See `CreateDirectSource::name` — the string is the kind mapping.
+    fn name(&self) -> &'static str {
+        "argument"
+    }
+
+    fn is_available(&self, matches: &ArgMatches) -> bool {
+        self.inline_content(matches).is_some()
+    }
+
+    fn collect(&self, matches: &ArgMatches) -> Result<Option<RequestContent>, InputError> {
+        Ok(self.inline_content(matches).map(RequestContent::Direct))
+    }
+}
+
+/// Piped stdin, with padz's abort-on-empty semantics.
+///
+/// Reuses the framework's [`StdinReader`] abstraction — so
+/// `standout::input::env::set_default_stdin_reader` overrides work here just as
+/// they do for the framework's own source — but deliberately does **not** reuse
+/// `StdinSource`, whose empty-input `None` would let the chain fall through to
+/// the editor. Here an empty pipe resolves to [`RequestContent::PipedEmpty`],
+/// which the handlers turn into the same abort they always produced.
+struct PipedSource {
+    reader: Arc<dyn StdinReader>,
+}
+
+impl PipedSource {
+    /// Reads the process's real stdin, honoring any installed test override.
+    fn from_process() -> Self {
+        Self {
+            reader: Arc::new(DefaultStdin),
+        }
+    }
+
+    /// Reads from an injected reader. Used by tests to drive both the piped and
+    /// terminal cases without a pty and without touching the real stdin.
+    #[cfg(test)]
+    fn with_reader(reader: impl StdinReader + 'static) -> Self {
+        Self {
+            reader: Arc::new(reader),
+        }
+    }
+}
+
+impl InputCollector<RequestContent> for PipedSource {
+    fn name(&self) -> &'static str {
+        "stdin"
+    }
+
+    fn is_available(&self, _matches: &ArgMatches) -> bool {
+        // A terminal stdin is not a source of content; it means "open the editor".
+        !self.reader.is_terminal()
+    }
+
+    fn collect(&self, _matches: &ArgMatches) -> Result<Option<RequestContent>, InputError> {
+        if self.reader.is_terminal() {
+            return Ok(None);
+        }
+        let raw = self
+            .reader
+            .read_to_string()
+            .map_err(InputError::StdinFailed)?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            // Never `None`: falling through to the editor would silently
+            // replace padz's abort-on-empty-pipe behavior.
+            return Ok(Some(RequestContent::PipedEmpty));
+        }
+        Ok(Some(RequestContent::Piped(trimmed.to_string())))
+    }
+}
+
+// =============================================================================
+// Chains
+// =============================================================================
+
+/// The `create` content chain: direct args, then piped stdin, then the editor.
+fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
+    InputChain::new()
+        .try_source(CreateDirectSource { mode })
+        .try_source(PipedSource::from_process())
+        .default(RequestContent::Editor)
+}
+
+/// The `edit` content chain: inline todos content, then piped stdin, then the editor.
+fn edit_chain(mode: PadzMode) -> InputChain<RequestContent> {
+    InputChain::new()
+        .try_source(EditDirectSource { mode })
+        .try_source(PipedSource::from_process())
+        .default(RequestContent::Editor)
+}
+
+// =============================================================================
+// Pre-dispatch hooks
+// =============================================================================
+
+/// Resolves `create`'s content before dispatch. Wired via `#[dispatch(pre_dispatch = ...)]`.
+///
+/// This is what `GroupBuilder::input` does internally; padz spells it out
+/// because its command table is built by the `Dispatch` derive, which exposes
+/// `pre_dispatch` but not `input`. The chain needs the configured [`PadzMode`],
+/// which only exists on app state, so it is built here rather than at app-build
+/// time.
+pub fn resolve_create_content(
+    matches: &ArgMatches,
+    ctx: &mut CommandContext,
+) -> Result<(), HookError> {
+    let mode = mode_of(ctx)?;
+    insert_input(ctx, matches, CREATE_CONTENT, create_chain(mode))
+}
+
+/// Resolves `edit`'s content before dispatch (also used by `open`, which shares
+/// `edit`'s handler).
+pub fn resolve_edit_content(
+    matches: &ArgMatches,
+    ctx: &mut CommandContext,
+) -> Result<(), HookError> {
+    let mode = mode_of(ctx)?;
+    insert_input(ctx, matches, EDIT_CONTENT, edit_chain(mode))
+}
+
+/// Resolves `chain` against the deepest subcommand's matches and files the
+/// result in the request's [`Inputs`] bag under `name`.
+///
+/// Pre-dispatch hooks are handed the top-level matches, but the sources read
+/// args declared on the subcommand — the same matches the handler sees.
+fn insert_input(
+    ctx: &mut CommandContext,
+    matches: &ArgMatches,
+    name: &'static str,
+    chain: InputChain<RequestContent>,
+) -> Result<(), HookError> {
+    let resolved = chain
+        .resolve_with_source(get_deepest_matches(matches))
+        .map_err(|e| HookError::pre_dispatch(format!("input `{}`: {}", name, e)))?;
+
+    if !ctx.extensions.contains::<Inputs>() {
+        ctx.extensions.insert(Inputs::new());
+    }
+    ctx.extensions
+        .get_mut::<Inputs>()
+        .expect("Inputs just inserted")
+        .insert(name, resolved);
+    Ok(())
+}
+
+/// The configured pad mode, read from durable app state.
+fn mode_of(ctx: &CommandContext) -> Result<PadzMode, HookError> {
+    ctx.app_state
+        .get::<AppState>()
+        .map(|s| s.mode)
+        .ok_or_else(|| HookError::pre_dispatch("AppState not initialized in app_state"))
+}
+
+// =============================================================================
+// Naked invocation
+// =============================================================================
+
+/// Which command a naked `padz` stands for: `create` when stdin is piped,
+/// `list` otherwise.
+///
+/// # Why this is not `App::default_command`
+///
+/// Standout 7.6 has a declarative default command, but it names exactly one
+/// static command (`insert_default_command` splices that literal into argv).
+/// Padz's rule is *conditional* — the whole point is that `cat notes | padz`
+/// captures while a bare `padz` reads — and 7.6 offers no predicate hook for
+/// that. Standout's default also only fires inside `App::run`, and padz drives
+/// `parse_from` + `dispatch` so it can build app state and resolve the output
+/// mode first, so the setting would not apply on that path regardless.
+///
+/// So this stays application-owned, but it is a pure function of a
+/// [`StdinReader`] rather than an inline `is_terminal()` probe, which is what
+/// makes both arms testable without a pty.
+pub fn naked_command(reader: &dyn StdinReader) -> &'static str {
+    if reader.is_terminal() {
+        "list"
+    } else {
+        "create"
+    }
+}
+
+/// [`naked_command`] against the process's real stdin (honoring test overrides).
+pub fn naked_command_from_process() -> &'static str {
+    naked_command(&DefaultStdin)
+}
+
+// =============================================================================
+// ArgMatches helpers
+// =============================================================================
+
+fn flag(matches: &ArgMatches, name: &str) -> bool {
+    matches.try_get_one::<bool>(name).ok().flatten() == Some(&true)
+}
+
+fn title_args(matches: &ArgMatches) -> Vec<String> {
+    many(matches, "title")
+}
+
+fn index_args(matches: &ArgMatches) -> Vec<String> {
+    many(matches, "indexes")
+}
+
+fn many(matches: &ArgMatches, name: &str) -> Vec<String> {
+    matches
+        .try_get_many::<String>(name)
+        .ok()
+        .flatten()
+        .map(|vals| vals.cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Turns the literal two-character sequence `\n` into a real newline.
+///
+/// Shells make it awkward to put a real newline in an argument, so padz has
+/// always accepted `padz create 'Title\nBody'` on the quick paths.
+fn expand_newlines(raw: &str) -> String {
+    raw.replace("\\n", "\n")
+}
+
+/// Resolves `chain`, returning the value and the source kind that produced it,
+/// so tests can assert on provenance as well as the value.
+#[cfg(test)]
+fn resolve_for_test(
+    chain: InputChain<RequestContent>,
+    matches: &ArgMatches,
+) -> (RequestContent, standout::input::InputSourceKind) {
+    let r = chain.resolve_with_source(matches).expect("chain resolves");
+    (r.value, r.source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use standout::input::env::MockStdin;
+    use standout::input::InputSourceKind;
+
+    /// Builds `create`'s clap matches the way the real command parses them.
+    fn create_matches(args: &[&str]) -> ArgMatches {
+        clap::Command::new("create")
+            .arg(
+                clap::Arg::new("editor")
+                    .long("editor")
+                    .short('e')
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("no_editor")
+                    .long("no-editor")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("title")
+                    .num_args(0..)
+                    .trailing_var_arg(true)
+                    .action(clap::ArgAction::Append),
+            )
+            .try_get_matches_from(std::iter::once("create").chain(args.iter().copied()))
+            .expect("test args parse")
+    }
+
+    fn edit_matches(args: &[&str]) -> ArgMatches {
+        clap::Command::new("edit")
+            .arg(
+                clap::Arg::new("indexes")
+                    .num_args(1..)
+                    .action(clap::ArgAction::Append),
+            )
+            .try_get_matches_from(std::iter::once("edit").chain(args.iter().copied()))
+            .expect("test args parse")
+    }
+
+    /// A create chain with an injected stdin, so no test needs a pty.
+    fn create_chain_with(mode: PadzMode, stdin: MockStdin) -> InputChain<RequestContent> {
+        InputChain::new()
+            .try_source(CreateDirectSource { mode })
+            .try_source(PipedSource::with_reader(stdin))
+            .default(RequestContent::Editor)
+    }
+
+    fn edit_chain_with(mode: PadzMode, stdin: MockStdin) -> InputChain<RequestContent> {
+        InputChain::new()
+            .try_source(EditDirectSource { mode })
+            .try_source(PipedSource::with_reader(stdin))
+            .default(RequestContent::Editor)
+    }
+
+    // --- create: the direct/quick path ---
+
+    /// `--no-editor` takes the args verbatim — and does not read stdin, even
+    /// though something is piped. This is the precedence, pinned.
+    #[test]
+    fn no_editor_wins_over_piped_stdin() {
+        let (value, source) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::piped("IGNORED")),
+            &create_matches(&["--no-editor", "ArgTitle"]),
+        );
+        assert_eq!(value, RequestContent::Direct("ArgTitle".into()));
+        assert_eq!(source, InputSourceKind::Arg);
+    }
+
+    /// Todos mode with title args skips the editor; notes mode does not.
+    #[test]
+    fn todos_mode_with_title_takes_the_direct_path() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Todos, MockStdin::terminal()),
+            &create_matches(&["Buy", "milk"]),
+        );
+        assert_eq!(value, RequestContent::Direct("Buy milk".into()));
+    }
+
+    #[test]
+    fn notes_mode_with_title_still_opens_the_editor() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::terminal()),
+            &create_matches(&["A", "note"]),
+        );
+        assert_eq!(value, RequestContent::Editor);
+    }
+
+    /// Todos mode without title args has nothing to quick-create from.
+    #[test]
+    fn todos_mode_without_title_opens_the_editor() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Todos, MockStdin::terminal()),
+            &create_matches(&[]),
+        );
+        assert_eq!(value, RequestContent::Editor);
+    }
+
+    /// `--editor` forces the editor even in todos mode with title args.
+    #[test]
+    fn editor_flag_defeats_the_direct_path() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Todos, MockStdin::terminal()),
+            &create_matches(&["--editor", "Buy", "milk"]),
+        );
+        assert_eq!(value, RequestContent::Editor);
+    }
+
+    /// Literal `\n` in an arg becomes a real newline on the direct path.
+    #[test]
+    fn direct_path_expands_literal_newlines() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::terminal()),
+            &create_matches(&["--no-editor", r"Title\nBody line"]),
+        );
+        assert_eq!(value, RequestContent::Direct("Title\nBody line".into()));
+    }
+
+    /// `--no-editor` with no title at all still takes the direct path, with
+    /// empty text — which is how padz has always produced an empty pad here.
+    #[test]
+    fn no_editor_without_title_is_direct_and_empty() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::piped("IGNORED")),
+            &create_matches(&["--no-editor"]),
+        );
+        assert_eq!(value, RequestContent::Direct(String::new()));
+    }
+
+    // --- create: stdin ---
+
+    #[test]
+    fn piped_stdin_is_used_when_no_direct_source() {
+        let (value, source) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::piped("  Piped body  ")),
+            &create_matches(&[]),
+        );
+        assert_eq!(value, RequestContent::Piped("Piped body".into()));
+        assert_eq!(source, InputSourceKind::Stdin);
+    }
+
+    /// The regression this module's `PipedSource` exists for: an empty pipe is
+    /// an abort, never a fall-through to the editor.
+    #[test]
+    fn empty_pipe_aborts_rather_than_opening_the_editor() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::piped_empty()),
+            &create_matches(&[]),
+        );
+        assert_eq!(value, RequestContent::PipedEmpty);
+    }
+
+    /// Whitespace-only is empty too — the old code trimmed before testing.
+    #[test]
+    fn whitespace_only_pipe_aborts() {
+        let (value, _) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::piped("   \n  \n")),
+            &create_matches(&[]),
+        );
+        assert_eq!(value, RequestContent::PipedEmpty);
+    }
+
+    /// A terminal stdin means "no piped content": open the editor.
+    #[test]
+    fn terminal_stdin_falls_through_to_the_editor() {
+        let (value, source) = resolve_for_test(
+            create_chain_with(PadzMode::Notes, MockStdin::terminal()),
+            &create_matches(&[]),
+        );
+        assert_eq!(value, RequestContent::Editor);
+        assert_eq!(source, InputSourceKind::Default);
+    }
+
+    // --- edit ---
+
+    #[test]
+    fn todos_edit_with_trailing_words_is_direct() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Todos, MockStdin::terminal()),
+            &edit_matches(&["1", "Edited", "text"]),
+        );
+        assert_eq!(value, RequestContent::Direct("Edited text".into()));
+    }
+
+    #[test]
+    fn todos_edit_expands_literal_newlines() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Todos, MockStdin::terminal()),
+            &edit_matches(&["1", r"Edited\nBody"]),
+        );
+        assert_eq!(value, RequestContent::Direct("Edited\nBody".into()));
+    }
+
+    /// Notes mode never quick-edits, even with trailing words.
+    #[test]
+    fn notes_edit_with_trailing_words_opens_the_editor() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Notes, MockStdin::terminal()),
+            &edit_matches(&["1", "Edited", "text"]),
+        );
+        assert_eq!(value, RequestContent::Editor);
+    }
+
+    /// Index-only args are not content, so there is nothing to quick-edit from.
+    #[test]
+    fn todos_edit_with_only_indexes_opens_the_editor() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Todos, MockStdin::terminal()),
+            &edit_matches(&["1", "2"]),
+        );
+        assert_eq!(value, RequestContent::Editor);
+    }
+
+    #[test]
+    fn edit_reads_piped_stdin() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Notes, MockStdin::piped("New body")),
+            &edit_matches(&["1"]),
+        );
+        assert_eq!(value, RequestContent::Piped("New body".into()));
+    }
+
+    #[test]
+    fn edit_empty_pipe_aborts() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Notes, MockStdin::piped_empty()),
+            &edit_matches(&["1"]),
+        );
+        assert_eq!(value, RequestContent::PipedEmpty);
+    }
+
+    /// Todos inline content beats a pipe, mirroring create's direct path.
+    #[test]
+    fn todos_edit_inline_content_wins_over_stdin() {
+        let (value, _) = resolve_for_test(
+            edit_chain_with(PadzMode::Todos, MockStdin::piped("PIPED")),
+            &edit_matches(&["1", "Inline"]),
+        );
+        assert_eq!(value, RequestContent::Direct("Inline".into()));
+    }
+
+    // --- naked invocation ---
+
+    #[test]
+    fn naked_padz_lists_on_a_terminal() {
+        assert_eq!(naked_command(&MockStdin::terminal()), "list");
+    }
+
+    #[test]
+    fn naked_padz_creates_when_piped() {
+        assert_eq!(naked_command(&MockStdin::piped("captured")), "create");
+    }
+
+    /// An empty pipe is still a pipe: naked padz routes to `create`, which then
+    /// aborts on the empty content rather than listing.
+    #[test]
+    fn naked_padz_creates_even_when_the_pipe_is_empty() {
+        assert_eq!(naked_command(&MockStdin::piped_empty()), "create");
+    }
+}

--- a/crates/padz/src/cli/mod.rs
+++ b/crates/padz/src/cli/mod.rs
@@ -21,22 +21,32 @@
 //!
 //! ### Smart Create (`padz create`)
 //!
-//! Priority order for content source:
+//! Priority order for content source — declared as an input chain in
+//! [`input`], resolved before dispatch, and handed to the handler as one typed
+//! [`input::RequestContent`]:
 //!
-//! 1. **Piped Input** (highest priority)
+//! 1. **Title Argument, used directly** (highest priority)
+//!    - `padz create --no-editor "Meeting Notes"`, or todos mode with a title.
+//!    - Uses the args verbatim. **Skips editor, and does not read stdin** —
+//!      even if something is piped.
+//!
+//! 2. **Piped Input**
 //!    - `echo "foo" | padz create`
-//!    - Creates pad with piped content. **Skips editor**.
+//!    - Creates pad with piped content. **Skips editor**. A piped-but-empty
+//!      stdin aborts the create; it does not fall through to the editor.
 //!
-//! 2. **Clipboard** (fallback when no pipe and no title arg)
-//!    - `padz create` (with something in clipboard)
-//!    - Pre-fills editor with clipboard content. **Opens editor**.
-//!
-//! 3. **Title Argument**
-//!    - `padz create "Meeting Notes"`
-//!    - Uses argument as title. Opens editor for body.
+//! 3. **Editor** (when nothing above applies)
+//!    - `padz create "Meeting Notes"` on a terminal.
+//!    - Uses the argument as title and opens the editor for the body.
 //!
 //! After saving from editor, pad content is automatically copied to clipboard.
 //! Use `--no-editor` flag to skip opening the editor.
+//!
+//! **The clipboard is not an input source.** Padz writes pad text *to* the
+//! clipboard after a pad is saved or viewed; it never reads the clipboard to
+//! pre-fill one. Earlier revisions of this doc described a "clipboard fallback"
+//! that pre-filled the editor — that path was never wired, and the claim is
+//! recorded here only to keep it from being reintroduced as new behavior.
 //!
 //! ### View Copies to Clipboard
 //!
@@ -54,6 +64,7 @@
 //! ## Module Structure
 //!
 //! - `commands`: App construction, state wiring, and dispatch
+//! - `input`: Declarative request-input precedence (create/edit) + naked invocation
 //! - `handlers`: Thin typed adapters — extract args, call the API, return a typed result
 //! - `result`: The typed, mode-independent result each handler returns
 //! - `render`: Render-time view derivation for standout's templates
@@ -66,6 +77,7 @@ pub mod editor;
 pub mod env;
 pub mod errors;
 pub mod handlers;
+pub mod input;
 pub mod render;
 pub mod result;
 pub mod setup;

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -324,8 +324,15 @@ fn render_custom_help() -> String {
 pub enum Commands {
     // --- Core commands ---
     /// Create a new pad
+    ///
+    /// The content source (args / piped stdin / editor) is resolved before
+    /// dispatch by `cli::input`'s chain; the handler receives the decision.
     #[command(alias = "n", display_order = 1)]
-    #[dispatch(pure, template = "modification_result")]
+    #[dispatch(
+        pure,
+        template = "modification_result",
+        pre_dispatch = crate::cli::input::resolve_create_content
+    )]
     Create {
         /// Force opening the editor (even in todos mode)
         #[arg(long, short = 'e', conflicts_with = "no_editor")]
@@ -507,7 +514,11 @@ pub enum Commands {
 
     /// Edit a pad in the editor
     #[command(alias = "e", display_order = 11, hide = true)]
-    #[dispatch(pure, template = "modification_result")]
+    #[dispatch(
+        pure,
+        template = "modification_result",
+        pre_dispatch = crate::cli::input::resolve_edit_content
+    )]
     Edit {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = active_pads_completer())]
@@ -515,8 +526,16 @@ pub enum Commands {
     },
 
     /// Open a pad in the editor (alias for edit)
+    ///
+    /// Shares `edit`'s handler, and therefore needs `edit`'s input chain: the
+    /// handler reads its content decision from the same named input.
     #[command(alias = "o", display_order = 12)]
-    #[dispatch(pure, handler = handlers::edit__handler, template = "modification_result")]
+    #[dispatch(
+        pure,
+        handler = handlers::edit__handler,
+        template = "modification_result",
+        pre_dispatch = crate::cli::input::resolve_edit_content
+    )]
     Open {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]

--- a/crates/padz/tests/input_precedence_e2e.rs
+++ b/crates/padz/tests/input_precedence_e2e.rs
@@ -1,0 +1,400 @@
+//! # Request-input precedence for `create` / `edit`, and naked invocation
+//!
+//! These tests pin *where a pad's text comes from*: title args, piped stdin, or
+//! the editor — and in which order those win. The rules moved out of the
+//! handlers and into `cli::input`'s declarative chain; this suite exists to
+//! prove that move changed nothing a user can observe.
+//!
+//! ## How these tests reach each case
+//!
+//! Every assertion here runs the real binary, so stdin is a real file
+//! descriptor. Two consequences shape the suite:
+//!
+//! - **`.output()` gives the child a null stdin**, which is *not* a terminal.
+//!   Padz therefore treats a plain `padz create` in a test exactly like an
+//!   empty pipe — an abort. Tests that want piped content use `write_stdin`;
+//!   tests that want the empty-pipe abort simply pass nothing.
+//! - **The editor path needs a terminal stdin**, which a spawned process
+//!   without a pty cannot have. So the editor arm is *not* reachable here, and
+//!   is covered where it can be driven deterministically: the chain's unit
+//!   tests in `cli::input`, which inject a `MockStdin::terminal()` reader.
+//!
+//! That split is deliberate. These tests own the piped/arg precedence through
+//! the real binary; the unit tests own the terminal/editor arm through a
+//! controlled reader. Neither depends on the developer's editor or clipboard.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+/// The built `padz` binary under test.
+///
+/// The macro form, not the `cargo::cargo_bin(name)` function: the function is
+/// deprecated because it breaks under a custom cargo build-dir.
+fn padz_bin() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin!("padz").to_path_buf()
+}
+
+/// A project with an isolated store, so tests never touch the developer's pads.
+struct Fixture {
+    _temp: TempDir,
+    project: std::path::PathBuf,
+    global: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let global = temp.path().join("global");
+        fs::create_dir_all(&project).unwrap();
+        fs::create_dir_all(&global).unwrap();
+        // Marks the project root for padz's store discovery.
+        fs::create_dir(project.join(".git")).unwrap();
+
+        let fixture = Self {
+            _temp: temp,
+            project,
+            global,
+        };
+        fixture.run(&["init"]);
+        fixture
+    }
+
+    fn cmd(&self) -> Command {
+        let mut cmd = Command::new(padz_bin());
+        cmd.env("PADZ_GLOBAL_DATA", self.global.as_os_str())
+            // The editor must never actually launch from a test. If a change
+            // ever routes one of these cases to the editor arm, this makes it
+            // fail loudly instead of hanging or opening the developer's vim.
+            .env("EDITOR", "/bin/false")
+            .current_dir(&self.project);
+        cmd
+    }
+
+    /// Runs padz, asserting success, and returns stdout.
+    fn run(&self, args: &[&str]) -> String {
+        let out = self.cmd().args(args).output().unwrap();
+        assert!(
+            out.status.success(),
+            "padz {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    }
+
+    /// Runs padz with `stdin` piped in.
+    fn run_piped(&self, args: &[&str], stdin: &str) -> String {
+        let out = self
+            .cmd()
+            .args(args)
+            .write_stdin(stdin.to_string())
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "padz {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    }
+
+    fn try_run_piped(&self, args: &[&str], stdin: &str) -> std::process::Output {
+        self.cmd()
+            .args(args)
+            .write_stdin(stdin.to_string())
+            .output()
+            .unwrap()
+    }
+
+    fn set_mode(&self, mode: &str) {
+        self.run(&["config", "set", "mode", mode]);
+    }
+
+    /// The (title, content) of every pad the command reports, in order.
+    ///
+    /// `--output json` must precede any title text: `title` is a
+    /// `trailing_var_arg`, so anything after it is captured as title words.
+    fn pads(json: &str) -> Vec<(String, String)> {
+        let v: serde_json::Value =
+            serde_json::from_str(json).unwrap_or_else(|e| panic!("not JSON: {e}\n{json}"));
+        v["pads"]
+            .as_array()
+            .expect("pads array")
+            .iter()
+            .map(|p| {
+                (
+                    p["pad"]["metadata"]["title"].as_str().unwrap().to_string(),
+                    p["pad"]["content"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn messages(json: &str) -> Vec<String> {
+        let v: serde_json::Value = serde_json::from_str(json).unwrap();
+        v["messages"]
+            .as_array()
+            .map(|ms| {
+                ms.iter()
+                    .map(|m| m["content"].as_str().unwrap_or_default().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// create: the direct/arg path outranks stdin
+// ---------------------------------------------------------------------------
+
+/// The precedence's sharpest edge: `--no-editor` uses the args and does **not**
+/// read stdin, even with content piped in. Piped text is dropped on this path.
+#[test]
+fn no_editor_uses_args_and_ignores_piped_stdin() {
+    let f = Fixture::new();
+    let out = f.run_piped(
+        &["create", "--output", "json", "--no-editor", "ArgTitle"],
+        "PIPED_CONTENT_IS_IGNORED",
+    );
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("ArgTitle".into(), "ArgTitle".into())]
+    );
+}
+
+/// `--no-editor` with no title args creates an empty pad — still ignoring stdin.
+#[test]
+fn no_editor_without_title_creates_an_empty_pad() {
+    let f = Fixture::new();
+    let out = f.run_piped(&["create", "--output", "json", "--no-editor"], "IGNORED");
+    assert_eq!(Fixture::pads(&out), vec![(String::new(), String::new())]);
+}
+
+/// Literal `\n` in an argument becomes a real newline, splitting title from body.
+#[test]
+fn direct_path_expands_literal_newlines() {
+    let f = Fixture::new();
+    let out = f.run(&[
+        "create",
+        "--output",
+        "json",
+        "--no-editor",
+        r"Title\nBody line",
+    ]);
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("Title".into(), "Title\n\nBody line".into())]
+    );
+}
+
+/// Todos mode with title args takes the direct path (editor skipped), so the
+/// piped text is ignored exactly as with `--no-editor`.
+#[test]
+fn todos_mode_with_title_skips_editor_and_ignores_stdin() {
+    let f = Fixture::new();
+    f.set_mode("todos");
+    let out = f.run_piped(&["create", "--output", "json", "Todo Item"], "IGNORED");
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("Todo Item".into(), "Todo Item".into())]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// create: stdin
+// ---------------------------------------------------------------------------
+
+/// Piped stdin with no competing arg source: title and body come from the pipe.
+#[test]
+fn piped_stdin_supplies_title_and_body() {
+    let f = Fixture::new();
+    let out = f.run_piped(
+        &["create", "--output", "json"],
+        "Piped Title\n\nPiped body.",
+    );
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("Piped Title".into(), "Piped Title\n\nPiped body.".into())]
+    );
+}
+
+/// A title arg overrides the piped buffer's title, keeping the piped body.
+#[test]
+fn title_arg_overrides_the_piped_title() {
+    let f = Fixture::new();
+    let out = f.run_piped(
+        &["create", "--output", "json", "ArgWins"],
+        "StdinTitle\n\nStdinBody",
+    );
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("ArgWins".into(), "ArgWins\n\nStdinBody".into())]
+    );
+}
+
+/// An empty pipe aborts the create: a warning, and no pad in the store.
+///
+/// This is the case that makes padz's stdin handling application-owned —
+/// standout's own `StdinSource` reports empty input as "no input", which in a
+/// chain would fall through to the next source (here, the editor).
+#[test]
+fn empty_pipe_aborts_and_creates_no_pad() {
+    let f = Fixture::new();
+    let out = f.run_piped(&["create", "--output", "json"], "");
+
+    assert_eq!(Fixture::pads(&out), vec![]);
+    assert!(
+        Fixture::messages(&out)
+            .iter()
+            .any(|m| m.contains("Aborted: empty content")),
+        "expected an abort warning, got: {out}"
+    );
+
+    let listed = f.run_piped(&["list", "--output", "json"], "");
+    assert_eq!(Fixture::pads(&listed), vec![], "the store must stay empty");
+}
+
+/// Whitespace-only input is empty too — padz trims before deciding.
+#[test]
+fn whitespace_only_pipe_aborts() {
+    let f = Fixture::new();
+    let out = f.run_piped(&["create", "--output", "json"], "   \n  \n");
+    assert_eq!(Fixture::pads(&out), vec![]);
+    assert!(Fixture::messages(&out)
+        .iter()
+        .any(|m| m.contains("Aborted: empty content")));
+}
+
+/// Nested creation: the piped path still honors `--inside`.
+#[test]
+fn piped_create_nests_under_inside() {
+    let f = Fixture::new();
+    f.run(&["create", "--output", "json", "--no-editor", "Parent"]);
+    let out = f.run_piped(
+        &["create", "--output", "json", "--inside", "1"],
+        "ChildTitle\n\nChildBody",
+    );
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let parent = &v["pads"][0]["pad"]["metadata"]["parent_id"];
+    assert!(
+        parent.is_string(),
+        "child pad should carry a parent_id, got: {parent}"
+    );
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("ChildTitle".into(), "ChildTitle\n\nChildBody".into())]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// edit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn edit_takes_content_from_piped_stdin() {
+    let f = Fixture::new();
+    f.run(&["create", "--output", "json", "--no-editor", "Orig"]);
+    let out = f.run_piped(&["edit", "--output", "json", "1"], "NewTitle\n\nNewBody");
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("NewTitle".into(), "NewTitle\n\nNewBody".into())]
+    );
+}
+
+/// An empty pipe aborts an edit — and unlike create's warning, this is an error.
+#[test]
+fn edit_with_empty_pipe_errors() {
+    let f = Fixture::new();
+    f.run(&["create", "--output", "json", "--no-editor", "Orig"]);
+    let out = f.try_run_piped(&["edit", "--output", "json", "1"], "");
+
+    assert!(!out.status.success(), "an empty pipe must fail the edit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Aborted: empty content"),
+        "got stderr: {stderr}"
+    );
+
+    // The pad is untouched.
+    let listed = f.run_piped(&["list", "--output", "json"], "");
+    assert_eq!(Fixture::pads(&listed)[0].0, "Orig");
+}
+
+/// Todos mode: trailing words after the index are a quick-edit, beating stdin.
+///
+/// The words join into one line with no blank-line separator, so the whole
+/// thing is the title and the piped text never lands — same shape as the
+/// quick-create path.
+#[test]
+fn todos_edit_uses_inline_words_over_stdin() {
+    let f = Fixture::new();
+    f.set_mode("todos");
+    f.run(&["create", "--output", "json", "T1"]);
+    let out = f.run_piped(
+        &["edit", "--output", "json", "1", "Edited", "text"],
+        "PIPED",
+    );
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("Edited text".into(), "Edited text".into())]
+    );
+}
+
+/// The quick-edit path expands literal `\n` just like quick-create.
+#[test]
+fn todos_edit_expands_literal_newlines() {
+    let f = Fixture::new();
+    f.set_mode("todos");
+    f.run(&["create", "--output", "json", "T1"]);
+    let out = f.run(&["edit", "--output", "json", "1", r"Edited\nBody"]);
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("Edited".into(), "Edited\n\nBody".into())]
+    );
+}
+
+/// `open` shares `edit`'s handler, so it must resolve the same input. Without
+/// its own chain registration the handler's input lookup would fail outright.
+#[test]
+fn open_shares_edits_input_resolution() {
+    let f = Fixture::new();
+    f.run(&["create", "--output", "json", "--no-editor", "Orig"]);
+    let out = f.run_piped(&["open", "--output", "json", "1"], "ViaOpen\n\nBody");
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("ViaOpen".into(), "ViaOpen\n\nBody".into())]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// naked invocation
+// ---------------------------------------------------------------------------
+
+/// `cat file | padz` captures the pipe as a new pad.
+#[test]
+fn naked_padz_with_a_pipe_creates() {
+    let f = Fixture::new();
+    let out = f.run_piped(&["--output", "json"], "Captured\n\nFrom a pipe");
+    assert_eq!(
+        Fixture::pads(&out),
+        vec![("Captured".into(), "Captured\n\nFrom a pipe".into())]
+    );
+}
+
+/// A naked invocation whose pipe is empty routes to `create`, which then aborts.
+/// It must not silently fall back to listing.
+#[test]
+fn naked_padz_with_an_empty_pipe_aborts_the_create() {
+    let f = Fixture::new();
+    let out = f.run_piped(&["--output", "json"], "");
+    assert!(
+        Fixture::messages(&out)
+            .iter()
+            .any(|m| m.contains("Aborted: empty content")),
+        "expected the create abort, got: {out}"
+    );
+}

--- a/docs/cli_behavior.txt
+++ b/docs/cli_behavior.txt
@@ -4,42 +4,62 @@
 
 Standard CLIs are "dumb". They do exactly what they are told, often requiring verbose flags for common actions:
 -   Creating a note from clipboard requires `pbpaste | padz create`.
+    (Padz still expects that pipe — see the clipboard note under "The Solution".)
 -   Creating a quick note requires `padz create -m "Title"`.
 -   Just running `padz` shows help instead of the useful list.
 
 ## The Solution: Context-Aware Intelligence
 
-Padz infers intent from the context of execution (Arguments, Stdin, Clipboard).
+Padz infers intent from the context of execution (Arguments, Stdin).
+
+The clipboard is **not** part of that inference: padz writes pad text *to* the
+clipboard (see §3), but never reads it to decide what a pad should contain.
 
 ### 1. Naked Execution (`padz`)
--   **Behavior**: Running `padz` with no arguments defaults to `padz list`.
--   **Location**: `crates/padz-cli/src/cli/commands.rs` — function `run`
--   **Logic**: If `cli.command` is `None`, dispatch to `handle_list`.
--   **Why**: The "Read" operation is 90% of usage. It should be the path of least resistance.
+-   **Behavior**: Running `padz` with no arguments depends on stdin:
+    -   **stdin is a terminal** → `padz list`.
+    -   **stdin is piped** → `padz create`, capturing the pipe (`cat notes | padz`).
+        An empty pipe reaches `create` and aborts there; it does not fall back to `list`.
+-   **Location**: `crates/padz/src/cli/input.rs` — function `naked_command`;
+    called from `cli/commands.rs`'s `run`, which splices the chosen command into argv.
+-   **Why**: The "Read" operation is 90% of usage. It should be the path of least
+    resistance — while a pipe means the user is handing padz something to keep.
+-   **Why not standout's `default_command`**: it names one *static* command, and
+    this rule is conditional. See `naked_command`'s docs.
 
 ### 2. Smart Create (`padz create`)
--   **Location**: `crates/padz-cli/src/cli/commands.rs` — function `handle_create`
+-   **Location**: the precedence is declared as a standout `InputChain` in
+    `crates/padz/src/cli/input.rs`; `cli/handlers.rs`'s `create` acts on the
+    resolved `RequestContent` and never inspects stdin itself.
 
-**Priority order for content source:**
+**Priority order for content source** (first match wins):
 
-1. **Piped Input** (highest priority)
-   -   Detected via `!std::io::stdin().is_terminal()`
+1. **Title Argument, used directly** (highest priority)
+   -   When `--no-editor` is set, or todos mode is given title args — and never
+       when `--editor` is passed.
+   -   `padz create --no-editor "Meeting Notes"`
+   -   Action: uses the args verbatim. **Skips editor, and does not read stdin
+       at all** — piped text is ignored on this path.
+   -   Why: an explicit "just record this" needs no further input.
+
+2. **Piped Input**
+   -   Detected by the `StdinReader` seam (`is_terminal()`), not by the handler.
    -   `echo "foo" | padz create`
-   -   Action: Creates pad with piped content. **Skips editor**.
+   -   Action: Creates pad with piped content. **Skips editor**. A title arg
+       still overrides the piped buffer's title.
    -   Why: Scripting/automation use case.
+   -   **Empty pipe**: aborts the create — no pad, no editor.
 
-2. **Clipboard** (fallback when no pipe and no title arg)
-   -   `padz create` (with something in clipboard)
-   -   Action: Pre-fills editor with clipboard content. **Opens editor** (unless `--no-editor`).
-   -   Why: "I just copied this snippet, I want to save it." Removes `pbpaste` friction but allows review.
-
-3. **Title Argument**
-   -   `padz create "Meeting Notes"`
+3. **Editor** (when nothing above applies)
+   -   `padz create "Meeting Notes"` at a terminal.
    -   Action: Uses argument as title. Opens editor for body.
 
 **Editor behavior:**
 -   After saving from editor, the pad content is automatically copied to clipboard.
 -   Use `--no-editor` flag to skip opening the editor.
+-   The editor runs against the pad's **real file** in `.padz/`; if it fails to
+    launch, the pad created to hold it is removed. That lifecycle is why the
+    editor is a decision the chain defaults to, not a standout `EditorSource`.
 
 ### 3. View Copies to Clipboard
 -   `padz view 1` displays the pad AND copies its content to clipboard.


### PR DESCRIPTION
Makes create/edit's request-input precedence and naked invocation declarative, without changing anything a user can observe.

`for #195`

## What changed

The precedence for where a pad's text comes from is now a standout `InputChain` in the new `cli::input`, resolved as pre-dispatch configuration. `create` and `edit` no longer read stdin, probe `is_terminal()`, or select a source; they receive one resolved, typed `RequestContent` and act on it. The chain is attached declaratively through the existing `Dispatch` derive (`pre_dispatch = ...`), alongside each command's template.

The chain reads as the policy it encodes:

```
InputChain::new()
    .try_source(CreateDirectSource { mode })  // args, editor skipped
    .try_source(PipedSource::from_process())  // piped stdin
    .default(RequestContent::Editor)          // otherwise: the editor
```

Request-only values go through the named-input bag on `ctx.extensions`; `AppState` keeps only durable services (the chain reads `mode` from it at hook time).

## Context

**The precedence was characterized through the binary seam before it was touched**, and the executable behavior — not the documentation — is what was preserved. The full pre-refactor matrix was re-run against the refactored binary and matches case-for-case. Notable facts that characterization pinned, all preserved:

- The **args path outranks stdin** and does not read it at all: `printf X | padz create --no-editor "T"` ignores the pipe. (The doc's old "piped input is highest priority" was wrong.)
- `--no-editor` with no title creates an **empty pad**, still ignoring the pipe.
- An **empty pipe aborts** — a warning for `create`, an error for `edit`.
- `--editor` + a pipe never reaches the editor, and a single-line piped buffer's text is dropped when a title arg overrides it. Pre-existing; preserved deliberately, not "fixed" here.

**Three things deliberately do not use a standout primitive.** Each is isolated in `cli::input`, documented with its reason at the definition, and tested:

1. **`StdinSource`** reports empty piped input as `None`, which in a chain means "fall through to the next source". Padz must *abort* on an empty pipe — using the stock source would have silently turned "empty pipe → abort" into "empty pipe → open an editor". `PipedSource` reuses standout's `StdinReader` seam (and therefore its test overrides) but owns the empty semantics as `RequestContent::PipedEmpty`.
2. **`EditorSource`** edits a scratch buffer and returns a string. Padz creates the pad first, opens the editor on the **real file** in `.padz/`, refreshes from disk, and deletes the pad if the launch fails. That lifecycle belongs to the handler, so the chain resolves to a *decision* and stops.
3. **`App::default_command`** names one static command; padz's naked rule is conditional on stdin being piped. It also only fires inside `App::run`, and padz drives `parse_from` + `dispatch` (to build state and resolve the output mode first), so the setting would not apply regardless. Naked invocation stays application-owned as the pure, testable `naked_command(&dyn StdinReader)` instead of an inline `is_terminal()` probe.

**The stale clipboard claim is corrected, not implemented.** `cli_behavior.txt` and the `cli` module docs described a "clipboard fallback" that pre-filled the editor. That path was never wired — WS04 flagged the same claim — so per the coordinator brief the docs now state the executable truth: **the clipboard is write-only** (written after a pad is saved/viewed, never read to prefill one). The naked-execution section (which claimed an unconditional `padz` → `list`) and dead `crates/padz-cli` / `handle_create` paths are corrected in the same pass.

## Verification

`pixi run lint` ✅ · `pixi run test` ✅ — 793 passing, up from 756 (37 new).

Scenario matrix, all covered by controlled readers/adapters — **no test depends on the developer's clipboard or editor** (the e2e fixture pins `EDITOR=/bin/false` so a misroute fails loudly rather than opening someone's vim):

| Scenario | Covered by |
|---|---|
| title args, literal `\n`, `--no-editor`, `--editor` | e2e + unit |
| piped non-empty / empty / whitespace-only stdin | e2e + unit |
| notes mode, todos mode, nested (`--inside`) | e2e |
| naked invocation with a pipe / with an empty pipe | e2e |
| `open` sharing `edit`'s chain | e2e |
| **terminal stdin → editor**, **naked on a TTY → list** | unit (`MockStdin`) + manual pty |

The editor/TTY arms are **not reachable from e2e**: a spawned process without a pty has a null stdin, which is not a terminal, so padz treats a plain `padz create` there exactly like an empty pipe. That split is deliberate and documented in the test module — the chain's unit tests drive those arms with an injected `MockStdin::terminal()`. I additionally verified both arms end-to-end through a real pty: naked `padz` listed, and `create` ran a fake `$EDITOR` whose text landed in the pad.

One test earned its keep during the work: `InputChain::try_source` maps a source's **name string** to its `InputSourceKind`, and anything unrecognized silently becomes `Default`. A source named `"args"` resolved correctly but misreported its provenance; the name is now `"argument"`, with a comment at the definition.

## Out of scope / what not to "fix"

- The `--editor`-plus-pipe and single-line-buffer quirks above are **pre-existing behavior**, preserved on purpose. Changing them is a product decision, not a refactor.
- No prompts added, no sources reordered, no empty-input/abort semantics altered.
- No piping commands or shell interpolation (per the brief).
- WS06 test-pyramid migration and WS07 template/CSS presentation untouched.
- `padz 1` (the "naked integer" shortcut in PADZ.md) errors at clap parse today and never reaches the naked path. Unaffected by this change; not in scope.

## Brief gap (flagged, not guessed)

The coordinator brief did not name an ADR/Spec list to self-check against. I self-checked instead against the repo's governing docs for this surface — `docs/cli_behavior.txt` and `docs/architecture_cli_logic_split.txt` — plus the WS04 boundary (editor/clipboard/stdin/TTY/env/subprocess stay in the `padz` binary; `padzapp` stays CLI-free and receives resolved typed data), which this diff holds to: nothing here touches `padzapp`.


## Shepherd brief — round 1

Own PR #202 for issue #195. The five open threads are one repeated ownership/coercion class in `handlers.rs`: reviewer claims that `String` values are passed where `&str` is required. The pushed head passed `pixi run lint` and `pixi run test` (793 tests), so verify the actual inferred types and compiler behavior at every site before editing. If the reviewer is wrong because pattern matching produced references/coercions are valid, reply with concrete compiler/type evidence and resolve; if clarity or ownership is genuinely wrong, fix it consistently across every instance and add/adjust the narrowest useful test.

Sweep all new `RequestContent` match arms and helper calls for the same owned-vs-borrowed class, including subsequent reuse after calls. Preserve the characterized precedence and empty-input semantics; do not “fix” the deliberately retained editor/pipe quirks or activate clipboard reads. Keep `padzapp`, WS06 testing migration, and WS07 presentation out of scope.

Resolve all five threads, then verify `pixi run lint` and `pixi run test`.