### PR TITLE
Deepen Standout ownership for views and semantic notices

### DIFF
--- a/CHANGELOG/unreleased-standout-ownership.md
+++ b/CHANGELOG/unreleased-standout-ownership.md
@@ -1,0 +1,9 @@
+- Deepen the CLI/core ownership split for `view` and pin-state notices. `view`
+  structured output now keeps `title` and `content` unindented, exposes the
+  requested `nesting` mode, and leaves four-space human indentation to the
+  MiniJinja template. Viewing multiple selected roots now performs one clipboard
+  write in display order, separated by `---`; child rows remain excluded from the
+  `view` clipboard payload, as before. Repeating `pin` or `unpin` now exposes an
+  additive `notices` array with a stable semantic `kind` and canonical display
+  path; the former English entry is no longer duplicated in `messages`, while the
+  human sentence remains unchanged through the modification template.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -162,6 +162,7 @@ impl<'a> ScopedApi<'a> {
             action: action.to_string(),
             pads: result.affected_pads,
             messages: result.messages,
+            notices: result.notices,
             request: ModificationRequest {
                 status: self.state.wants_status(force_show_status),
             },
@@ -423,52 +424,37 @@ impl<'a> ScopedApi<'a> {
     ) -> Result<Output<PadContentResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
-        // Copy content to clipboard (only root-level pads for tree/indented)
-        for (i, dp) in result.listed_pads.iter().enumerate() {
-            let depth = result.listed_depths.get(i).copied().unwrap_or(0);
-            if depth == 0 {
-                copy_content_to_clipboard(&dp.pad.content);
-            }
-        }
-
-        let indent_per_level: usize = match nesting {
-            NestingMode::Indented => 4,
-            _ => 0,
-        };
-
         let pads: Vec<PadContent> = result
             .listed_pads
             .iter()
             .enumerate()
             .map(|(i, dp)| {
                 let depth = result.listed_depths.get(i).copied().unwrap_or(0);
-                let indent = " ".repeat(depth * indent_per_level);
-
                 // Extract body (content minus title) to avoid double-title in output
                 let body = extract_title_and_body(&dp.pad.content)
                     .map(|(_, b)| b)
                     .unwrap_or_default();
 
-                // Apply indentation to content lines if indented mode
-                let (display_title, display_body) = if indent.is_empty() {
-                    (dp.pad.metadata.title.clone(), body)
-                } else {
-                    let indented_body = indent_lines(&body, &indent);
-                    (
-                        format!("{}{}", indent, dp.pad.metadata.title),
-                        indented_body,
-                    )
-                };
-
                 PadContent {
-                    title: display_title,
-                    content: display_body,
+                    title: dp.pad.metadata.title.clone(),
+                    content: body,
                     depth,
                     uuid: show_uuid.then(|| dp.pad.metadata.id.to_string()),
                 }
             })
             .collect();
-        Ok(Output::Render(PadContentResult { pads }))
+        let view = PadContentResult { pads, nesting };
+
+        // `view` copies only the selected roots, in display order. Build one
+        // payload and perform one CLI-owned write so multiple selectors do not
+        // overwrite one another and rendered/structured output never becomes the
+        // clipboard source.
+        let clipboard_text = view_clipboard_text(&view);
+        if !clipboard_text.is_empty() {
+            let _ = copy_to_clipboard(&clipboard_text);
+        }
+
+        Ok(Output::Render(view))
     }
 
     // --- Copy operations ---
@@ -534,6 +520,20 @@ impl<'a> ScopedApi<'a> {
             msg,
         )])))
     }
+}
+
+/// Clipboard payload for `view`, derived only from its semantic result.
+///
+/// Child rows are excluded to preserve `view`'s established clipboard contract;
+/// selected roots are joined in their canonical display order with the same
+/// separator used by human multi-pad output.
+fn view_clipboard_text(view: &PadContentResult) -> String {
+    view.pads
+        .iter()
+        .filter(|pad| pad.depth == 0)
+        .map(|pad| format_for_clipboard(&pad.title, &pad.content))
+        .collect::<Vec<_>>()
+        .join("\n---\n\n")
 }
 
 /// Get a scoped API accessor from the command context
@@ -760,6 +760,7 @@ fn aborted_create() -> ModificationResult {
         action: "Created".to_string(),
         pads: Vec::new(),
         messages: vec![CmdMessage::warning("Aborted: empty content")],
+        notices: Vec::new(),
         request: ModificationRequest::default(),
     }
 }
