### PR TITLE
Adopt Standout 7.9 artifact and default command seams

### DIFF
--- a/CHANGELOG/unreleased-standout-7-9-integration.md
+++ b/CHANGELOG/unreleased-standout-7-9-integration.md
@@ -1,0 +1,11 @@
+- Upgrade the coherent Standout dependency family from 7.7.0 to 7.9.0. Naked
+  `padz` now uses Standout's invocation-aware default resolver (terminal stdin
+  lists; redirected stdin, including an empty pipe, creates) without local argv
+  injection. Exports now return owned bytes and semantic report facts from
+  `padzapp`; Standout selects and writes the suggested or explicit destination,
+  then renders the receipt-aware success report. Metadata warnings remain
+  machine-readable and artifact bytes/formats are unchanged. Structured export
+  reports now use Standout's `{ report, receipt }` envelope rather than the old
+  prose `messages` result. Owned-byte exports keep source data and the compressed
+  artifact plus encoder buffers live at peak, while API/handler handoff moves the
+  byte vector without another copy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "east-asian-width"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8c47de0fcde8bd09c98fc22e4ea10ed14b9c05bf02c309e1e743aee7d0d9f6"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,8 +1947,8 @@ dependencies = [
 
 [[package]]
 name = "standout"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "anyhow",
  "clap",
@@ -1966,16 +1972,16 @@ dependencies = [
 
 [[package]]
 name = "standout-bbparser"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "console 0.16.4",
 ]
 
 [[package]]
 name = "standout-dispatch"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "anyhow",
  "clap",
