### PR TITLE
Let Standout own create and edit input resolution

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -84,6 +84,15 @@ pub fn run() -> Result<()> {
 /// templates, styles, and dispatch table the binary uses. Building the app twice —
 /// once for the binary, once for tests — is exactly the drift this avoids.
 pub fn build_dispatch_app(app_state: AppState) -> App {
+    // Input policy depends on the configured mode, so construct the chains at
+    // assembly time before moving the durable state into Standout. These three
+    // commands are skipped by the Dispatch derive and registered explicitly so
+    // Standout owns deepest-match resolution and the request-scoped Inputs bag.
+    let mode = app_state.mode;
+    let create_content = super::input::create_chain(mode);
+    let edit_content = super::input::edit_chain(mode);
+    let open_content = super::input::edit_chain(mode);
+
     App::builder()
         .app_state(app_state)
         .templates(embed_templates!("src/cli/templates"))
@@ -95,6 +104,24 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
         .context_fn(MODIFICATION_VIEW, modification_view_provider)
         .commands(Commands::dispatch_config())
         .expect("Failed to configure commands")
+        .command_with("create", super::handlers::create__handler, |config| {
+            config
+                .template("modification_result")
+                .input(super::input::CREATE_CONTENT, create_content)
+        })
+        .expect("Failed to configure create input")
+        .command_with("edit", super::handlers::edit__handler, |config| {
+            config
+                .template("modification_result")
+                .input(super::input::EDIT_CONTENT, edit_content)
+        })
+        .expect("Failed to configure edit input")
+        .command_with("open", super::handlers::edit__handler, |config| {
+            config
+                .template("modification_result")
+                .input(super::input::EDIT_CONTENT, open_content)
+        })
+        .expect("Failed to configure open input")
         .build()
         .expect("Failed to build app")
 }

--- a/crates/padz/src/cli/input.rs
+++ b/crates/padz/src/cli/input.rs
@@ -53,14 +53,13 @@
 
 use clap::ArgMatches;
 use padzapp::config::PadzMode;
-use standout::cli::{get_deepest_matches, CommandContext, HookError};
 use standout::input::env::{DefaultStdin, StdinReader};
-use standout::input::{InputChain, InputCollector, InputError, Inputs};
+use standout::input::{InputChain, InputCollector, InputError};
 use std::sync::Arc;
 
 // `split_indexes_and_content` is the handlers' own arg-splitting rule; the edit
 // source must apply the same one to know whether trailing words are content.
-use super::handlers::{split_indexes_and_content, AppState};
+use super::handlers::split_indexes_and_content;
 
 /// The name the `create` content input is registered and looked up under.
 pub const CREATE_CONTENT: &str = "create_content";
@@ -223,7 +222,7 @@ impl InputCollector<RequestContent> for PipedSource {
 // =============================================================================
 
 /// The `create` content chain: direct args, then piped stdin, then the editor.
-fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
+pub(super) fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
     InputChain::new()
         .try_source(CreateDirectSource { mode })
         .try_source(PipedSource::from_process())
@@ -231,73 +230,11 @@ fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
 }
 
 /// The `edit` content chain: inline todos content, then piped stdin, then the editor.
-fn edit_chain(mode: PadzMode) -> InputChain<RequestContent> {
+pub(super) fn edit_chain(mode: PadzMode) -> InputChain<RequestContent> {
     InputChain::new()
         .try_source(EditDirectSource { mode })
         .try_source(PipedSource::from_process())
         .default(RequestContent::Editor)
-}
-
-// =============================================================================
-// Pre-dispatch hooks
-// =============================================================================
-
-/// Resolves `create`'s content before dispatch. Wired via `#[dispatch(pre_dispatch = ...)]`.
-///
-/// This is what `GroupBuilder::input` does internally; padz spells it out
-/// because its command table is built by the `Dispatch` derive, which exposes
-/// `pre_dispatch` but not `input`. The chain needs the configured [`PadzMode`],
-/// which only exists on app state, so it is built here rather than at app-build
-/// time.
-pub fn resolve_create_content(
-    matches: &ArgMatches,
-    ctx: &mut CommandContext,
-) -> Result<(), HookError> {
-    let mode = mode_of(ctx)?;
-    insert_input(ctx, matches, CREATE_CONTENT, create_chain(mode))
-}
-
-/// Resolves `edit`'s content before dispatch (also used by `open`, which shares
-/// `edit`'s handler).
-pub fn resolve_edit_content(
-    matches: &ArgMatches,
-    ctx: &mut CommandContext,
-) -> Result<(), HookError> {
-    let mode = mode_of(ctx)?;
-    insert_input(ctx, matches, EDIT_CONTENT, edit_chain(mode))
-}
-
-/// Resolves `chain` against the deepest subcommand's matches and files the
-/// result in the request's [`Inputs`] bag under `name`.
-///
-/// Pre-dispatch hooks are handed the top-level matches, but the sources read
-/// args declared on the subcommand — the same matches the handler sees.
-fn insert_input(
-    ctx: &mut CommandContext,
-    matches: &ArgMatches,
-    name: &'static str,
-    chain: InputChain<RequestContent>,
-) -> Result<(), HookError> {
-    let resolved = chain
-        .resolve_with_source(get_deepest_matches(matches))
-        .map_err(|e| HookError::pre_dispatch(format!("input `{}`: {}", name, e)))?;
-
-    if !ctx.extensions.contains::<Inputs>() {
-        ctx.extensions.insert(Inputs::new());
-    }
-    ctx.extensions
-        .get_mut::<Inputs>()
-        .expect("Inputs just inserted")
-        .insert(name, resolved);
-    Ok(())
-}
-
-/// The configured pad mode, read from durable app state.
-fn mode_of(ctx: &CommandContext) -> Result<PadzMode, HookError> {
-    ctx.app_state
-        .get::<AppState>()
-        .map(|s| s.mode)
-        .ok_or_else(|| HookError::pre_dispatch("AppState not initialized in app_state"))
 }
 
 // =============================================================================

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -328,11 +328,7 @@ pub enum Commands {
     /// The content source (args / piped stdin / editor) is resolved before
     /// dispatch by `cli::input`'s chain; the handler receives the decision.
     #[command(alias = "n", display_order = 1)]
-    #[dispatch(
-        pure,
-        template = "modification_result",
-        pre_dispatch = crate::cli::input::resolve_create_content
-    )]
+    #[dispatch(skip)]
     Create {
         /// Force opening the editor (even in todos mode)
         #[arg(long, short = 'e', conflicts_with = "no_editor")]
@@ -514,11 +510,7 @@ pub enum Commands {
 
     /// Edit a pad in the editor
     #[command(alias = "e", display_order = 11, hide = true)]
-    #[dispatch(
-        pure,
-        template = "modification_result",
-        pre_dispatch = crate::cli::input::resolve_edit_content
-    )]
+    #[dispatch(skip)]
     Edit {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = active_pads_completer())]