@@ -1555,6 +1556,38 @@ mod tests {
             rendered(view(&app.ctx, vec!["1".into()], false, true, false, false, false).unwrap());
 
         assert!(result.pads[0].uuid.is_some());
+    }
+
+    #[test]
+    fn view_clipboard_payload_joins_roots_once_and_excludes_children() {
+        let view = PadContentResult {
+            nesting: NestingMode::Tree,
+            pads: vec![
+                PadContent {
+                    title: "First".to_string(),
+                    content: "one".to_string(),
+                    depth: 0,
+                    uuid: None,
+                },
+                PadContent {
+                    title: "Child".to_string(),
+                    content: "nested".to_string(),
+                    depth: 1,
+                    uuid: None,
+                },
+                PadContent {
+                    title: "Second".to_string(),
+                    content: "two".to_string(),
+                    depth: 0,
+                    uuid: None,
+                },
+            ],
+        };
+
+        assert_eq!(
+            view_clipboard_text(&view),
+            "First\n\none\n---\n\nSecond\n\ntwo"
+        );
     }
 
     // --- mutation -------------------------------------------------------------

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -50,6 +50,7 @@ use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
 use minijinja::Value;
 use padzapp::api::CmdMessage;
+use padzapp::commands::CmdNotice;
 use padzapp::index::{DisplayIndex, DisplayPad, SearchMatch};
 use padzapp::model::TodoStatus;
 use padzapp::peek::{format_as_peek, PeekResult};
@@ -215,6 +216,15 @@ pub struct ModificationView {
     pub rows: Vec<PadRow>,
     pub show_status: bool,
     pub messages: Vec<CmdMessage>,
+    /// Presentation-ready projections of semantic core notices.
+    pub notices: Vec<ModificationNoticeView>,
+}
+
+/// The small amount of display shaping a semantic modification notice needs.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModificationNoticeView {
+    pub kind: &'static str,
+    pub index: String,
 }
 
 // =============================================================================
@@ -295,6 +305,22 @@ pub fn build_modification_view(result: &ModificationResult) -> ModificationView 
             .collect(),
         show_status: result.request.status,
         messages: result.messages.clone(),
+        notices: result.notices.iter().map(modification_notice).collect(),
+    }
+}
+
+fn modification_notice(notice: &CmdNotice) -> ModificationNoticeView {
+    let (kind, path) = match notice {
+        CmdNotice::AlreadyPinned { path } => ("already_pinned", path),
+        CmdNotice::AlreadyUnpinned { path } => ("already_unpinned", path),
+    };
+    ModificationNoticeView {
+        kind,
+        index: path
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("."),
     }
 }
 
@@ -590,6 +616,7 @@ mod tests {
                 vec![dp(pad("child"), DisplayIndex::Regular(1), vec![])],
             )],
             messages: vec![],
+            notices: vec![],
             request: ModificationRequest { status: true },
         };
         let view = build_modification_view(&result);

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -27,6 +27,7 @@
 //! it is part of the result and visible in structured output.
 
 use padzapp::api::CmdMessage;
+use padzapp::commands::{CmdNotice, NestingMode};
 use padzapp::index::DisplayPad;
 use serde::{Deserialize, Serialize};
 
@@ -80,6 +81,9 @@ pub struct ModificationResult {
     pub action: String,
     pub pads: Vec<DisplayPad>,
     pub messages: Vec<CmdMessage>,
+    /// Machine-readable facts emitted by the core; templates own their prose.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notices: Vec<CmdNotice>,
     pub request: ModificationRequest,
 }
 
