### PR TITLE
Adopt Standout 7.7 typed outcomes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,8 +1941,8 @@ dependencies = [
 
 [[package]]
 name = "standout"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "anyhow",
  "clap",
@@ -1966,16 +1966,16 @@ dependencies = [
 
 [[package]]
 name = "standout-bbparser"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "console 0.16.4",
 ]
 
 [[package]]
 name = "standout-dispatch"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "anyhow",
  "clap",
@@ -1986,8 +1986,8 @@ dependencies = [
 
 [[package]]
 name = "standout-input"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "clap",
  "once_cell",
@@ -1999,8 +1999,8 @@ dependencies = [
 
 [[package]]
 name = "standout-macros"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2009,8 +2009,8 @@ dependencies = [
 
 [[package]]
 name = "standout-pipe"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "thiserror 2.0.17",
  "wait-timeout",
@@ -2018,8 +2018,8 @@ dependencies = [
 
 [[package]]
 name = "standout-render"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "console 0.16.4",
  "cssparser",
@@ -2034,13 +2034,14 @@ dependencies = [
  "serde_yaml",
  "standout-bbparser",
  "terminal_size",
+ "thiserror 2.0.17",
  "unicode-width",
 ]
 
 [[package]]
 name = "standout-seeker"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "regex",
  "thiserror 2.0.17",
@@ -2048,8 +2049,8 @@ dependencies = [
 
 [[package]]
 name = "standout-test"
-version = "7.6.4"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.6.4#baf96ab6f6bf44e946584759ea90564b88b652ed"
+version = "7.7.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
 dependencies = [
  "clap",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/arthur-debert/padz"
 
 # Resolve the standout family from the v7.7.0 git tag instead of crates.io.
 #
-# WHY THIS EXISTS — it is a graph-unification fix, not a version change.
+# WHY THIS PATCH EXISTS — it keeps the git-only test harness and the published
+# runtime crates in one dependency graph.
 #
 # The test pyramid needs `standout-test` (the in-process `TestHarness`), and the
 # newest *published* standout-test is 7.5.1, which does not compile against
@@ -28,7 +29,9 @@ repository = "https://github.com/arthur-debert/padz"
 # one layer down (e.g. two `standout-dispatch` crates ⇒ two `CommandContext`s).
 #
 # `[patch]` is workspace-local: it is not published and never reaches consumers
-# of the `padz` crate, who resolve plain 7.7.0 from crates.io.
+# of the `padz` crate. Its three direct Standout dependencies are published at
+# 7.7.0 and downstream consumers resolve those ordinary requirements from
+# crates.io; only the dev-only `standout-test` remains git-only.
 #
 # REMOVE THIS once standout-test 7.7.x is published to crates.io; it then goes
 # back to a plain dev-dependency version requirement in crates/padz/Cargo.toml.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/arthur-debert/padz"
 
-# Resolve the standout family from the v7.6.4 git tag instead of crates.io.
+# Resolve the standout family from the v7.7.0 git tag instead of crates.io.
 #
 # WHY THIS EXISTS — it is a graph-unification fix, not a version change.
 #
 # The test pyramid needs `standout-test` (the in-process `TestHarness`), and the
 # newest *published* standout-test is 7.5.1, which does not compile against
-# standout 7.6: 7.6 made `RunResult` `#[non_exhaustive]` and added the `Error`
+# standout 7.x: 7.6 made `RunResult` `#[non_exhaustive]` and added the `Error`
 # variant, and 7.5.1 matches it exhaustively. The fixed standout-test exists —
-# version 7.6.4 in the upstream repo — but carries `publish = false`, so it can
+# version 7.7.0 in the upstream repo — but carries `publish = false`, so it can
 # only be reached as a git dependency. And a git standout-test resolves its own
 # `standout` through a workspace *path* dep, which Cargo treats as a crate
 # distinct from crates.io's standout: the two `App` types then don't unify and
@@ -24,24 +24,21 @@ repository = "https://github.com/arthur-debert/padz"
 #
 # Patching the whole family to the tag collapses that back into one graph.
 #
-# WHY IT IS SAFE: the v7.6.4 tag is byte-identical to the published 7.6.4 for
-# every crate patched below (verified with `diff -r` across all eight `src/`
-# trees), so this changes *no code* — only which copy Cargo considers canonical.
 # The whole family is listed because a partial patch reintroduces the same split
 # one layer down (e.g. two `standout-dispatch` crates ⇒ two `CommandContext`s).
 #
 # `[patch]` is workspace-local: it is not published and never reaches consumers
-# of the `padz` crate, who resolve plain 7.6.4 from crates.io.
+# of the `padz` crate, who resolve plain 7.7.0 from crates.io.
 #
-# REMOVE THIS once standout-test 7.6.x is published to crates.io; it then goes
+# REMOVE THIS once standout-test 7.7.x is published to crates.io; it then goes
 # back to a plain dev-dependency version requirement in crates/padz/Cargo.toml.
 # Tracked upstream at arthur-debert/standout.
 [patch.crates-io]
-standout = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-bbparser = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-dispatch = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-input = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-macros = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-pipe = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-render = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
-standout-seeker = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
+standout = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-bbparser = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-dispatch = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-input = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-macros = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-pipe = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-render = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-seeker = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -30,9 +30,9 @@ console = "0.15"
 directories = "6.0.0"
 dark-light = "0.2"
 once_cell = "1.19"
-standout = "7.6.4"
-standout-macros = "7.6.4"
-standout-dispatch = "7.6.4"
+standout = "7.7.0"
+standout-macros = "7.7.0"
+standout-dispatch = "7.7.0"
 # Standout's template engine. Needed directly to type the context providers in
 # cli::render, whose values standout hands to MiniJinja.
 minijinja = "2"
@@ -57,20 +57,20 @@ unicode-width = "0.2.2"
 # builder that restores them on drop. Re-exports `serial_test`, which every
 # harness test needs: those seams are process-global.
 #
-# Pinned to the v7.6.4 git tag rather than a crates.io version ON PURPOSE. The
+# Pinned to the v7.7.0 git tag rather than a crates.io version ON PURPOSE. The
 # newest *published* standout-test is 7.5.1, and it does not compile against the
-# standout 7.6.4 this crate uses: 7.6 made `RunResult` `#[non_exhaustive]` and
+# standout 7.7.0 this crate uses: 7.6 made `RunResult` `#[non_exhaustive]` and
 # added the `Error` variant, while 7.5.1 matches `RunResult` exhaustively. Its
 # `standout = "^7.5.1"` requirement claims that unification is fine, so Cargo
 # resolves it happily and then fails to build — the incompatibility is real but
-# invisible to semver. The v7.6.4 tag (matching our standout exactly) handles
+# invisible to semver. The v7.7.0 tag (matching our standout exactly) handles
 # `Error` and matches non-exhaustively; it is unpublished only because the crate
 # carries `publish = false` upstream. Tracked at arthur-debert/standout; swap this
-# back to a plain version requirement once 7.6.x is on crates.io.
+# back to a plain version requirement once 7.7.x is on crates.io.
 #
 # Safe for `cargo publish`: a dev-dependency with no `version` key is stripped
 # from the packaged manifest, so this git source never reaches consumers.
-standout-test = { git = "https://github.com/arthur-debert/standout", tag = "v7.6.4" }
+standout-test = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
 # Direct, even though standout-test re-exports `serial`: the macro it re-exports
 # expands to `::serial_test` paths, so the crate has to be nameable here for
 # `#[serial]` to resolve. Same major as standout-test's own requirement, so the

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -632,7 +632,7 @@ mod dispatch_result_tests {
     /// the printed line from reading `Error: ... Error: boom`.
     #[test]
     fn error_variant_strips_standout_prefix() {
-        let err = handle_dispatch_result(RunResult::Error("Error: boom".to_string()))
+        let err = handle_dispatch_result(RunResult::Error("Error: boom".into()))
             .expect_err("Error variant must fail");
 
         let rendered = err.to_string();

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -34,6 +34,7 @@
 
 mod support;
 
+use standout::cli::{ExitStatus, OutputKind, RunErrorKind, SuccessKind};
 use standout_test::{serial, TestHarness};
 use support::Fixture;
 use unicode_width::UnicodeWidthStr;
@@ -135,6 +136,8 @@ fn list_dispatches_and_renders_every_pad() {
             .run(&app, cmd, fx.argv(&["list"]));
 
     result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    assert_eq!(result.success_kind(), Some(SuccessKind::Command));
     result.assert_stdout_contains("first pad");
     result.assert_stdout_contains("second pad");
 }
@@ -150,12 +153,11 @@ fn an_unknown_command_does_not_dispatch() {
             .no_color()
             .run(&app, cmd, fx.argv(&["definitely-not-a-command"]));
 
-    // Clap rejects it before dispatch; the run must not quietly succeed.
-    assert!(
-        !result.is_handled() || result.is_error(),
-        "an unknown command must not render as a normal result: {:?}",
-        result.stdout()
-    );
+    // Clap rejects it before dispatch. Standout 7.7 keeps both the shell status
+    // and the failure's origin typed, so this cannot regress to a runtime error.
+    result.assert_error();
+    result.assert_exit_status(ExitStatus::USAGE_ERROR);
+    result.assert_error_kind(RunErrorKind::ClapUsage);
 }
 
 #[test]
@@ -443,19 +445,10 @@ fn edit_with_an_empty_pipe_errors_and_leaves_the_pad_alone() {
     );
 
     // Unlike create's warning, an empty pipe is a hard error for edit.
-    assert!(
-        result.is_error(),
-        "an empty pipe must fail the edit, got: {:?}",
-        result.stdout()
-    );
-    assert!(
-        result
-            .error()
-            .unwrap_or_default()
-            .contains("Aborted: empty content"),
-        "got: {:?}",
-        result.error()
-    );
+    result.assert_error();
+    result.assert_exit_status(ExitStatus::FAILURE);
+    result.assert_error_kind(RunErrorKind::Handler);
+    result.assert_error_contains("Aborted: empty content");
     drop(result);
 
     let (app, cmd) = fx.read_app();
@@ -598,6 +591,8 @@ fn an_empty_store_renders_the_create_hint() {
         .run(&app, cmd, fx.argv(&["list"]));
 
     result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    assert_eq!(result.success_kind(), Some(SuccessKind::Command));
     result.assert_stdout_contains("No pads yet, create one with `padz create`");
 }
 
@@ -1269,6 +1264,8 @@ fn output_file_path_writes_the_result_to_the_file_and_stays_silent() {
     );
 
     result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    assert_eq!(result.success_kind(), Some(SuccessKind::Command));
     assert_eq!(
         result.stdout(),
         "",
@@ -1312,6 +1309,36 @@ fn output_file_path_writes_text_without_ansi_escapes() {
         "a file is not a terminal; the written output must be escape-free: {written:?}"
     );
     assert!(written.contains("written pad"));
+}
+
+#[test]
+#[serial]
+fn output_file_path_reports_a_typed_final_write_failure() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "unwritten pad", "");
+    drop(state);
+
+    // A directory is a deterministic invalid file target on every supported
+    // platform, without depending on permission bits or the test user's uid.
+    let target = fx.root();
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        fx.argv(&[
+            "list",
+            "--output",
+            "json",
+            "--output-file-path",
+            target.to_str().unwrap(),
+        ]),
+    );
+
+    result.assert_error();
+    result.assert_exit_status(ExitStatus::FAILURE);
+    result.assert_error_kind(RunErrorKind::FinalWrite(OutputKind::Text));
+    result.assert_error_contains("Error writing output");
 }
 
 // =============================================================================


### PR DESCRIPTION
## Context

This adopts the complete Standout family from the coherent `v7.7.0` git tag, including unpublished `standout-test`. Padz now uses v7.7 typed execution metadata in its in-process harness: command success/status, Clap usage status and origin, handler failure status and origin, and framework-owned final-write failure origin. Output-file success and failure are both proven at the smallest `TestHarness` seam, including the written bytes and stdout suppression.

The structured-output projection audit found no application-owned Padz CSV shaping to remove: Padz currently accepts Standout generic flattening as its pinned CSV contract. This PR therefore leaves projections unused and preserves every human and structured output schema.

This does not complete #208. The compound artifact plus semantic-report contract and destination-aware success rendering remain blocked upstream, as do state-aware input factories, derived-dispatch configuration, and dynamic default-command resolution. Export destination writes and Padz input/default workarounds remain unchanged.

Real-process tests remain only for boundaries documented by their files: the `main.rs` stdout/stderr/exit split, Clap/custom-help process exits, pre-dispatch config handling, process-derived naked invocation, real editor subprocesses, and actual OS filesystem/link behavior. Typed framework outcomes and output-file writes do not require those boundaries and are covered in `TestHarness` here.

closes #209

## Validation

- `cargo test -p padz --test harness` (44 passed)
- `pixi run test` (834 passed, 1 skipped)
- `pixi run lint` (12 checks passed)