@@ -1986,8 +1992,8 @@ dependencies = [
 
 [[package]]
 name = "standout-input"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "clap",
  "once_cell",
@@ -1999,8 +2005,8 @@ dependencies = [
 
 [[package]]
 name = "standout-macros"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2009,8 +2015,8 @@ dependencies = [
 
 [[package]]
 name = "standout-pipe"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "thiserror 2.0.17",
  "wait-timeout",
@@ -2018,14 +2024,15 @@ dependencies = [
 
 [[package]]
 name = "standout-render"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "console 0.16.4",
  "cssparser",
  "csv",
  "dark-light",
  "deunicode",
+ "east-asian-width",
  "minijinja",
  "once_cell",
  "quick-xml",
@@ -2040,8 +2047,8 @@ dependencies = [
 
 [[package]]
 name = "standout-seeker"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "regex",
  "thiserror 2.0.17",
@@ -2049,8 +2056,8 @@ dependencies = [
 
 [[package]]
 name = "standout-test"
-version = "7.7.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.7.0#6fbe99944a81b8f77faa7e0954329c7a08c8bf69"
+version = "7.9.0"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
 dependencies = [
  "clap",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/arthur-debert/padz"
 
-# Resolve the standout family from the v7.7.0 git tag instead of crates.io.
+# Resolve the standout family from the v7.9.0 git tag instead of crates.io.
 #
 # WHY THIS PATCH EXISTS — it keeps the git-only test harness and the published
 # runtime crates in one dependency graph.
@@ -17,7 +17,7 @@ repository = "https://github.com/arthur-debert/padz"
 # newest *published* standout-test is 7.5.1, which does not compile against
 # standout 7.x: 7.6 made `RunResult` `#[non_exhaustive]` and added the `Error`
 # variant, and 7.5.1 matches it exhaustively. The fixed standout-test exists —
-# version 7.7.0 in the upstream repo — but carries `publish = false`, so it can
+# version 7.9.0 in the upstream repo — but carries `publish = false`, so it can
 # only be reached as a git dependency. And a git standout-test resolves its own
 # `standout` through a workspace *path* dep, which Cargo treats as a crate
 # distinct from crates.io's standout: the two `App` types then don't unify and
@@ -30,18 +30,18 @@ repository = "https://github.com/arthur-debert/padz"
 #
 # `[patch]` is workspace-local: it is not published and never reaches consumers
 # of the `padz` crate. Its three direct Standout dependencies are published at
-# 7.7.0 and downstream consumers resolve those ordinary requirements from
+# 7.9.0 and downstream consumers resolve those ordinary requirements from
 # crates.io; only the dev-only `standout-test` remains git-only.
 #
-# REMOVE THIS once standout-test 7.7.x is published to crates.io; it then goes
+# REMOVE THIS once a compatible standout-test is published to crates.io; it then goes
 # back to a plain dev-dependency version requirement in crates/padz/Cargo.toml.
 # Tracked upstream at arthur-debert/standout.
 [patch.crates-io]
-standout = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-bbparser = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-dispatch = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-input = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-macros = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-pipe = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-render = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
-standout-seeker = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-bbparser = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-dispatch = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-input = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-macros = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-pipe = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-render = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-seeker = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }

--- a/PADZ.md
+++ b/PADZ.md
@@ -537,51 +537,15 @@ padz delete 1 --verbose       # Delete and show updated list (default)
 
 ### Command Resolution
 
-PADZ has smart command resolution for convenience:
+A naked invocation adapts to stdin:
 
-1. **No arguments**: Runs `list`
+- At a terminal, `padz` means `padz list`.
+- With redirected stdin, including an empty pipe, `padz` means `padz create`.
 
-   ```bash
-   padz          # Same as: padz list
-   ```
-
-2. **Single integer**: Runs `view` (or `open`, configurable)
-
-   ```bash
-   padz 1        # Same as: padz view 1
-   ```
-
-3. **Starts with flag**: Assumed to be for `list`
-
-   ```bash
-   padz -g       # Same as: padz list -g
-   padz -s "foo" # Same as: padz list -s "foo"
-   ```
-
-4. **Known command**: Runs that command
-
-   ```bash
-   padz create
-   padz search
-   ```
-
-5. **Unknown text**: Assumed to be `create` with title
-
-   ```bash
-   padz "My note"    # Same as: padz create "My note"
-   ```
-
-This means you rarely need to type `create` or `list` explicitly.
-
-The key thing about this, called naked mode (no sub command specified) is how to integrate with the cli library.
-we want to avoid haveing to parse as much as possible.
-
-so the right way to do is;
-execute the command as it. if it has no subcommand , the library will generate an error.
-intercep the error. if it's a no command given error, now you will figure out what needs to be done.
-use the parsed data from the cli to figure out if you have no args (list), an int(view) and so on.
-
-one you do, inject the right string into the user generated input, then re ran the injected command through the cli library.
+Standout resolves that default from a non-consuming terminal fact after a
+successful naked parse. Explicit and nested commands, aliases, global flags,
+help, version, and invalid syntax keep their ordinary Clap behavior; the
+resolver neither rewrites argv locally nor reads the piped content.
 
 ## Output Format
 

--- a/PADZ.md
+++ b/PADZ.md
@@ -70,20 +70,17 @@ padz list
 
 # Create a new pad (opens $EDITOR)
 padz create
-padz new
 padz n
 
 # Create with a title
 padz create "My note title"
-padz "Quick note"
 
 # Create with piped content
-echo "TODO: Fix the bug" | padz new "Bug fix"
+echo "TODO: Fix the bug" | padz n "Bug fix"
 
 # View a pad
 padz view 1
 padz v 1
-padz 1          # Shortcut: naked integer
 
 # Edit a pad in $EDITOR
 padz open 1
@@ -104,7 +101,7 @@ padz ls -s "keyword"
 
 #### `padz create [title...] [flags]`
 
-Aliases: `new`, `n`, `c`
+Alias: `n`
 
 Create a new pad. If no content is piped, opens `$EDITOR`.
 
@@ -118,16 +115,15 @@ Create a new pad. If no content is piped, opens `$EDITOR`.
 ```bash
 padz create                              # Opens editor, prompts for title
 padz create "Shopping list"              # Opens editor with title set
-padz "Quick note"                        # Shortcut syntax
-padz -t "My Title" Some initial content  # Title + initial content
-echo "Content" | padz new "Title"        # Pipe content in
+echo "Content" | padz n "Title"          # Pipe content in
 padz create --global "Global note"       # Create in global scope
 ```
 
 **Shortcuts:**
 
-- Just `padz "Some text"` creates a new pad
-- Anything that isn't a recognized command is treated as a create
+- `padz n` is the short form of `padz create`.
+- A command name is required when arguments are present. Only a no-argument
+  invocation is resolved contextually; see [Command Resolution](#command-resolution).
 
 ### Viewing pad
 
@@ -192,12 +188,9 @@ View the content of a pad in your terminal.
 ```bash
 padz view 1      # View pad #1
 padz v 1         # Same (alias)
-padz 1           # Same (naked integer shortcut)
 padz view p1     # View pinned pad #1
 padz view d1     # View deleted pad #1 (if using --deleted flag)
 ```
-
-**Note:** The "naked integer" shortcut (`padz 1`) defaults to `view`. This is configurable in the code via `config.NakedIntCommand`.
 
 #### `padz peek <index> [flags]`
 

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -30,9 +30,9 @@ console = "0.15"
 directories = "6.0.0"
 dark-light = "0.2"
 once_cell = "1.19"
-standout = "7.7.0"
-standout-macros = "7.7.0"
-standout-dispatch = "7.7.0"
+standout = "7.9.0"
+standout-macros = "7.9.0"
+standout-dispatch = "7.9.0"
 # Standout's template engine. Needed directly to type the context providers in
 # cli::render, whose values standout hands to MiniJinja.
 minijinja = "2"
@@ -57,20 +57,20 @@ unicode-width = "0.2.2"
 # builder that restores them on drop. Re-exports `serial_test`, which every
 # harness test needs: those seams are process-global.
 #
-# Pinned to the v7.7.0 git tag rather than a crates.io version ON PURPOSE. The
+# Pinned to the v7.9.0 git tag rather than a crates.io version ON PURPOSE. The
 # newest *published* standout-test is 7.5.1, and it does not compile against the
-# standout 7.7.0 this crate uses: 7.6 made `RunResult` `#[non_exhaustive]` and
+# standout 7.9.0 this crate uses: 7.6 made `RunResult` `#[non_exhaustive]` and
 # added the `Error` variant, while 7.5.1 matches `RunResult` exhaustively. Its
 # `standout = "^7.5.1"` requirement claims that unification is fine, so Cargo
 # resolves it happily and then fails to build — the incompatibility is real but
-# invisible to semver. The v7.7.0 tag (matching our standout exactly) handles
+# invisible to semver. The v7.9.0 tag (matching our standout exactly) handles
 # `Error` and matches non-exhaustively; it is unpublished only because the crate
 # carries `publish = false` upstream. Tracked at arthur-debert/standout; swap this
-# back to a plain version requirement once 7.7.x is on crates.io.
+# back to a plain version requirement once a compatible release is on crates.io.
 #
 # Safe for `cargo publish`: a dev-dependency with no `version` key is stripped
 # from the packaged manifest, so this git source never reaches consumers.
-standout-test = { git = "https://github.com/arthur-debert/standout", tag = "v7.7.0" }
+standout-test = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
 # Direct, even though standout-test re-exports `serial`: the macro it re-exports
 # expands to `::serial_test` paths, so the crate has to be nameable here for
 # `#[serial]` to resolve. Same major as standout-test's own requirement, so the

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -22,7 +22,8 @@ use super::render::{
     MODIFICATION_VIEW, TERMINAL,
 };
 use super::setup::{
-    build_command, parse_cli, Cli, Commands, CompletionAction, CompletionShell, ConfigSubcommand,
+    build_command, invocation_default_command, parse_cli, Cli, Commands, CompletionAction,
+    CompletionShell, ConfigSubcommand,
 };
 use clapfig::{Clapfig, ConfigAction, SearchMode, SearchPath};
 use padzapp::config::PadzConfig;
@@ -53,22 +54,11 @@ pub fn run() -> Result<()> {
     // Initialize app state for handlers
     let app_state = create_app_state(&cli)?;
 
-    // Determine effective args: handle naked invocation by injecting synthetic command.
-    // Which command a bare `padz` means is decided by `cli::input::naked_command`
-    // (see its docs for why standout's `default_command` cannot express it).
-    let args: Vec<String> = if cli.command.is_none() {
-        vec![
-            "padz".to_string(),
-            super::input::naked_command_from_process().to_string(),
-        ]
-    } else {
-        std::env::args().collect()
-    };
-
-    // Build app with injected state, parse, and dispatch through unified path
+    // The same invocation-aware resolver ran during `parse_cli`, so the first
+    // parse and this stateful dispatch parse agree without local argv surgery.
     let app = build_dispatch_app(app_state);
     let cmd = build_command();
-    let matches = app.parse_from(cmd, args);
+    let matches = app.parse_from(cmd, std::env::args());
     handle_dispatch_result(app.dispatch(matches, output_mode))
 }
 
@@ -95,6 +85,7 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
 
     App::builder()
         .app_state(app_state)
+        .default_command_with(invocation_default_command)
         .templates(embed_templates!("src/cli/templates"))
         .template_ext(".jinja")
         .styles(embed_styles!("src/styles"))
@@ -128,7 +119,7 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
 
 /// Handle the result of a dispatch operation.
 ///
-/// Standout 7.6 reports handler, hook, and output failures through the native
+/// Standout reports handler, hook, and output failures through the native
 /// `RunResult::Error` variant. Under 6.2 there was no such variant: failures
 /// arrived as `Handled("Error: ...")` and had to be detected by string prefix.
 /// The error message still carries standout's `Error: ` prefix, which is
@@ -150,10 +141,12 @@ fn handle_dispatch_result(result: RunResult) -> Result<()> {
                 msg.trim_start_matches("Error: ").to_string(),
             ));
         }
-        RunResult::Binary(data, filename) => {
-            std::fs::write(&filename, &data)
-                .map_err(|e| padzapp::error::PadzError::Api(e.to_string()))?;
-            println!("Exported to {}", filename);
+        RunResult::Artifact(artifact) => {
+            // Standout has already selected and written the final destination.
+            // Its receipt makes the report truthful; Padz only emits it.
+            if let Some(report) = artifact.report() {
+                print!("{}", report);
+            }
         }
         RunResult::Silent => {}
         RunResult::NoMatch(matches) => {

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -84,6 +84,15 @@ pub fn run() -> Result<()> {
 /// templates, styles, and dispatch table the binary uses. Building the app twice —
 /// once for the binary, once for tests — is exactly the drift this avoids.
 pub fn build_dispatch_app(app_state: AppState) -> App {
+    // Input policy depends on the configured mode, so construct the chains at
+    // assembly time before moving the durable state into Standout. These three
+    // commands are skipped by the Dispatch derive and registered explicitly so
+    // Standout owns deepest-match resolution and the request-scoped Inputs bag.
+    let mode = app_state.mode;
+    let create_content = super::input::create_chain(mode);
+    let edit_content = super::input::edit_chain(mode);
+    let open_content = super::input::edit_chain(mode);
+
     App::builder()
         .app_state(app_state)
         .templates(embed_templates!("src/cli/templates"))
@@ -95,6 +104,24 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
         .context_fn(MODIFICATION_VIEW, modification_view_provider)
         .commands(Commands::dispatch_config())
         .expect("Failed to configure commands")
+        .command_with("create", super::handlers::create__handler, |config| {
+            config
+                .template("modification_result")
+                .input(super::input::CREATE_CONTENT, create_content)
+        })
+        .expect("Failed to configure create input")
+        .command_with("edit", super::handlers::edit__handler, |config| {
+            config
+                .template("modification_result")
+                .input(super::input::EDIT_CONTENT, edit_content)
+        })
+        .expect("Failed to configure edit input")
+        .command_with("open", super::handlers::edit__handler, |config| {
+            config
+                .template("modification_result")
+                .input(super::input::EDIT_CONTENT, open_content)
+        })
+        .expect("Failed to configure open input")
         .build()
         .expect("Failed to build app")
 }

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -23,13 +23,13 @@ use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
 use padzapp::model::{extract_title_and_body, Scope};
 use padzapp::store::fs::FileStore;
-use standout::cli::{CommandContext, CommandContextInput, Output};
+use standout::cli::{Artifact, CommandContext, CommandContextInput, Output};
 use standout_macros::handler;
 use std::cell::RefCell;
 
 use super::result::{
-    ListRequest, MessagesResult, ModificationRequest, ModificationResult, PadContent,
-    PadContentResult, PadListResult, PathResult, UuidResult,
+    ExportReportResult, ListRequest, MessagesResult, ModificationRequest, ModificationResult,
+    PadContent, PadContentResult, PadListResult, PathResult, UuidResult,
 };
 
 // =============================================================================
@@ -316,7 +316,7 @@ impl<'a> ScopedApi<'a> {
         json: bool,
         with_metadata: bool,
         nesting: NestingMode,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<ExportReportResult>, anyhow::Error> {
         let result = if let Some(title) = single_file {
             self.call(|api, scope| api.export_pads_single_file(scope, indexes, title, nesting))?
         } else if json {
@@ -324,7 +324,19 @@ impl<'a> ScopedApi<'a> {
         } else {
             self.call(|api, scope| api.export_pads(scope, indexes, nesting, with_metadata))?
         };
-        self.messages(result)
+        Ok(match result {
+            padzapp::commands::export::ExportOutcome::Empty { format } => {
+                Output::Render(ExportReportResult::empty(format))
+            }
+            padzapp::commands::export::ExportOutcome::Artifact(artifact) => {
+                let report = artifact.report.into();
+                Output::Artifact(
+                    Artifact::new(artifact.bytes)
+                        .suggest_destination(artifact.suggested_filename)
+                        .with_report(report),
+                )
+            }
+        })
     }
 
     pub fn import_pads(
@@ -1145,7 +1157,7 @@ pub fn export(
     #[flag] flat: bool,
     #[flag] tree: bool,
     #[flag] indented: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<ExportReportResult>, anyhow::Error> {
     let nesting = parse_nesting_mode(flat, tree, indented);
     api(ctx).export_pads(
         &indexes,

--- a/crates/padz/src/cli/input.rs
+++ b/crates/padz/src/cli/input.rs
@@ -1,4 +1,4 @@
-//! Request-scoped input resolution for `create`/`edit`, and naked invocation.
+//! Request-scoped input resolution for `create` and `edit`.
 //!
 //! # Why this module exists
 //!
@@ -44,12 +44,8 @@
 //!   so the chain resolves to [`RequestContent::Editor`] and stops there; it
 //!   does not try to launch anything.
 //! - **`ClipboardSource`**: padz does not, and did not, read the clipboard as a
-//!   create/edit input source. See [`naked_command`]'s sibling note in
-//!   `cli::mod` docs — the clipboard is written to after a pad is saved, never
-//!   read from to prefill one.
-//! - **`App::default_command`**: it names one static command, but padz's naked
-//!   invocation picks between two depending on whether stdin is piped. See
-//!   [`naked_command`].
+//!   create/edit input source. The clipboard is written to after a pad is
+//!   saved, never read from to prefill one.
 
 use clap::ArgMatches;
 use padzapp::config::PadzMode;
@@ -235,39 +231,6 @@ pub(super) fn edit_chain(mode: PadzMode) -> InputChain<RequestContent> {
         .try_source(EditDirectSource { mode })
         .try_source(PipedSource::from_process())
         .default(RequestContent::Editor)
-}
-
-// =============================================================================
-// Naked invocation
-// =============================================================================
-
-/// Which command a naked `padz` stands for: `create` when stdin is piped,
-/// `list` otherwise.
-///
-/// # Why this is not `App::default_command`
-///
-/// Standout 7.6 has a declarative default command, but it names exactly one
-/// static command (`insert_default_command` splices that literal into argv).
-/// Padz's rule is *conditional* — the whole point is that `cat notes | padz`
-/// captures while a bare `padz` reads — and 7.6 offers no predicate hook for
-/// that. Standout's default also only fires inside `App::run`, and padz drives
-/// `parse_from` + `dispatch` so it can build app state and resolve the output
-/// mode first, so the setting would not apply on that path regardless.
-///
-/// So this stays application-owned, but it is a pure function of a
-/// [`StdinReader`] rather than an inline `is_terminal()` probe, which is what
-/// makes both arms testable without a pty.
-pub fn naked_command(reader: &dyn StdinReader) -> &'static str {
-    if reader.is_terminal() {
-        "list"
-    } else {
-        "create"
-    }
-}
-
-/// [`naked_command`] against the process's real stdin (honoring test overrides).
-pub fn naked_command_from_process() -> &'static str {
-    naked_command(&DefaultStdin)
 }
 
 // =============================================================================
@@ -554,24 +517,5 @@ mod tests {
             &edit_matches(&["1", "Inline"]),
         );
         assert_eq!(value, RequestContent::Direct("Inline".into()));
-    }
-
-    // --- naked invocation ---
-
-    #[test]
-    fn naked_padz_lists_on_a_terminal() {
-        assert_eq!(naked_command(&MockStdin::terminal()), "list");
-    }
-
-    #[test]
-    fn naked_padz_creates_when_piped() {
-        assert_eq!(naked_command(&MockStdin::piped("captured")), "create");
-    }
-
-    /// An empty pipe is still a pipe: naked padz routes to `create`, which then
-    /// aborts on the empty content rather than listing.
-    #[test]
-    fn naked_padz_creates_even_when_the_pipe_is_empty() {
-        assert_eq!(naked_command(&MockStdin::piped_empty()), "create");
     }
 }

--- a/crates/padz/src/cli/input.rs
+++ b/crates/padz/src/cli/input.rs
@@ -53,14 +53,13 @@
 
 use clap::ArgMatches;
 use padzapp::config::PadzMode;
-use standout::cli::{get_deepest_matches, CommandContext, HookError};
 use standout::input::env::{DefaultStdin, StdinReader};
-use standout::input::{InputChain, InputCollector, InputError, Inputs};
+use standout::input::{InputChain, InputCollector, InputError};
 use std::sync::Arc;
 
 // `split_indexes_and_content` is the handlers' own arg-splitting rule; the edit
 // source must apply the same one to know whether trailing words are content.
-use super::handlers::{split_indexes_and_content, AppState};
+use super::handlers::split_indexes_and_content;
 
 /// The name the `create` content input is registered and looked up under.
 pub const CREATE_CONTENT: &str = "create_content";
@@ -223,7 +222,7 @@ impl InputCollector<RequestContent> for PipedSource {
 // =============================================================================
 
 /// The `create` content chain: direct args, then piped stdin, then the editor.
-fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
+pub(super) fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
     InputChain::new()
         .try_source(CreateDirectSource { mode })
         .try_source(PipedSource::from_process())
@@ -231,73 +230,11 @@ fn create_chain(mode: PadzMode) -> InputChain<RequestContent> {
 }
 
 /// The `edit` content chain: inline todos content, then piped stdin, then the editor.
-fn edit_chain(mode: PadzMode) -> InputChain<RequestContent> {
+pub(super) fn edit_chain(mode: PadzMode) -> InputChain<RequestContent> {
     InputChain::new()
         .try_source(EditDirectSource { mode })
         .try_source(PipedSource::from_process())
         .default(RequestContent::Editor)
-}
-
-// =============================================================================
-// Pre-dispatch hooks
-// =============================================================================
-
-/// Resolves `create`'s content before dispatch. Wired via `#[dispatch(pre_dispatch = ...)]`.
-///
-/// This is what `GroupBuilder::input` does internally; padz spells it out
-/// because its command table is built by the `Dispatch` derive, which exposes
-/// `pre_dispatch` but not `input`. The chain needs the configured [`PadzMode`],
-/// which only exists on app state, so it is built here rather than at app-build
-/// time.
-pub fn resolve_create_content(
-    matches: &ArgMatches,
-    ctx: &mut CommandContext,
-) -> Result<(), HookError> {
-    let mode = mode_of(ctx)?;
-    insert_input(ctx, matches, CREATE_CONTENT, create_chain(mode))
-}
-
-/// Resolves `edit`'s content before dispatch (also used by `open`, which shares
-/// `edit`'s handler).
-pub fn resolve_edit_content(
-    matches: &ArgMatches,
-    ctx: &mut CommandContext,
-) -> Result<(), HookError> {
-    let mode = mode_of(ctx)?;
-    insert_input(ctx, matches, EDIT_CONTENT, edit_chain(mode))
-}
-
-/// Resolves `chain` against the deepest subcommand's matches and files the
-/// result in the request's [`Inputs`] bag under `name`.
-///
-/// Pre-dispatch hooks are handed the top-level matches, but the sources read
-/// args declared on the subcommand — the same matches the handler sees.
-fn insert_input(
-    ctx: &mut CommandContext,
-    matches: &ArgMatches,
-    name: &'static str,
-    chain: InputChain<RequestContent>,
-) -> Result<(), HookError> {
-    let resolved = chain
-        .resolve_with_source(get_deepest_matches(matches))
-        .map_err(|e| HookError::pre_dispatch(format!("input `{}`: {}", name, e)))?;
-
-    if !ctx.extensions.contains::<Inputs>() {
-        ctx.extensions.insert(Inputs::new());
-    }
-    ctx.extensions
-        .get_mut::<Inputs>()
-        .expect("Inputs just inserted")
-        .insert(name, resolved);
-    Ok(())
-}
-
-/// The configured pad mode, read from durable app state.
-fn mode_of(ctx: &CommandContext) -> Result<PadzMode, HookError> {
-    ctx.app_state
-        .get::<AppState>()
-        .map(|s| s.mode)
-        .ok_or_else(|| HookError::pre_dispatch("AppState not initialized in app_state"))
 }
 
 // =============================================================================

--- a/crates/padz/src/cli/mod.rs
+++ b/crates/padz/src/cli/mod.rs
@@ -64,11 +64,11 @@
 //! ## Module Structure
 //!
 //! - `commands`: App construction, state wiring, and dispatch
-//! - `input`: Declarative request-input precedence (create/edit) + naked invocation
+//! - `input`: Declarative request-input precedence for create/edit
 //! - `handlers`: Thin typed adapters — extract args, call the API, return a typed result
 //! - `result`: The typed, mode-independent result each handler returns
 //! - `render`: Render-time view derivation for standout's templates
-//! - `setup`: Argument parsing via clap, help text
+//! - `setup`: Argument parsing via clap, help text, and naked-invocation resolution
 
 pub mod clipboard;
 pub mod commands;

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -1,7 +1,7 @@
 //! # Typed handler results
 //!
 //! Every padz handler returns one of the types in this module (or `Output::Silent` /
-//! `Output::Binary`). A result is **mode-independent**: the same value is serialized
+//! `Output::Artifact`). A result is **mode-independent**: the same value is serialized
 //! once by standout and then either fed to a MiniJinja template (human modes) or
 //! emitted directly (structured modes). Handlers therefore never look at
 //! `OutputMode`, never branch on it, and never print.
@@ -99,6 +99,100 @@ pub struct MessagesResult {
 impl MessagesResult {
     pub fn new(messages: Vec<CmdMessage>) -> Self {
         Self { messages }
+    }
+}
+
+/// The machine-readable report carried by an export artifact.
+///
+/// Standout wraps this value with its own `receipt` after the final write. An
+/// empty selection renders this value directly with `status = "empty"` and
+/// never enters the artifact path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportReportResult {
+    pub status: ExportStatus,
+    pub format: ExportFormat,
+    pub exported: usize,
+    pub warnings: Vec<ExportWarning>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportStatus {
+    Empty,
+    Exported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFormat {
+    Archive,
+    MetadataArchive,
+    JsonArchive,
+    SingleFile,
+}
+
+/// A CLI-owned projection of a semantic core warning.
+///
+/// The template owns the sentence; structured modes retain the warning kind,
+/// complete title list, count, preview, and overflow count as facts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExportWarning {
+    MetadataUnavailable {
+        count: usize,
+        titles: Vec<String>,
+        preview: Vec<String>,
+        additional: usize,
+    },
+}
+
+impl ExportReportResult {
+    pub fn empty(format: padzapp::commands::export::ExportFormat) -> Self {
+        Self {
+            status: ExportStatus::Empty,
+            format: format.into(),
+            exported: 0,
+            warnings: Vec::new(),
+        }
+    }
+}
+
+impl From<padzapp::commands::export::ExportReport> for ExportReportResult {
+    fn from(report: padzapp::commands::export::ExportReport) -> Self {
+        Self {
+            status: ExportStatus::Exported,
+            format: report.format.into(),
+            exported: report.exported,
+            warnings: report.warnings.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::export::ExportFormat> for ExportFormat {
+    fn from(format: padzapp::commands::export::ExportFormat) -> Self {
+        match format {
+            padzapp::commands::export::ExportFormat::Archive => Self::Archive,
+            padzapp::commands::export::ExportFormat::MetadataArchive => Self::MetadataArchive,
+            padzapp::commands::export::ExportFormat::JsonArchive => Self::JsonArchive,
+            padzapp::commands::export::ExportFormat::SingleFile => Self::SingleFile,
+        }
+    }
+}
+
+impl From<padzapp::commands::export::ExportWarning> for ExportWarning {
+    fn from(warning: padzapp::commands::export::ExportWarning) -> Self {
+        match warning {
+            padzapp::commands::export::ExportWarning::MetadataUnavailable { titles } => {
+                let count = titles.len();
+                let preview = titles.iter().take(3).cloned().collect();
+                Self::MetadataUnavailable {
+                    count,
+                    titles,
+                    preview,
+                    additional: count.saturating_sub(3),
+                }
+            }
+        }
     }
 }
 

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -328,11 +328,7 @@ pub enum Commands {
     /// The content source (args / piped stdin / editor) is resolved before
     /// dispatch by `cli::input`'s chain; the handler receives the decision.
     #[command(alias = "n", display_order = 1)]
-    #[dispatch(
-        pure,
-        template = "modification_result",
-        pre_dispatch = crate::cli::input::resolve_create_content
-    )]
+    #[dispatch(skip)]
     Create {
         /// Force opening the editor (even in todos mode)
         #[arg(long, short = 'e', conflicts_with = "no_editor")]
@@ -514,11 +510,7 @@ pub enum Commands {
 
     /// Edit a pad in the editor
     #[command(alias = "e", display_order = 11, hide = true)]
-    #[dispatch(
-        pure,
-        template = "modification_result",
-        pre_dispatch = crate::cli::input::resolve_edit_content
-    )]
+    #[dispatch(skip)]
     Edit {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = active_pads_completer())]
@@ -530,12 +522,7 @@ pub enum Commands {
     /// Shares `edit`'s handler, and therefore needs `edit`'s input chain: the
     /// handler reads its content decision from the same named input.
     #[command(alias = "o", display_order = 12)]
-    #[dispatch(
-        pure,
-        handler = handlers::edit__handler,
-        template = "modification_result",
-        pre_dispatch = crate::cli::input::resolve_edit_content
-    )]
+    #[dispatch(skip)]
     Open {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -3,7 +3,9 @@ use super::complete::{
 };
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use once_cell::sync::Lazy;
-use standout::cli::{render_help_with_topics, App, CommandGroup, Dispatch, HelpConfig};
+use standout::cli::{
+    render_help_with_topics, App, CommandGroup, DefaultCommandContext, Dispatch, HelpConfig,
+};
 use standout::topics::TopicRegistry;
 use standout::OutputMode;
 
@@ -100,9 +102,25 @@ static HELP_TOPICS: Lazy<TopicRegistry> = Lazy::new(|| {
 ///   `--help`/topics through Standout. 7.6 additionally rejects an app that
 ///   configures topics or command groups without it.
 fn app_with_topics() -> App {
-    let mut app = App::new().help_handling(true);
+    let mut app = App::new()
+        .help_handling(true)
+        .default_command_with(invocation_default_command);
     *app.registry_mut() = HELP_TOPICS.clone();
     app
+}
+
+/// Select the command for a successfully parsed naked invocation without
+/// consuming stdin. Explicit commands, help, version, and usage errors never
+/// reach this resolver; Standout centralizes those precedence rules.
+pub(super) fn invocation_default_command(ctx: &DefaultCommandContext<'_>) -> Option<String> {
+    Some(
+        if ctx.stdin_is_piped() {
+            "create"
+        } else {
+            "list"
+        }
+        .to_string(),
+    )
 }
 
 /// Parse a topic file content into a Topic struct
@@ -657,7 +675,7 @@ pub enum Commands {
 
     /// Export pads to a tar.gz archive (or single file with --single-file)
     #[command(display_order = 21)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "export")]
     Export {
         /// Export all pads to a single file with this title (format detected from extension: .md for markdown, otherwise text)
         #[arg(long, value_name = "TITLE", conflicts_with = "json")]

--- a/crates/padz/src/cli/templates/export.jinja
+++ b/crates/padz/src/cli/templates/export.jinja
@@ -1,0 +1,19 @@
+{#-
+  Empty exports render the handler result directly. Artifact success reports
+  arrive only after Standout completes the final write, under its
+  `{ report, receipt }` envelope.
+-#}
+{%- if receipt is defined -%}
+{%- for warning in report.warnings -%}
+{%- if warning.kind == "metadata_unavailable" -%}
+[warning]{{ warning.count }} .txt pad(s) exported without metadata (txt has no metadata format): {{ warning.preview | join(", ") }}{% if warning.additional > 0 %} (+ {{ warning.additional }} more){% endif %}[/warning]{{ "" | nl }}
+{%- endif -%}
+{%- endfor -%}
+{%- if report.format == "single_file" -%}
+[success]Exported {{ report.exported }} pads to {{ receipt.destination }}[/success]{{ "" | nl }}
+{%- else -%}
+[success]Exported to {{ receipt.destination }}[/success]{{ "" | nl }}
+{%- endif -%}
+{%- else -%}
+[info]No pads to export.[/info]{{ "" | nl }}
+{%- endif -%}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,7 +26,8 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    MessagesResult, ModificationResult, PadContentResult, PadListResult, PathResult, UuidResult,
+    ExportFormat, ExportStatus, ExportWarning, MessagesResult, ModificationResult,
+    PadContentResult, PadListResult, PathResult, UuidResult,
 };
 use padzapp::commands::{CmdNotice, NestingMode};
 use standout::cli::Output;
@@ -42,6 +43,8 @@ where
         Output::Render(value) => value,
         Output::Silent => panic!("expected Output::Render, got Silent"),
         Output::Binary { .. } => panic!("expected Output::Render, got Binary"),
+        Output::Artifact(_) => panic!("expected Output::Render, got Artifact"),
+        _ => panic!("expected Output::Render, got a newer output variant"),
     }
 }
 
@@ -482,6 +485,64 @@ fn uuid_maps_selectors_to_one_uuid_each() {
         "uuid handler should return a parseable uuid, got {:?}",
         result.uuids[0]
     );
+}
+
+// =============================================================================
+// Export artifacts
+// =============================================================================
+
+#[test]
+fn export_maps_core_bytes_suggestion_and_report_without_writing() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "plain text", "body");
+    let ctx = support::ctx_with_state(state);
+
+    let Output::Artifact(artifact) =
+        handlers::export(&ctx, None, false, true, vec![], false, false, false)
+            .expect("export handler failed")
+    else {
+        panic!("expected an artifact");
+    };
+
+    assert_eq!(&artifact.bytes()[..2], &[0x1f, 0x8b], "tar.gz magic");
+    assert!(artifact
+        .suggested_destination()
+        .is_some_and(|path| path.to_string_lossy().ends_with(".meta.gz")));
+
+    let report = artifact.report().expect("artifact report");
+    assert_eq!(report.status, ExportStatus::Exported);
+    assert_eq!(report.format, ExportFormat::MetadataArchive);
+    assert_eq!(report.exported, 1);
+    assert!(matches!(
+        &report.warnings[0],
+        ExportWarning::MetadataUnavailable {
+            count: 1,
+            additional: 0,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn empty_export_stays_a_non_artifact_result() {
+    let fx = Fixture::new();
+    let ctx = fx.ctx();
+
+    let report = rendered(handlers::export(
+        &ctx,
+        None,
+        false,
+        false,
+        vec![],
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(report.status, ExportStatus::Empty);
+    assert_eq!(report.format, ExportFormat::Archive);
+    assert_eq!(report.exported, 0);
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -3,8 +3,9 @@
 //! # The seam this file protects
 //!
 //! Everything between argv and rendered output, in process: clap parsing, the
-//! pre-dispatch input chains, dispatch to the right handler, the view builders,
-//! the templates, the stylesheet, and the output-mode matrix. It is the only
+//! declaratively registered pre-dispatch input chains, dispatch to the right
+//! handler, the view builders, the templates, the stylesheet, and the
+//! output-mode matrix. It is the only
 //! layer that can catch a flag wired to the wrong parameter, a template that
 //! reads a field the result no longer carries, or a structured mode that
 //! accidentally renders human text.
@@ -31,6 +32,11 @@
 //! a spawned process has no pty, so its stdin can never *be* a terminal, and its
 //! terminal width can never be forced — the harness injects both as values. See
 //! each section for what its old file could not reach.
+//!
+//! `create`, `edit`, and `open` are registered explicitly at app assembly so
+//! Standout owns their input bags. The direct, piped, empty-pipe, editor, and
+//! shared-`open` cases below therefore also guard that composition-root wiring:
+//! if a named input is not installed, the handlers' typed lookups fail.
 
 mod support;
 
@@ -515,8 +521,8 @@ fn open_shares_edits_input_resolution() {
     fx.seed_pad(&state, "Orig", "");
     drop(state);
 
-    // `open` aliases `edit`'s handler; without its own chain registration the
-    // handler's input lookup would fail outright.
+    // `open` aliases `edit`'s handler; its explicit declarative registration
+    // must supply the same named input or typed retrieval fails outright.
     let (app, cmd) = fx.app(&["list"]);
     let result = TestHarness::new()
         .no_color()

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -166,6 +166,85 @@ fn an_unknown_command_does_not_dispatch() {
     result.assert_error_kind(RunErrorKind::ClapUsage);
 }
 
+// =============================================================================
+// Invocation-aware default command
+// =============================================================================
+
+#[test]
+#[serial]
+fn a_naked_invocation_lists_when_stdin_is_a_terminal() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "existing", "body");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let result =
+        TestHarness::new()
+            .interactive_stdin()
+            .run(&app, cmd, fx.argv(&["--output", "json"]));
+
+    result.assert_success();
+    assert_eq!(
+        pads(result.stdout()),
+        vec![("existing".into(), "existing\n\nbody".into())]
+    );
+}
+
+#[test]
+#[serial]
+fn a_naked_invocation_creates_from_piped_stdin() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new()
+        .piped_stdin("Captured\n\nFrom a pipe")
+        .run(&app, cmd, fx.argv(&["--output", "json"]));
+
+    result.assert_success();
+    assert_eq!(
+        pads(result.stdout()),
+        vec![("Captured".into(), "Captured\n\nFrom a pipe".into())]
+    );
+}
+
+#[test]
+#[serial]
+fn a_naked_invocation_with_an_empty_pipe_aborts_create() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new()
+        .piped_stdin("")
+        .run(&app, cmd, fx.argv(&["--output", "json"]));
+
+    result.assert_success();
+    assert_eq!(pads(result.stdout()), Vec::<(String, String)>::new());
+    assert!(messages(result.stdout())
+        .iter()
+        .any(|message| message.contains("Aborted: empty content")));
+}
+
+#[test]
+#[serial]
+fn an_explicit_command_keeps_precedence_over_piped_stdin() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "existing", "");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new().piped_stdin("must not create").run(
+        &app,
+        cmd,
+        fx.argv(&["list", "--output", "json"]),
+    );
+
+    result.assert_success();
+    assert_eq!(
+        pads(result.stdout()),
+        vec![("existing".into(), "existing".into())]
+    );
+}
+
 #[test]
 #[serial]
 fn search_flag_reaches_the_handler_as_a_filter() {
@@ -1246,6 +1325,135 @@ fn an_empty_result_stays_valid_in_every_structured_mode() {
 // =============================================================================
 // Output file
 // =============================================================================
+
+#[test]
+#[serial]
+fn export_artifact_uses_the_explicit_destination_and_reports_its_receipt() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "exported", "body");
+    drop(state);
+
+    let target = fx.root().join("chosen.tar.gz");
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        fx.argv(&["export", "--output-file-path", target.to_str().unwrap()]),
+    );
+
+    result.assert_success();
+    assert_eq!(&result.artifact_bytes().unwrap()[..2], &[0x1f, 0x8b]);
+    result.assert_artifact_written_to(&target);
+    result.assert_artifact_report_contains(&format!("Exported to {}", target.display()));
+    assert_eq!(
+        std::fs::read(&target).unwrap(),
+        result.artifact_bytes().unwrap()
+    );
+}
+
+#[test]
+#[serial]
+fn export_artifact_report_is_machine_readable_and_keeps_metadata_warnings() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "plain text", "body");
+    drop(state);
+
+    let target = fx.root().join("metadata.tar.gz");
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&[
+            "export",
+            "--with-metadata",
+            "--output",
+            "json",
+            "--output-file-path",
+            target.to_str().unwrap(),
+        ]),
+    );
+
+    result.assert_success();
+    let report: serde_json::Value =
+        serde_json::from_str(result.artifact_report().unwrap()).unwrap();
+    assert_eq!(report["report"]["status"], "exported");
+    assert_eq!(report["report"]["format"], "metadata_archive");
+    assert_eq!(report["report"]["exported"], 1);
+    assert_eq!(
+        report["report"]["warnings"][0]["kind"],
+        "metadata_unavailable"
+    );
+    assert_eq!(report["report"]["warnings"][0]["titles"][0], "plain text");
+    assert_eq!(
+        report["receipt"]["destination"],
+        target.display().to_string()
+    );
+}
+
+#[test]
+#[serial]
+fn export_artifact_uses_its_suggested_single_file_destination() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "one", "body");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new().no_color().cwd(fx.root()).run(
+        &app,
+        cmd,
+        fx.argv(&["export", "--single-file", "My / Export.md"]),
+    );
+
+    result.assert_success();
+    result.assert_artifact_suggested_destination("My _ Export.md");
+    result.assert_artifact_written_to("My _ Export.md");
+    result.assert_artifact_report_contains("Exported 1 pads to My _ Export.md");
+    let written = std::fs::read_to_string(fx.root().join("My _ Export.md")).unwrap();
+    assert!(written.contains("## one"));
+}
+
+#[test]
+#[serial]
+fn empty_export_remains_non_artifact_output() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new()
+        .no_color()
+        .run(&app, cmd, fx.argv(&["export"]));
+
+    result.assert_success();
+    assert!(result.artifact().is_none());
+    result.assert_stdout_contains("No pads to export.");
+}
+
+#[test]
+#[serial]
+fn artifact_write_failure_is_typed_and_emits_no_success_report() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "unwritten", "");
+    drop(state);
+
+    let target = fx.root();
+    let (app, cmd) = fx.read_app();
+    let result = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        fx.argv(&["export", "--output-file-path", target.to_str().unwrap()]),
+    );
+
+    result.assert_error();
+    result.assert_exit_status(ExitStatus::FAILURE);
+    result.assert_error_kind(RunErrorKind::FinalWrite(OutputKind::Artifact));
+    assert!(
+        result.artifact().is_none(),
+        "failed writes have no receipt/report"
+    );
+    assert!(!result.error().unwrap_or_default().contains("Exported to"));
+}
 
 #[test]
 #[serial]

--- a/crates/padz/tests/naked_invocation_e2e.rs
+++ b/crates/padz/tests/naked_invocation_e2e.rs
@@ -2,31 +2,14 @@
 //!
 //! ## The real boundary this file protects
 //!
-//! **`cli::run`'s own wiring, which no in-process harness can reach.**
+//! **`cli::run`'s two-stage parse/state wiring, which the in-process app harness
+//! does not enter.**
 //!
-//! Which command a bare `padz` means is decided by `cli::run` *before* dispatch:
-//! it calls `input::naked_command_from_process()` and injects a synthetic
-//! command into the argv it hands to standout. `TestHarness` drives
-//! `App::run_to_string`, which starts at dispatch — so it enters *after* the
-//! decision this file is about, and cannot test it. Only a real process runs
-//! `run()` from the top.
-//!
-//! `naked_command`'s own logic (terminal → `list`, pipe → `create`, empty pipe →
-//! `create`-then-abort) is not what these tests protect: that is covered at a
-//! smaller seam by the unit tests in `cli::input`, which inject a `MockStdin`
-//! and assert all three arms directly. What is left here, and only here, is that
-//! `run()` actually *consults* that decision and injects the command it names —
-//! a wiring fact whose only observation point is the process.
-//!
-//! ## What used to live here
-//!
-//! This file was `input_precedence_e2e.rs`, and it owned the whole create/edit
-//! input-precedence suite. Those cases moved to `tests/harness.rs`, which drives
-//! the same input chain in process through an injected stdin reader. The move
-//! removed a hole rather than trading one for another: this file's own header
-//! used to note that a spawned process has no pty, so a *terminal* stdin — and
-//! therefore the editor arm — was unreachable. The harness injects the reader,
-//! so it tests both arms; see `a_terminal_stdin_routes_create_to_the_editor`.
+//! Standout now owns the invocation-aware decision in both the initial parsing
+//! app and the stateful dispatch app. `tests/harness.rs` covers terminal,
+//! piped, piped-empty, globals, and explicit-command precedence at the smaller
+//! in-process seam. This single smoke remains to prove the real binary's first
+//! parse also installs the resolver before it builds command-specific state.
 
 use assert_cmd::Command;
 use std::fs;
@@ -122,23 +105,12 @@ impl Fixture {
             })
             .collect()
     }
-
-    fn messages(json: &str) -> Vec<String> {
-        let v: serde_json::Value = serde_json::from_str(json).unwrap();
-        v["messages"]
-            .as_array()
-            .map(|ms| {
-                ms.iter()
-                    .map(|m| m["content"].as_str().unwrap_or_default().to_string())
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
 }
 
 /// `cat file | padz` captures the pipe as a new pad.
 ///
-/// Proves `run()` injects `create` for a piped naked invocation.
+/// Proves both parses resolve the same default and the stateful dispatch reads
+/// the still-unconsumed pipe.
 #[test]
 fn naked_padz_with_a_pipe_creates() {
     let f = Fixture::new();
@@ -146,39 +118,5 @@ fn naked_padz_with_a_pipe_creates() {
     assert_eq!(
         Fixture::pads(&out),
         vec![("Captured".into(), "Captured\n\nFrom a pipe".into())]
-    );
-}
-
-/// A naked invocation whose pipe is empty routes to `create`, which then aborts.
-/// It must not silently fall back to listing.
-#[test]
-fn naked_padz_with_an_empty_pipe_aborts_the_create() {
-    let f = Fixture::new();
-    let out = f.run_piped(&["--output", "json"], "");
-    assert!(
-        Fixture::messages(&out)
-            .iter()
-            .any(|m| m.contains("Aborted: empty content")),
-        "expected the create abort, got: {out}"
-    );
-}
-
-/// A naked invocation with no pipe lists.
-///
-/// `.output()` gives the child a null stdin, which is not a terminal — so padz
-/// sees "piped" and this asserts the *create* arm's abort rather than a listing.
-/// The terminal arm genuinely needs a pty, and is covered instead by
-/// `cli::input`'s unit tests against `MockStdin::terminal()`.
-#[test]
-fn naked_padz_without_a_terminal_stdin_routes_to_create() {
-    let f = Fixture::new();
-    f.run(&["create", "--output", "json", "--no-editor", "Existing"]);
-
-    let out = f.run_piped(&["--output", "json"], "");
-    assert!(
-        Fixture::messages(&out)
-            .iter()
-            .any(|m| m.contains("Aborted: empty content")),
-        "a non-terminal stdin must route to create, not list: {out}"
     );
 }

--- a/crates/padzapp/src/api/transfer.rs
+++ b/crates/padzapp/src/api/transfer.rs
@@ -15,7 +15,7 @@ impl<S: DataStore> PadzApi<S> {
         indexes: &[I],
         nesting: commands::NestingMode,
         with_metadata: bool,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::export::ExportOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::export::run(&self.store, scope, &selectors, nesting, with_metadata)
     }
@@ -26,7 +26,7 @@ impl<S: DataStore> PadzApi<S> {
         indexes: &[I],
         title: &str,
         nesting: commands::NestingMode,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::export::ExportOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::export::run_single_file(&self.store, scope, &selectors, title, nesting)
     }
@@ -36,7 +36,7 @@ impl<S: DataStore> PadzApi<S> {
         scope: Scope,
         indexes: &[I],
         nesting: commands::NestingMode,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::export::ExportOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::export::run_json(&self.store, scope, &selectors, nesting)
     }

--- a/crates/padzapp/src/commands/io/export.rs
+++ b/crates/padzapp/src/commands/io/export.rs
@@ -1,5 +1,5 @@
 use crate::commands::metadata_schema::{Archive, PadEntry, TagRegistryEntry, SCHEMA_VERSION};
-use crate::commands::{CmdMessage, CmdResult, NestingMode};
+use crate::commands::NestingMode;
 use crate::error::{PadzError, Result};
 use crate::index::DisplayIndex;
 use crate::index::DisplayPad;
@@ -12,7 +12,6 @@ use flate2::Compression;
 use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use pulldown_cmark_to_cmark::cmark;
 use std::collections::HashSet;
-use std::fs::File;
 use std::io::Write;
 use uuid::Uuid;
 
@@ -46,43 +45,102 @@ pub struct SingleFileExportResult {
     pub format: SingleFileFormat,
 }
 
+/// The export representation produced by the reusable application layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportFormat {
+    Archive,
+    MetadataArchive,
+    JsonArchive,
+    SingleFile,
+}
+
+/// A semantic warning discovered while producing an export.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExportWarning {
+    /// These pads use a format with no inline metadata dialect.
+    MetadataUnavailable { titles: Vec<String> },
+}
+
+/// Presentation-free facts that accompany a completed export artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportReport {
+    pub format: ExportFormat,
+    pub exported: usize,
+    pub warnings: Vec<ExportWarning>,
+}
+
+/// Exact export bytes plus the core's suggested destination and report facts.
+///
+/// The bytes are intentionally owned so a shell adapter can hand them to its
+/// final-output framework without a lifetime or temporary-file contract. Peak
+/// memory is therefore the live source data plus the compressed artifact and
+/// encoder buffers; moving this value across the API/handler seams does not copy
+/// the byte vector.
+#[derive(Debug)]
+pub struct ExportArtifact {
+    pub bytes: Vec<u8>,
+    pub suggested_filename: String,
+    pub report: ExportReport,
+}
+
+/// An export either has no selected pads or yields an artifact for its caller
+/// to place. The reusable core never creates or writes the final destination.
+#[derive(Debug)]
+pub enum ExportOutcome {
+    Empty { format: ExportFormat },
+    Artifact(ExportArtifact),
+}
+
 pub fn run<S: DataStore>(
     store: &S,
     scope: Scope,
     selectors: &[PadSelector],
     nesting: NestingMode,
     with_metadata: bool,
-) -> Result<CmdResult> {
+) -> Result<ExportOutcome> {
     // 1. Resolve pads
     let pads = resolve_pads(store, scope, selectors)?;
 
     if pads.is_empty() {
-        let mut res = CmdResult::default();
-        res.add_message(CmdMessage::info("No pads to export."));
-        return Ok(res);
+        return Ok(ExportOutcome::Empty {
+            format: if with_metadata {
+                ExportFormat::MetadataArchive
+            } else {
+                ExportFormat::Archive
+            },
+        });
     }
 
     let nested = resolve_nested(store, scope, &pads, nesting)?;
 
-    // 2. Prepare output file
+    // 2. Prepare the suggested destination and owned archive bytes.
     let now = Utc::now();
     let suffix = if with_metadata { "meta" } else { "tar" };
     let filename = format!("padz-{}.{}.gz", now.format("%Y-%m-%d_%H-%M-%S"), suffix);
-    let file = File::create(&filename).map_err(PadzError::Io)?;
+    let mut bytes = Vec::new();
 
-    // 3. Write archive
-    let mut result = CmdResult::default();
-    let messages = if with_metadata {
-        write_archive_with_metadata(file, store, scope, &nested)?
+    // 3. Produce archive bytes. Destination selection and writing belong to
+    // the caller (the Padz CLI delegates them to Standout).
+    let warnings = if with_metadata {
+        write_archive_with_metadata(&mut bytes, store, scope, &nested)?
     } else {
-        write_archive(file, &nested)?;
+        write_archive(&mut bytes, &nested)?;
         Vec::new()
     };
-    for m in messages {
-        result.add_message(m);
-    }
-    result.add_message(CmdMessage::success(format!("Exported to {}", filename)));
-    Ok(result)
+
+    Ok(ExportOutcome::Artifact(ExportArtifact {
+        bytes,
+        suggested_filename: filename,
+        report: ExportReport {
+            format: if with_metadata {
+                ExportFormat::MetadataArchive
+            } else {
+                ExportFormat::Archive
+            },
+            exported: pads.len(),
+            warnings,
+        },
+    }))
 }
 
 fn resolve_nested<S: DataStore>(
@@ -156,7 +214,7 @@ pub(crate) fn write_archive_with_metadata<W: Write, S: DataStore>(
     store: &S,
     scope: Scope,
     pads: &[NestedPad],
-) -> Result<Vec<CmdMessage>> {
+) -> Result<Vec<ExportWarning>> {
     use crate::commands::inline_metadata::{serialize_lex_metadata, serialize_md_frontmatter};
 
     let enc = GzEncoder::new(writer, Compression::default());
@@ -216,22 +274,13 @@ pub(crate) fn write_archive_with_metadata<W: Write, S: DataStore>(
 
     tar.finish().map_err(PadzError::Io)?;
 
-    let mut messages = Vec::new();
-    if !skipped_txt.is_empty() {
-        let preview: Vec<&str> = skipped_txt.iter().take(3).map(String::as_str).collect();
-        let suffix = if skipped_txt.len() > 3 {
-            format!(" (+ {} more)", skipped_txt.len() - 3)
-        } else {
-            String::new()
-        };
-        messages.push(CmdMessage::warning(format!(
-            "{} .txt pad(s) exported without metadata (txt has no metadata format): {}{}",
-            skipped_txt.len(),
-            preview.join(", "),
-            suffix,
-        )));
-    }
-    Ok(messages)
+    Ok(if skipped_txt.is_empty() {
+        Vec::new()
+    } else {
+        vec![ExportWarning::MetadataUnavailable {
+            titles: skipped_txt,
+        }]
+    })
 }
 
 fn sanitize_filename(name: &str) -> String {
@@ -255,13 +304,13 @@ pub fn run_single_file<S: DataStore>(
     selectors: &[PadSelector],
     title: &str,
     nesting: NestingMode,
-) -> Result<CmdResult> {
+) -> Result<ExportOutcome> {
     let pads = resolve_pads(store, scope, selectors)?;
 
     if pads.is_empty() {
-        let mut res = CmdResult::default();
-        res.add_message(CmdMessage::info("No pads to export."));
-        return Ok(res);
+        return Ok(ExportOutcome::Empty {
+            format: ExportFormat::SingleFile,
+        });
     }
 
     let nested = resolve_nested(store, scope, &pads, nesting)?;
@@ -269,17 +318,16 @@ pub fn run_single_file<S: DataStore>(
     let format = SingleFileFormat::from_filename(title);
     let result = merge_pads_to_single_file(&nested, title, format);
 
-    // Write to file
     let filename = sanitize_output_filename(title, format);
-    std::fs::write(&filename, &result.content).map_err(PadzError::Io)?;
-
-    let mut cmd_result = CmdResult::default();
-    cmd_result.add_message(CmdMessage::success(format!(
-        "Exported {} pads to {}",
-        pads.len(),
-        filename
-    )));
-    Ok(cmd_result)
+    Ok(ExportOutcome::Artifact(ExportArtifact {
+        bytes: result.content.into_bytes(),
+        suggested_filename: filename,
+        report: ExportReport {
+            format: ExportFormat::SingleFile,
+            exported: pads.len(),
+            warnings: Vec::new(),
+        },
+    }))
 }
 
 /// Merge pads into a single file content string.
@@ -458,39 +506,31 @@ pub fn run_json<S: DataStore>(
     scope: Scope,
     selectors: &[PadSelector],
     nesting: NestingMode,
-) -> Result<CmdResult> {
+) -> Result<ExportOutcome> {
     let pads = resolve_pads(store, scope, selectors)?;
 
     if pads.is_empty() {
-        let mut res = CmdResult::default();
-        res.add_message(CmdMessage::info("No pads to export."));
-        return Ok(res);
+        return Ok(ExportOutcome::Empty {
+            format: ExportFormat::JsonArchive,
+        });
     }
 
     let nested = resolve_nested(store, scope, &pads, nesting)?;
 
     let now = Utc::now();
     let filename = format!("padz-{}.json.tar.gz", now.format("%Y-%m-%d_%H-%M-%S"));
-    let file = File::create(&filename).map_err(PadzError::Io)?;
+    let mut bytes = Vec::new();
+    write_json_archive(&mut bytes, store, scope, &nested, now)?;
 
-    write_json_archive(file, store, scope, &nested, now)?;
-
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!("Exported to {}", filename)));
-    Ok(result)
-}
-
-/// Collect the resolved + nested pads for a JSON export. Public for tests that
-/// want to drive `write_json_archive` directly without writing to CWD.
-#[cfg(test)]
-pub(crate) fn collect_export_pads<S: DataStore>(
-    store: &S,
-    scope: Scope,
-    selectors: &[PadSelector],
-    nesting: NestingMode,
-) -> Result<Vec<NestedPad>> {
-    let pads = resolve_pads(store, scope, selectors)?;
-    resolve_nested(store, scope, &pads, nesting)
+    Ok(ExportOutcome::Artifact(ExportArtifact {
+        bytes,
+        suggested_filename: filename,
+        report: ExportReport {
+            format: ExportFormat::JsonArchive,
+            exported: pads.len(),
+            warnings: Vec::new(),
+        },
+    }))
 }
 
 pub(crate) fn write_json_archive<W: Write, S: DataStore>(
@@ -897,21 +937,25 @@ mod tests {
         );
         // No pads created
         let res = run(&store, Scope::Project, &[], NestingMode::Flat, false).unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("No pads to export")));
+        assert!(matches!(
+            res,
+            ExportOutcome::Empty {
+                format: ExportFormat::Archive
+            }
+        ));
 
         let res_single =
             run_single_file(&store, Scope::Project, &[], "out.md", NestingMode::Flat).unwrap();
-        assert!(res_single
-            .messages
-            .iter()
-            .any(|m| m.content.contains("No pads to export")));
+        assert!(matches!(
+            res_single,
+            ExportOutcome::Empty {
+                format: ExportFormat::SingleFile
+            }
+        ));
     }
 
     #[test]
-    fn test_export_single_file_creates_file() {
+    fn test_export_single_file_returns_owned_artifact_without_writing() {
         use std::path::Path;
         let mut store = BucketedStore::new(
             MemBackend::new(),
@@ -921,10 +965,9 @@ mod tests {
         );
         create::run(&mut store, Scope::Project, "A".into(), "".into(), None).unwrap();
 
-        // Since run_single_file forces writing to CWD with a sanitized name,
-        // we use a unique name to avoid collisions and check CWD.
+        // A unique name proves the core did not create the suggested destination.
         let unique_title = format!("Export_Test_{}", uuid::Uuid::new_v4());
-        let expected_filename = format!("{}.md", unique_title); // sanitization should be no-op for alphanumeric+underscore
+        let expected_filename = format!("{}.md", unique_title);
         let expected_path = Path::new(&expected_filename);
 
         // Export
@@ -934,22 +977,20 @@ mod tests {
         // So passing "Title.md" results in "Title.md".
         let input_title = format!("{}.md", unique_title);
 
-        let res =
+        let outcome =
             run_single_file(&store, Scope::Project, &[], &input_title, NestingMode::Flat).unwrap();
+        let ExportOutcome::Artifact(artifact) = outcome else {
+            panic!("expected an export artifact");
+        };
 
-        assert!(res.messages[0].content.contains("Exported 1 pads"));
-        assert!(
-            expected_path.exists(),
-            "File {} should be created in CWD",
-            expected_filename
-        );
+        assert_eq!(artifact.suggested_filename, expected_filename);
+        assert_eq!(artifact.report.exported, 1);
+        assert_eq!(artifact.report.format, ExportFormat::SingleFile);
+        assert!(!expected_path.exists(), "the reusable core must not write");
 
-        let content = std::fs::read_to_string(expected_path).unwrap();
+        let content = String::from_utf8(artifact.bytes).unwrap();
         assert!(content.contains(&format!("# {}", input_title))); // Title in H1
         assert!(content.contains("## A"));
-
-        // Cleanup
-        let _ = std::fs::remove_file(expected_path);
     }
 
     // --- Nesting mode tests ---

--- a/crates/padzapp/src/commands/io/import.rs
+++ b/crates/padzapp/src/commands/io/import.rs
@@ -834,18 +834,24 @@ mod tests {
     use chrono::Utc;
 
     /// Build a JSON archive from the source store into a tempfile and return
-    /// the path. Uses `write_json_archive` directly so the test controls the
-    /// output location (the public `run_json` writes to CWD).
+    /// the path. The core supplies owned bytes; this test supplies the final
+    /// destination because the importer consumes a path.
     fn export_to_tmpfile<S: crate::store::DataStore>(
         store: &S,
         scope: Scope,
         selectors: &[PadSelector],
     ) -> std::path::PathBuf {
-        let nested =
-            export::collect_export_pads(store, scope, selectors, NestingMode::Tree).unwrap();
-        let temp = tempfile::NamedTempFile::with_suffix(".tar.gz").unwrap();
-        let (file, path) = temp.keep().unwrap();
-        export::write_json_archive(file, store, scope, &nested, Utc::now()).unwrap();
+        use std::io::Write as _;
+
+        let outcome = export::run_json(store, scope, selectors, NestingMode::Tree).unwrap();
+        let export::ExportOutcome::Artifact(artifact) = outcome else {
+            panic!("expected JSON export artifact");
+        };
+        assert_eq!(artifact.report.format, export::ExportFormat::JsonArchive);
+
+        let mut temp = tempfile::NamedTempFile::with_suffix(".tar.gz").unwrap();
+        temp.write_all(&artifact.bytes).unwrap();
+        let (_, path) = temp.keep().unwrap();
         path
     }
 

--- a/docs/cli_behavior.txt
+++ b/docs/cli_behavior.txt
@@ -20,12 +20,14 @@ clipboard (see §3), but never reads it to decide what a pad should contain.
     -   **stdin is a terminal** → `padz list`.
     -   **stdin is piped** → `padz create`, capturing the pipe (`cat notes | padz`).
         An empty pipe reaches `create` and aborts there; it does not fall back to `list`.
--   **Location**: `crates/padz/src/cli/input.rs` — function `naked_command`;
-    called from `cli/commands.rs`'s `run`, which splices the chosen command into argv.
+-   **Location**: `crates/padz/src/cli/setup.rs` — Standout's
+    `default_command_with` resolver is attached to both the initial parsing app
+    and the stateful dispatch app.
 -   **Why**: The "Read" operation is 90% of usage. It should be the path of least
     resistance — while a pipe means the user is handing padz something to keep.
--   **Why not standout's `default_command`**: it names one *static* command, and
-    this rule is conditional. See `naked_command`'s docs.
+-   **How**: Standout evaluates the resolver only after a successful naked parse
+    and exposes a non-consuming stdin terminal fact, so explicit/nested
+    commands, help, version, and invalid syntax keep Clap precedence.
 
 ### 2. Smart Create (`padz create`)
 -   **Location**: the precedence is declared as a standout `InputChain` in

--- a/docs/cli_behavior.txt
+++ b/docs/cli_behavior.txt
@@ -20,9 +20,9 @@ clipboard (see §3), but never reads it to decide what a pad should contain.
     -   **stdin is a terminal** → `padz list`.
     -   **stdin is piped** → `padz create`, capturing the pipe (`cat notes | padz`).
         An empty pipe reaches `create` and aborts there; it does not fall back to `list`.
--   **Location**: `crates/padz/src/cli/setup.rs` — Standout's
-    `default_command_with` resolver is attached to both the initial parsing app
-    and the stateful dispatch app.
+-   **Location**: the resolver lives in `crates/padz/src/cli/setup.rs`. It is
+    attached to the initial parsing app there and to the stateful dispatch app
+    in `crates/padz/src/cli/commands.rs` (`build_dispatch_app`).
 -   **Why**: The "Read" operation is 90% of usage. It should be the path of least
     resistance — while a pipe means the user is handing padz something to keep.
 -   **How**: Standout evaluates the resolver only after a successful naked parse


### PR DESCRIPTION
## Context

Standout 7.9.0 now supplies the two framework seams Padz issue #208 was waiting on: invocation-aware default command resolution and compound artifacts with post-write reports. This adopts those tagged APIs through one coherent dependency graph.

This is a partial slice of #208. The remaining core-prose and semantic-notice migration is out of scope.

for #208

## What changed

- Upgraded the complete Standout dependency family to v7.9.0.
- Replaced Padz's naked-argv injection with Standout's invocation-aware default-command resolver.
- Changed all export forms to return owned compound artifacts with semantic reports and suggested filenames.
- Added a CLI-owned export report DTO and template that renders post-write reports using the actual receipt destination.
- Removed Padz's binary final-write workaround.
- Moved invocation and artifact coverage onto Standout's test harness, retaining one process smoke test for Padz's two-stage CLI construction.

## Compatibility

- Explicit and nested commands, aliases, help/version/invalid syntax, global options, editor/no-editor behavior, and empty-pipe behavior are preserved.
- Export bytes, formats, and suggested-filename rules remain compatible; empty exports remain non-artifacts.
- Human success and warning wording remains compatible, but now uses the actual completed destination.
- Structured export output intentionally changes from prose `messages` to machine-readable `{report, receipt}`.
- Failed writes remain nonzero and cannot render a success report.
- Owned-byte peak memory is the source plus compressed artifact and encoder buffers; moving the vector through the core and handler APIs does not copy it.

## Verification

- `pixi run test` — 840 passed, 1 skipped (`TEST: OK`)
- `pixi run lint` — 12 checks passed (`LINT: OK`)
- Commit and push hooks reran lint successfully.