@@ -101,9 +105,9 @@ impl MessagesResult {
 /// One pad's full content, as returned by `view`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PadContent {
-    /// Title, already carrying its tree indentation prefix in indented nesting mode.
+    /// Raw title with no presentation indentation.
     pub title: String,
-    /// Body (content minus the title line), indented to match `title`.
+    /// Raw body (content minus the title line), with no presentation indentation.
     pub content: String,
     /// Depth in the pad tree; 0 for a root pad.
     pub depth: usize,
@@ -116,6 +120,8 @@ pub struct PadContent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PadContentResult {
     pub pads: Vec<PadContent>,
+    /// The requested relationship shape; human rendering decides how it looks.
+    pub nesting: NestingMode,
 }
 
 /// Filesystem paths of the selected pads, one per selector match.

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -18,3 +18,12 @@
 {%- for msg in view.messages -%}
 {{ msg.content | style_as(msg.level) }}{{ "" | nl }}
 {%- endfor -%}
+
+{#- Semantic notices: wording stays here; structured modes receive kind + fields. -#}
+{%- for notice in view.notices -%}
+{%- if notice.kind == "already_pinned" -%}
+[info]Pad {{ notice.index }} is already pinned[/info]{{ "" | nl }}
+{%- elif notice.kind == "already_unpinned" -%}
+[info]Pad {{ notice.index }} is already unpinned[/info]{{ "" | nl }}
+{%- endif -%}
+{%- endfor -%}

--- a/crates/padz/src/cli/templates/view.jinja
+++ b/crates/padz/src/cli/templates/view.jinja
@@ -13,8 +13,14 @@
 {%- if pad.uuid %}
 [info]uuid: {{ pad.uuid }}[/info]
 {% endif -%}
+{%- if nesting == "indented" -%}
+{{ pad.title | indent(pad.depth * 4, true) }}
+
+{{ pad.content | indent(pad.depth * 4, true) }}
+{%- else -%}
 {{ pad.title }}
 
 {{ pad.content }}
+{%- endif -%}
 {% endfor -%}
 {% endif %}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -28,6 +28,7 @@ use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
     MessagesResult, ModificationResult, PadContentResult, PadListResult, PathResult, UuidResult,
 };
+use padzapp::commands::{CmdNotice, NestingMode};
 use standout::cli::Output;
 use support::Fixture;
 
@@ -233,6 +234,32 @@ fn view_includes_the_uuid_only_when_requested() {
 }
 
 #[test]
+fn indented_view_returns_raw_content_plus_nesting_facts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "parent body");
+    fx.seed_child(&state, "1", "child", "child body\nsecond line");
+    let ctx = support::ctx_with_state(state);
+
+    let result: PadContentResult = rendered(handlers::view(
+        &ctx,
+        vec!["1".to_string()],
+        false,
+        false,
+        false,
+        false,
+        true,
+    ));
+
+    assert_eq!(result.nesting, NestingMode::Indented);
+    assert_eq!(result.pads[1].depth, 1);
+    assert_eq!(result.pads[1].title, "child");
+    assert_eq!(result.pads[1].content, "child body\nsecond line");
+    assert!(!result.pads[1].title.starts_with(' '));
+    assert!(!result.pads[1].content.starts_with(' '));
+}
+
+#[test]
 fn view_of_an_unknown_selector_is_an_error_not_an_empty_result() {
     let fx = Fixture::new();
     let ctx = fx.ctx();
@@ -329,6 +356,25 @@ fn plain_modification_handlers_do_not_request_status_icons_in_notes_mode() {
     let result = rendered(handlers::pin(&ctx, vec!["1".to_string()]));
 
     assert!(!result.request.status);
+}
+
+#[test]
+fn repeated_pin_maps_the_core_notice_without_parsing_prose() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "note", "");
+    let ctx = support::ctx_with_state(state);
+
+    rendered(handlers::pin(&ctx, vec!["1".to_string()]));
+    let result = rendered(handlers::pin(&ctx, vec!["p1".to_string()]));
+
+    assert_eq!(
+        result.notices,
+        vec![CmdNotice::AlreadyPinned {
+            path: vec![padzapp::index::DisplayIndex::Pinned(1)]
+        }]
+    );
+    assert!(result.messages.is_empty());
 }
 
 #[test]

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -644,6 +644,84 @@ fn a_modification_renders_its_action_verb() {
 
 #[test]
 #[serial]
+fn a_semantic_pin_notice_renders_compatible_human_wording() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.pin_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let result =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["pin", "p1"]));
+
+    result.assert_success();
+    result.assert_stdout_contains("Pad p1 is already pinned");
+}
+
+#[test]
+#[serial]
+fn semantic_pin_notice_is_machine_readable() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.pin_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let result =
+        TestHarness::new()
+            .no_color()
+            .run(&app, cmd, fx.argv(&["pin", "p1", "--output", "json"]));
+    let value: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+
+    assert_eq!(value["notices"][0]["kind"], "already_pinned");
+    assert_eq!(value["notices"][0]["path"][0]["type"], "Pinned");
+    assert_eq!(value["notices"][0]["path"][0]["value"], 1);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
+#[test]
+#[serial]
+fn indented_view_is_shaped_by_the_template_not_the_result() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "parent body");
+    fx.seed_child(&state, "1", "child", "child body\nsecond line");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let human = TestHarness::new().no_color().text_output().run(
+        &app,
+        cmd,
+        fx.argv(&["view", "1", "--indented"]),
+    );
+    human.assert_stdout_contains("    child");
+    human.assert_stdout_contains("    child body\n    second line");
+    drop(human);
+
+    let (app, cmd) = fx.read_app();
+    let structured = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        fx.argv(&["view", "1", "--indented", "--output", "json"]),
+    );
+    let value: serde_json::Value = serde_json::from_str(structured.stdout()).unwrap();
+    assert_eq!(value["nesting"], "indented");
+    assert_eq!(value["pads"][1]["depth"], 1);
+    assert_eq!(value["pads"][1]["title"], "child");
+    assert_eq!(value["pads"][1]["content"], "child body\nsecond line");
+}
+
+#[test]
+#[serial]
 fn text_output_carries_no_ansi_escapes() {
     let fx = Fixture::new();
     let state = fx.app_state();

--- a/crates/padz/tests/support/mod.rs
+++ b/crates/padz/tests/support/mod.rs
@@ -163,6 +163,20 @@ impl Fixture {
             .with_api(|api| api.create_pad(state.scope, title.to_string(), body.to_string(), None))
             .unwrap_or_else(|e| panic!("failed to seed pad {title:?}: {e}"));
     }
+
+    /// Creates a child pad under a canonical display selector.
+    pub fn seed_child(&self, state: &AppState, parent: &str, title: &str, body: &str) {
+        state
+            .with_api(|api| {
+                api.create_pad(
+                    state.scope,
+                    title.to_string(),
+                    body.to_string(),
+                    Some(parent),
+                )
+            })
+            .unwrap_or_else(|e| panic!("failed to seed child pad {title:?}: {e}"));
+    }
 }
 
 impl Default for Fixture {

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -67,7 +67,8 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Controls how nested (parent/child) pads are rendered.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum NestingMode {
     /// Show only the selected pad(s), no children (legacy behavior).
     Flat,
@@ -76,6 +77,22 @@ pub enum NestingMode {
     Tree,
     /// Recursively include children, with 4-space indentation per nesting level.
     Indented,
+}
+
+/// A semantic, presentation-free fact a command wants the caller to surface.
+///
+/// Unlike [`CmdMessage`], notices carry no authored prose. CLI clients can render
+/// them for people while structured clients can branch on `kind` and fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CmdNotice {
+    /// A pin/unpin request found the pad in the requested state already.
+    AlreadyPinned {
+        path: Vec<crate::index::DisplayIndex>,
+    },
+    AlreadyUnpinned {
+        path: Vec<crate::index::DisplayIndex>,
+    },
 }
 
 pub mod archive;
@@ -186,6 +203,8 @@ pub struct CmdResult {
     pub listed_depths: Vec<usize>,
     pub pad_paths: Vec<PathBuf>,
     pub messages: Vec<CmdMessage>,
+    /// Semantic notices that clients render or inspect without parsing English.
+    pub notices: Vec<CmdNotice>,
     /// The nesting mode used to produce listed_pads.
     pub nesting: NestingMode,
 }

--- a/crates/padzapp/src/commands/pinning.rs
+++ b/crates/padzapp/src/commands/pinning.rs
@@ -1,5 +1,5 @@
 use crate::attributes::AttrValue;
-use crate::commands::{CmdMessage, CmdResult};
+use crate::commands::{CmdNotice, CmdResult};
 use crate::error::Result;
 use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::Scope;
@@ -43,17 +43,15 @@ fn pin_state<S: DataStore>(
         pad.metadata.set_attr("pinned", AttrValue::Bool(is_pinned));
         store.save_pad(&pad, scope, Bucket::Active)?;
 
-        // Only add info messages for no-op cases; success cases are shown via pad list
+        // No-op cases are semantic notices; the CLI owns their wording.
         if is_pinned && was_already_pinned {
-            result.add_message(CmdMessage::info(format!(
-                "Pad {} is already pinned",
-                super::helpers::fmt_path(&display_index)
-            )));
+            result.notices.push(CmdNotice::AlreadyPinned {
+                path: display_index.clone(),
+            });
         } else if !is_pinned && !was_already_pinned {
-            result.add_message(CmdMessage::info(format!(
-                "Pad {} is already unpinned",
-                super::helpers::fmt_path(&display_index)
-            )));
+            result.notices.push(CmdNotice::AlreadyUnpinned {
+                path: display_index.clone(),
+            });
         }
         affected_uuids.push(uuid);
     }
@@ -209,12 +207,13 @@ mod tests {
         )
         .unwrap();
 
-        // Should return info message
-        assert!(matches!(
-            result.messages[0].level,
-            crate::commands::MessageLevel::Info
-        ));
-        assert!(result.messages[0].content.contains("already pinned"));
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyPinned {
+                path: vec![DisplayIndex::Pinned(1)]
+            }]
+        );
+        assert!(result.messages.is_empty());
     }
 
     #[test]