@@ -530,12 +522,7 @@ pub enum Commands {
     /// Shares `edit`'s handler, and therefore needs `edit`'s input chain: the
     /// handler reads its content decision from the same named input.
     #[command(alias = "o", display_order = 12)]
-    #[dispatch(
-        pure,
-        handler = handlers::edit__handler,
-        template = "modification_result",
-        pre_dispatch = crate::cli::input::resolve_edit_content
-    )]
+    #[dispatch(skip)]
     Open {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -3,8 +3,9 @@
 //! # The seam this file protects
 //!
 //! Everything between argv and rendered output, in process: clap parsing, the
-//! pre-dispatch input chains, dispatch to the right handler, the view builders,
-//! the templates, the stylesheet, and the output-mode matrix. It is the only
+//! declaratively registered pre-dispatch input chains, dispatch to the right
+//! handler, the view builders, the templates, the stylesheet, and the
+//! output-mode matrix. It is the only
 //! layer that can catch a flag wired to the wrong parameter, a template that
 //! reads a field the result no longer carries, or a structured mode that
 //! accidentally renders human text.
@@ -31,6 +32,11 @@
 //! a spawned process has no pty, so its stdin can never *be* a terminal, and its
 //! terminal width can never be forced — the harness injects both as values. See
 //! each section for what its old file could not reach.
+//!
+//! `create`, `edit`, and `open` are registered explicitly at app assembly so
+//! Standout owns their input bags. The direct, piped, empty-pipe, editor, and
+//! shared-`open` cases below therefore also guard that composition-root wiring:
+//! if a named input is not installed, the handlers' typed lookups fail.
 
 mod support;
 
@@ -515,8 +521,8 @@ fn open_shares_edits_input_resolution() {
     fx.seed_pad(&state, "Orig", "");
     drop(state);
 
-    // `open` aliases `edit`'s handler; without its own chain registration the
-    // handler's input lookup would fail outright.
+    // `open` aliases `edit`'s handler; its explicit declarative registration
+    // must supply the same named input or typed retrieval fails outright.
     let (app, cmd) = fx.app(&["list"]);
     let result = TestHarness::new()
         .no_color()


### PR DESCRIPTION
for #208

## Context

Standout issue #209 confirmed that Padz does not need a state-aware input factory API to remove this part of its integration workaround. The composition root can copy `PadzMode` from the fully constructed app state, build the create/edit chains before moving that state into Standout, and explicitly register only the commands that need declarative inputs.

This removes Padz's copied pre-dispatch implementation of deepest-match selection, `Inputs` bag creation, and resolved-input insertion. Standout now owns those mechanics through `command_with(...).input(...)`, while the handlers continue using typed `CommandContextInput` retrieval.

This slice is independent of the remaining framework gaps. It deliberately leaves Padz's conditional naked-command selection and argv rewriting unchanged, and does not touch artifact/export handling or semantic-notice migration. Those #208 surfaces remain blocked on separate Standout capability decisions.

Behavior is preserved for direct, piped, empty-pipe, and editor input paths, including Padz's custom empty-pipe abort semantics and editor lifecycle cleanup. `open` retains the same edit handler and input chain, and all existing aliases, arguments, templates, structured output, and TestHarness stdin injection remain intact.

## Validation

- `cargo test -p padz cli::input` (21 passed)
- `cargo test -p padz --test harness` (44 passed)
- `pixi run test` (834 passed, 1 skipped)
- `pixi run lint` (12 checks passed)