@@ -235,12 +234,13 @@ mod tests {
         )
         .unwrap();
 
-        // Should return info message
-        assert!(matches!(
-            result.messages[0].level,
-            crate::commands::MessageLevel::Info
-        ));
-        assert!(result.messages[0].content.contains("already unpinned"));
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyUnpinned {
+                path: vec![DisplayIndex::Regular(1)]
+            }]
+        );
+        assert!(result.messages.is_empty());
     }
 
     #[test]

--- a/tests/e2e/bats/nested-output.bats
+++ b/tests/e2e/bats/nested-output.bats
@@ -67,22 +67,6 @@ teardown() {
 }
 
 # -----------------------------------------------------------------------------
-# VIEW --indented
-# -----------------------------------------------------------------------------
-
-@test "view: --indented shows children with indentation" {
-    local idx
-    idx=$(find_pad_by_title "Nested Test Parent" global)
-
-    run "${PADZ_BIN}" -g view --indented "${idx}"
-    assert_success
-    [[ "$output" == *"Nested Test Parent"* ]]
-    [[ "$output" == *"Nested Test Child"* ]]
-    # Indented children should have leading spaces
-    [[ "$output" == *"    Nested Test Child"* ]]
-}
-
-# -----------------------------------------------------------------------------
 # VIEW on leaf pad
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
for #206

## Summary

- replace core-authored pin/unpin no-op prose with serializable semantic notices and render the compatible human wording in MiniJinja
- return unindented semantic `view` title/body data plus depth and nesting facts, leaving four-space indentation to the human template
- derive one ordered, root-only clipboard payload from semantic view data while keeping normal output visible
- move the representative indented-view behavior from subprocess Bats coverage to the in-process Standout `TestHarness`

## Context

This is a vertical, showcase-quality slice of the locally actionable ownership work in #206. `padzapp` remains CLI-free: it returns semantic notices and raw view facts. The typed handlers remain adapters, while Standout owns structured serialization and template rendering; the CLI-owned clipboard adapter receives semantic note content rather than rendered text, ANSI, or structured output.

Phase 1 is intentionally excluded after verification against the pinned Standout v7.6.4 family. `Output::Binary`, `RenderedOutput::Binary`, and `RunResult::Binary` carry only bytes and a filename, so metadata-export partial-success diagnostics cannot remain observable without recreating output multiplexing in Padz. `App::run` does own suggested-file writes and non-zero error exits, but its binary success message is currently fixed. Export behavior is left unchanged until Standout provides a coherent tagged contract for binary diagnostics and compatible final-run reporting.

Phase 4 is also intentionally excluded. Standout v7.6.4 still lacks the state-aware input factory and per-invocation default-command resolver required to remove Padz's existing workarounds. Those documented workarounds remain unchanged.

Compatibility is preserved for human pin/unpin and indented-view output. Structured `view` output intentionally removes presentation-only leading spaces and adds the requested `nesting` fact. Repeated pin/unpin adds a machine-readable `notices` array; its former English entry is no longer duplicated in `messages`. The changelog documents these structured-contract changes. Clipboard failures remain best-effort as before; multiple selected roots now produce one write in canonical display order, separated by `---`, with child rows still excluded.

## Test evidence

- `pixi run test` — 833 passed, 1 skipped
- `pixi run lint` — 12 checks passed
- pre-commit and pre-push hooks re-ran the lint gate successfully
