### PR TITLE
STD02-WS01: Epic: Complete Remaining Standout Ownership Work - Workstream: Semantic Initialization and Maintenance Outcomes

### DIFF
--- a/CHANGELOG/unreleased-semantic-maintenance-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-maintenance-outcomes.md
@@ -1,0 +1,7 @@
+- Initialization, link/unlink, doctor, and purge now expose semantic structured
+  outcomes instead of prose-only `messages` arrays. Initialization reports its
+  action plus scope/store path or resolved link target; doctor reports a distinct
+  `clean`/`repaired` status with missing/recovered file counts; purge reports a
+  distinct `empty`/`purged` status with selected pad identities, total count, and
+  descendant count. Human wording, ordering, styles, confirmation and recursive
+  safety errors remain unchanged and are rendered by command-specific templates.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -28,8 +28,9 @@ use standout_macros::handler;
 use std::cell::RefCell;
 
 use super::result::{
-    ExportReportResult, ListRequest, MessagesResult, ModificationRequest, ModificationResult,
-    PadContent, PadContentResult, PadListResult, PathResult, UuidResult,
+    DoctorResult, ExportReportResult, InitializationResult, ListRequest, MessagesResult,
+    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
+    PathResult, PurgeResult, UuidResult,
 };
 
 // =============================================================================
@@ -271,41 +272,41 @@ impl<'a> ScopedApi<'a> {
         self.modification("Moved", result, false)
     }
 
-    // --- Message-only operations ---
+    // --- Maintenance outcomes ---
 
     pub fn purge_pads(
         &self,
         indexes: &[String],
         yes: bool,
         recursive: bool,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<PurgeResult>, anyhow::Error> {
         let include_done = self.state.mode == PadzMode::Todos;
-        let result =
+        let outcome =
             self.call(|api, scope| api.purge_pads(scope, indexes, recursive, yes, include_done))?;
-        self.messages(result)
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn doctor(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.doctor(scope))?;
-        self.messages(result)
+    pub fn doctor(&self) -> Result<Output<DoctorResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.doctor(scope))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn init(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.init(scope))?;
-        self.messages(result)
+    pub fn init(&self) -> Result<Output<InitializationResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.init(scope))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn init_link(&self, target: &str) -> Result<Output<MessagesResult>, anyhow::Error> {
+    pub fn init_link(&self, target: &str) -> Result<Output<InitializationResult>, anyhow::Error> {
         let target_path = std::path::PathBuf::from(target);
         let local_padz = &self.state.local_padz_dir;
-        let result = self.call(|api, _scope| api.init_link(local_padz, &target_path))?;
-        self.messages(result)
+        let outcome = self.call(|api, _scope| api.init_link(local_padz, &target_path))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn init_unlink(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
+    pub fn init_unlink(&self) -> Result<Output<InitializationResult>, anyhow::Error> {
         let local_padz = &self.state.local_padz_dir;
-        let result = self.call(|api, _scope| api.init_unlink(local_padz))?;
-        self.messages(result)
+        let outcome = self.call(|api, _scope| api.init_unlink(local_padz))?;
+        Ok(Output::Render(outcome.into()))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1142,7 +1143,7 @@ pub fn purge(
     #[arg] indexes: Vec<String>,
     #[flag] yes: bool,
     #[flag] recursive: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<PurgeResult>, anyhow::Error> {
     api(ctx).purge_pads(&indexes, yes, recursive)
 }
 
@@ -1212,7 +1213,7 @@ pub fn migrate(
 // =============================================================================
 
 #[handler]
-pub fn doctor(#[ctx] ctx: &CommandContext) -> Result<Output<MessagesResult>, anyhow::Error> {
+pub fn doctor(#[ctx] ctx: &CommandContext) -> Result<Output<DoctorResult>, anyhow::Error> {
     api(ctx).doctor()
 }
 
@@ -1221,7 +1222,7 @@ pub fn init(
     #[ctx] ctx: &CommandContext,
     #[arg] link: Option<String>,
     #[flag] unlink: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<InitializationResult>, anyhow::Error> {
     if let Some(target) = link {
         api(ctx).init_link(&target)
     } else if unlink {

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -102,6 +102,119 @@ impl MessagesResult {
     }
 }
 
+/// CLI projection of explicit store initialization and link maintenance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum InitializationResult {
+    Initialized { scope: String, store_path: String },
+    Linked { target: String },
+    Unlinked,
+}
+
+impl From<padzapp::commands::init::InitializationOutcome> for InitializationResult {
+    fn from(outcome: padzapp::commands::init::InitializationOutcome) -> Self {
+        use padzapp::commands::init::InitializationOutcome;
+
+        match outcome {
+            InitializationOutcome::Initialized { scope, store_path } => Self::Initialized {
+                scope: match scope {
+                    padzapp::model::Scope::Project => "project",
+                    padzapp::model::Scope::Global => "global",
+                }
+                .to_string(),
+                store_path: store_path.display().to_string(),
+            },
+            InitializationOutcome::Linked { target } => Self::Linked {
+                target: target.display().to_string(),
+            },
+            InitializationOutcome::Unlinked => Self::Unlinked,
+        }
+    }
+}
+
+/// CLI projection of a store reconciliation report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DoctorResult {
+    Clean {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+    Repaired {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+}
+
+impl From<padzapp::commands::doctor::DoctorOutcome> for DoctorResult {
+    fn from(outcome: padzapp::commands::doctor::DoctorOutcome) -> Self {
+        use padzapp::commands::doctor::DoctorOutcome;
+
+        match outcome {
+            DoctorOutcome::Clean {
+                missing_files,
+                recovered_files,
+            } => Self::Clean {
+                missing_files,
+                recovered_files,
+            },
+            DoctorOutcome::Repaired {
+                missing_files,
+                recovered_files,
+            } => Self::Repaired {
+                missing_files,
+                recovered_files,
+            },
+        }
+    }
+}
+
+/// Identity facts for one explicitly selected pad in a purge report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PurgePadResult {
+    pub selector: String,
+    pub id: String,
+    pub title: String,
+}
+
+/// CLI projection of a permanent-deletion request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum PurgeResult {
+    Empty,
+    Purged {
+        selected_pads: Vec<PurgePadResult>,
+        total_purged: usize,
+        descendant_count: usize,
+    },
+}
+
+impl From<padzapp::commands::purge::PurgeOutcome> for PurgeResult {
+    fn from(outcome: padzapp::commands::purge::PurgeOutcome) -> Self {
+        use padzapp::commands::purge::PurgeOutcome;
+
+        match outcome {
+            PurgeOutcome::Empty => Self::Empty,
+            PurgeOutcome::Purged {
+                selected_pads,
+                total_purged,
+                descendant_count,
+            } => Self::Purged {
+                selected_pads: selected_pads
+                    .into_iter()
+                    .map(|selected| PurgePadResult {
+                        selector: selected.index.to_string(),
+                        id: selected.pad.metadata.id.to_string(),
+                        title: selected.pad.metadata.title,
+                    })
+                    .collect(),
+                total_purged,
+                descendant_count,
+            },
+        }
+    }
+}
+
 /// The machine-readable report carried by an export artifact.
 ///
 /// Standout wraps this value with its own `receipt` after the final write. An

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -169,7 +169,7 @@ impl From<padzapp::commands::doctor::DoctorOutcome> for DoctorResult {
     }
 }
 
-/// Identity facts for one explicitly selected pad in a purge report.
+/// Identity facts for one unique, explicitly selected pad in a purge report.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PurgePadResult {
     pub selector: String,
@@ -177,7 +177,7 @@ pub struct PurgePadResult {
     pub title: String,
 }
 
-/// CLI projection of a permanent-deletion request.
+/// CLI projection of a permanent-deletion request with UUID-unique counts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum PurgeResult {

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -658,7 +658,7 @@ pub enum Commands {
     // --- Data operations ---
     /// Permanently delete pads
     #[command(display_order = 20)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "purge")]
     Purge {
         /// Indexes of the pads (e.g. d1 d2) - if omitted, purges all deleted pads
         #[arg(required = false, num_args = 0.., add = deleted_pads_completer())]
@@ -763,7 +763,7 @@ pub enum Commands {
     // --- Misc commands ---
     /// Check and fix data inconsistencies
     #[command(display_order = 30)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "doctor")]
     Doctor,
 
     /// Manage configuration
@@ -776,7 +776,7 @@ pub enum Commands {
 
     /// Initialize the store (optional utility)
     #[command(display_order = 32)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "initialization")]
     Init {
         /// Link to another project's padz data
         #[arg(long, value_name = "PATH", conflicts_with = "unlink")]

--- a/crates/padz/src/cli/templates/doctor.jinja
+++ b/crates/padz/src/cli/templates/doctor.jinja
@@ -1,0 +1,12 @@
+{#- Human projection of DoctorResult; counts and status remain structured facts. -#}
+{%- if status == "clean" -%}
+[success]No inconsistencies found.[/success]{{ "" | nl }}
+{%- else -%}
+[warning]Inconsistencies found and fixed:[/warning]{{ "" | nl }}
+{%- if missing_files > 0 -%}
+[info]  - Removed {{ missing_files }} pad(s) listed in DB but missing from disk.[/info]{{ "" | nl }}
+{%- endif -%}
+{%- if recovered_files > 0 -%}
+[success]  - Recovered {{ recovered_files }} pad(s) found on disk but missing from DB.[/success]{{ "" | nl }}
+{%- endif -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/initialization.jinja
+++ b/crates/padz/src/cli/templates/initialization.jinja
@@ -1,0 +1,12 @@
+{#- Human projection of InitializationResult. Completion guidance and layout are CLI-owned. -#}
+{%- if action == "initialized" -%}
+[success]Initialized padz store at {{ store_path }}[/success]{{ "" | nl -}}
+{{ "" | nl -}}
+[info]Tip: Enable shell completions for padz:[/info]{{ "" | nl -}}
+[info]  eval "$(padz completions bash)"  # add to ~/.bashrc[/info]{{ "" | nl -}}
+[info]  eval "$(padz completions zsh)"   # add to ~/.zshrc[/info]{{ "" | nl }}
+{%- elif action == "linked" -%}
+[success]Linked to {{ target }}[/success]{{ "" | nl }}
+{%- elif action == "unlinked" -%}
+[success]Unlinked.[/success]{{ "" | nl }}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/purge.jinja
+++ b/crates/padz/src/cli/templates/purge.jinja
@@ -1,0 +1,12 @@
+{#- Human projection of PurgeResult; the core returns no progress or success prose. -#}
+{%- if status == "empty" -%}
+[info]No pads to purge.[/info]{{ "" | nl }}
+{%- else -%}
+[info]Purging {{ total_purged }} pad(s)...[/info]{{ "" | nl }}
+{%- for selected in selected_pads -%}
+[success]Purged: {{ selected.selector }} {{ selected.title }}[/success]{{ "" | nl }}
+{%- endfor -%}
+{%- if descendant_count > 0 -%}
+[success]And purged {{ descendant_count }} descendant(s)[/success]{{ "" | nl }}
+{%- endif -%}
+{%- endif -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/doctor-clean.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/doctor-clean.json
@@ -1,0 +1,5 @@
+{
+  "status": "clean",
+  "missing_files": 0,
+  "recovered_files": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/initialization.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/initialization.json
@@ -1,0 +1,5 @@
+{
+  "action": "initialized",
+  "scope": "project",
+  "store_path": "<STORE_PATH>"
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/purge-completed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/purge-completed.json
@@ -1,0 +1,12 @@
+{
+  "status": "purged",
+  "selected_pads": [
+    {
+      "selector": "d1",
+      "id": "<UUID>",
+      "title": "gone"
+    }
+  ],
+  "total_purged": 1,
+  "descendant_count": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/purge-empty.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/purge-empty.json
@@ -1,0 +1,3 @@
+{
+  "status": "empty"
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,8 +26,8 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    ExportFormat, ExportStatus, ExportWarning, MessagesResult, ModificationResult,
-    PadContentResult, PadListResult, PathResult, UuidResult,
+    DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
+    ModificationResult, PadContentResult, PadListResult, PathResult, PurgeResult, UuidResult,
 };
 use padzapp::commands::{CmdNotice, NestingMode};
 use standout::cli::Output;
@@ -546,22 +546,96 @@ fn empty_export_stays_a_non_artifact_result() {
 }
 
 // =============================================================================
-// Message-only family
+// Initialization and maintenance outcomes
 // =============================================================================
 
 #[test]
-fn doctor_maps_a_healthy_store_to_messages() {
+fn initialization_maps_scope_and_store_path() {
+    let fx = Fixture::new();
+    let ctx = support::ctx_with_state(fx.app_state_for(&["init"]));
+
+    let result: InitializationResult = rendered(handlers::init(&ctx, None, false));
+
+    assert_eq!(
+        result,
+        InitializationResult::Initialized {
+            scope: "project".to_string(),
+            store_path: fx.project().join(".padz").display().to_string(),
+        }
+    );
+}
+
+#[test]
+fn link_and_unlink_map_typed_actions_and_resolved_target() {
+    let fx = Fixture::new();
+    let target = fx.root().join("target");
+    padzapp::init::create_bucket_layout(&target.join(".padz")).unwrap();
+    let ctx = fx.ctx();
+
+    let linked: InitializationResult = rendered(handlers::init(
+        &ctx,
+        Some(target.display().to_string()),
+        false,
+    ));
+    assert_eq!(
+        linked,
+        InitializationResult::Linked {
+            target: target
+                .join(".padz")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string(),
+        }
+    );
+
+    let unlinked: InitializationResult = rendered(handlers::init(&ctx, None, true));
+    assert_eq!(unlinked, InitializationResult::Unlinked);
+}
+
+#[test]
+fn doctor_maps_a_healthy_store_to_a_clean_result() {
     let fx = Fixture::new();
     let state = fx.app_state();
     fx.seed_pad(&state, "note", "");
     let ctx = support::ctx_with_state(state);
 
-    let result: MessagesResult = rendered(handlers::doctor(&ctx));
+    let result: DoctorResult = rendered(handlers::doctor(&ctx));
 
-    assert!(
-        !result.messages.is_empty(),
-        "doctor always reports what it checked"
+    assert_eq!(
+        result,
+        DoctorResult::Clean {
+            missing_files: 0,
+            recovered_files: 0,
+        }
     );
+}
+
+#[test]
+fn purge_maps_selected_pads_and_counts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "gone", "");
+    state
+        .with_api(|api| api.delete_pads(state.scope, &["1"]))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let result: PurgeResult = rendered(handlers::purge(&ctx, vec![], true, false));
+
+    let PurgeResult::Purged {
+        selected_pads,
+        total_purged,
+        descendant_count,
+    } = result
+    else {
+        panic!("expected a completed purge");
+    };
+    assert_eq!(selected_pads.len(), 1);
+    assert_eq!(selected_pads[0].selector, "d1");
+    assert_eq!(selected_pads[0].title, "gone");
+    assert_eq!(total_purged, 1);
+    assert_eq!(descendant_count, 0);
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -265,6 +265,142 @@ fn search_flag_reaches_the_handler_as_a_filter() {
     assert_eq!(got, vec!["meeting notes"]);
 }
 
+// =============================================================================
+// Semantic initialization and maintenance outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn initialization_preserves_text_and_exposes_structured_facts() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.app(&["init"]);
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["init", "--output", "text"]),
+    );
+
+    text.assert_success();
+    assert_eq!(
+        text.stdout(),
+        format!(
+            "Initialized padz store at {}\n\nTip: Enable shell completions for padz:\n  \
+             eval \"$(padz completions bash)\"  # add to ~/.bashrc\n  \
+             eval \"$(padz completions zsh)\"   # add to ~/.zshrc\n",
+            fx.project().join(".padz").display()
+        )
+    );
+    drop(text);
+
+    let json = TestHarness::new().run(&app, cmd, fx.argv(&["init", "--output", "json"]));
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    value["store_path"] = serde_json::json!("<STORE_PATH>");
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/initialization.json"
+    ))
+    .unwrap();
+    assert_eq!(value, fixture);
+    assert!(
+        value.get("messages").is_none(),
+        "initialization schema must expose facts rather than prose"
+    );
+}
+
+#[test]
+#[serial]
+fn doctor_preserves_clean_text_and_exposes_counts() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["doctor", "--output", "text"]),
+    );
+
+    text.assert_success();
+    assert_eq!(text.stdout(), "No inconsistencies found.\n");
+    drop(text);
+
+    let json = TestHarness::new().run(&app, cmd, fx.argv(&["doctor", "--output", "json"]));
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/doctor-clean.json")).unwrap();
+    assert_eq!(value, fixture);
+}
+
+#[test]
+#[serial]
+fn purge_preserves_completed_text_and_exposes_selection_and_counts() {
+    let text_fx = Fixture::new();
+    let state = text_fx.app_state();
+    text_fx.seed_pad(&state, "gone", "");
+    state
+        .with_api(|api| api.delete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = text_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        text_fx.argv(&["purge", "--yes", "--output", "text"]),
+    );
+
+    text.assert_success();
+    assert_eq!(text.stdout(), "Purging 1 pad(s)...\nPurged: d1 gone\n");
+
+    let json_fx = Fixture::new();
+    let state = json_fx.app_state();
+    json_fx.seed_pad(&state, "gone", "");
+    state
+        .with_api(|api| api.delete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = json_fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        json_fx.argv(&["purge", "--yes", "--output", "json"]),
+    );
+
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    assert!(value["selected_pads"][0]["id"]
+        .as_str()
+        .is_some_and(|id| id.len() == 36));
+    value["selected_pads"][0]["id"] = serde_json::json!("<UUID>");
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/purge-completed.json"
+    ))
+    .unwrap();
+    assert_eq!(value, fixture);
+}
+
+#[test]
+#[serial]
+fn empty_purge_is_distinct_in_text_and_structured_output() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["purge", "--yes", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "No pads to purge.\n");
+    drop(text);
+
+    let json = TestHarness::new().run(&app, cmd, fx.argv(&["purge", "--yes", "--output", "json"]));
+    json.assert_success();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/purge-empty.json")).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        fixture
+    );
+}
+
 #[test]
 #[serial]
 fn uuid_flag_reaches_the_view_handler() {

--- a/crates/padzapp/src/api/crud.rs
+++ b/crates/padzapp/src/api/crud.rs
@@ -97,7 +97,7 @@ impl<S: DataStore> PadzApi<S> {
     /// Permanently deletes pads.
     ///
     /// **Confirmation required**: The `confirmed` parameter must be `true` to proceed.
-    /// Returns an empty outcome or the selected pads and completed deletion counts.
+    /// Returns an empty outcome or unique selected pads and completed deletion counts.
     pub fn purge_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,

--- a/crates/padzapp/src/api/crud.rs
+++ b/crates/padzapp/src/api/crud.rs
@@ -97,6 +97,7 @@ impl<S: DataStore> PadzApi<S> {
     /// Permanently deletes pads.
     ///
     /// **Confirmation required**: The `confirmed` parameter must be `true` to proceed.
+    /// Returns an empty outcome or the selected pads and completed deletion counts.
     pub fn purge_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
@@ -104,7 +105,7 @@ impl<S: DataStore> PadzApi<S> {
         recursive: bool,
         confirmed: bool,
         include_done: bool,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::purge::PurgeOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::purge::run(
             &mut self.store,

--- a/crates/padzapp/src/api/init.rs
+++ b/crates/padzapp/src/api/init.rs
@@ -8,19 +8,25 @@ use crate::store::DataStore;
 use super::PadzApi;
 
 impl<S: DataStore> PadzApi<S> {
-    pub fn init(&self, scope: Scope) -> Result<commands::CmdResult> {
+    /// Initializes `scope` and returns its scope and resolved store path as data.
+    pub fn init(&self, scope: Scope) -> Result<commands::init::InitializationOutcome> {
         commands::init::run(&self.paths, scope)
     }
 
+    /// Creates a link and returns the canonical initialized target as data.
     pub fn init_link(
         &self,
         local_padz: &std::path::Path,
         target: &std::path::Path,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::init::InitializationOutcome> {
         commands::init::link(local_padz, target)
     }
 
-    pub fn init_unlink(&self, local_padz: &std::path::Path) -> Result<commands::CmdResult> {
+    /// Removes the local link and returns a typed unlink action.
+    pub fn init_unlink(
+        &self,
+        local_padz: &std::path::Path,
+    ) -> Result<commands::init::InitializationOutcome> {
         commands::init::unlink(local_padz)
     }
 }

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -8,7 +8,7 @@
 //! The API facade:
 //! - **Dispatches** to the appropriate command function
 //! - **Normalizes inputs** (e.g., converting display indexes to UUIDs)
-//! - **Returns structured types** (`Result<CmdResult>`)
+//! - **Returns structured types** (`CmdResult` or operation-specific outcomes)
 //!
 //! ## What the API Does NOT Do
 //!
@@ -17,9 +17,9 @@
 //! - **I/O operations**: No stdout, stderr, or file formatting
 //! - **Presentation concerns**: Returns data structures, not strings
 //!
-//! ## Consistent Output Representation
+//! ## Consistent Pad Representation
 //!
-//! All pad data in [`CmdResult`] uses [`DisplayPad`], which pairs a [`Pad`] with its
+//! All pad data in [`CmdResult`] and semantic outcomes uses [`DisplayPad`], which pairs a [`Pad`] with its
 //! canonical [`DisplayIndex`]. This applies to both:
 //! - `affected_pads`: Pads modified by the operation (with post-operation index)
 //! - `listed_pads`: Pads returned for display (with current index)
@@ -78,7 +78,10 @@ impl<S: DataStore> PadzApi<S> {
 }
 
 pub use crate::model::TodoStatus;
+pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
+pub use commands::init::InitializationOutcome;
+pub use commands::purge::PurgeOutcome;
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
 
 #[cfg(test)]

--- a/crates/padzapp/src/api/util.rs
+++ b/crates/padzapp/src/api/util.rs
@@ -9,7 +9,8 @@ use super::selectors::parse_selectors;
 use super::PadzApi;
 
 impl<S: DataStore> PadzApi<S> {
-    pub fn doctor(&mut self, scope: Scope) -> Result<commands::CmdResult> {
+    /// Reconciles the store and returns a clean/repaired outcome with direct counts.
+    pub fn doctor(&mut self, scope: Scope) -> Result<commands::doctor::DoctorOutcome> {
         commands::doctor::run(&mut self.store, scope)
     }
 
@@ -73,7 +74,13 @@ mod tests {
 
         let result = api.doctor(Scope::Project).unwrap();
 
-        assert!(!result.messages.is_empty());
+        assert_eq!(
+            result,
+            crate::commands::doctor::DoctorOutcome::Clean {
+                missing_files: 0,
+                recovered_files: 0
+            }
+        );
     }
 
     #[test]

--- a/crates/padzapp/src/commands/doctor.rs
+++ b/crates/padzapp/src/commands/doctor.rs
@@ -1,31 +1,33 @@
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::Result;
 use crate::model::Scope;
 use crate::store::DataStore;
 
-pub fn run<S: DataStore>(store: &mut S, scope: Scope) -> Result<CmdResult> {
+/// Semantic result of reconciling a store's index and content files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorOutcome {
+    Clean {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+    Repaired {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+}
+
+pub fn run<S: DataStore>(store: &mut S, scope: Scope) -> Result<DoctorOutcome> {
     let report = store.doctor(scope)?;
-    let mut result = CmdResult::default();
-
     if report.fixed_missing_files == 0 && report.recovered_files == 0 {
-        result.add_message(CmdMessage::success("No inconsistencies found."));
+        Ok(DoctorOutcome::Clean {
+            missing_files: 0,
+            recovered_files: 0,
+        })
     } else {
-        result.add_message(CmdMessage::warning("Inconsistencies found and fixed:"));
-        if report.fixed_missing_files > 0 {
-            result.add_message(CmdMessage::info(format!(
-                "  - Removed {} pad(s) listed in DB but missing from disk.",
-                report.fixed_missing_files
-            )));
-        }
-        if report.recovered_files > 0 {
-            result.add_message(CmdMessage::success(format!(
-                "  - Recovered {} pad(s) found on disk but missing from DB.",
-                report.recovered_files
-            )));
-        }
+        Ok(DoctorOutcome::Repaired {
+            missing_files: report.fixed_missing_files,
+            recovered_files: report.recovered_files,
+        })
     }
-
-    Ok(result)
 }
 
 #[cfg(test)]
@@ -60,8 +62,13 @@ mod tests {
 
         let result = run(&mut store, Scope::Project).unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("No inconsistencies"));
+        assert_eq!(
+            result,
+            DoctorOutcome::Clean {
+                missing_files: 0,
+                recovered_files: 0
+            }
+        );
     }
 
     #[test]
@@ -77,14 +84,13 @@ mod tests {
         let mut store = bucketed_with_active(backend);
         let result = run(&mut store, Scope::Project).unwrap();
 
-        // Should report inconsistencies found
-        assert!(result.messages.len() >= 2);
-        assert!(result.messages[0].content.contains("Inconsistencies found"));
-        // Should report recovered files
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Recovered") && m.content.contains("1")));
+        assert_eq!(
+            result,
+            DoctorOutcome::Repaired {
+                missing_files: 0,
+                recovered_files: 1
+            }
+        );
     }
 
     #[test]
@@ -114,14 +120,13 @@ mod tests {
         let mut store = bucketed_with_active(backend);
         let result = run(&mut store, Scope::Project).unwrap();
 
-        // Should report inconsistencies found
-        assert!(result.messages.len() >= 2);
-        assert!(result.messages[0].content.contains("Inconsistencies found"));
-        // Should report removed entries
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Removed") && m.content.contains("1")));
+        assert_eq!(
+            result,
+            DoctorOutcome::Repaired {
+                missing_files: 1,
+                recovered_files: 0
+            }
+        );
     }
 
     #[test]
@@ -157,16 +162,12 @@ mod tests {
         let mut store = bucketed_with_active(backend);
         let result = run(&mut store, Scope::Project).unwrap();
 
-        // Should have warning + both issue types
-        assert!(result.messages.len() >= 3);
-        assert!(result.messages[0].content.contains("Inconsistencies found"));
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Removed")));
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Recovered")));
+        assert_eq!(
+            result,
+            DoctorOutcome::Repaired {
+                missing_files: 1,
+                recovered_files: 1
+            }
+        );
     }
 }

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -1,34 +1,30 @@
-use crate::commands::{CmdMessage, CmdResult, PadzPaths};
+use crate::commands::PadzPaths;
 use crate::error::{PadzError, Result};
 use crate::init::create_bucket_layout;
 use crate::model::Scope;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
+/// Semantic result of explicit store initialization or link maintenance.
+///
+/// The reusable application layer reports only what happened. Shell-completion
+/// guidance, success wording, styles, and blank-line layout belong to clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitializationOutcome {
+    Initialized { scope: Scope, store_path: PathBuf },
+    Linked { target: PathBuf },
+    Unlinked,
+}
+
+pub fn run(paths: &PadzPaths, scope: Scope) -> Result<InitializationOutcome> {
     let dir = paths.scope_dir(scope)?;
 
     create_bucket_layout(&dir)?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!(
-        "Initialized padz store at {}",
-        dir.display()
-    )));
-
-    // Add shell completion hint
-    result.add_message(CmdMessage::info(String::new())); // blank line
-    result.add_message(CmdMessage::info(
-        "Tip: Enable shell completions for padz:".to_string(),
-    ));
-    result.add_message(CmdMessage::info(
-        "  eval \"$(padz completions bash)\"  # add to ~/.bashrc".to_string(),
-    ));
-    result.add_message(CmdMessage::info(
-        "  eval \"$(padz completions zsh)\"   # add to ~/.zshrc".to_string(),
-    ));
-
-    Ok(result)
+    Ok(InitializationOutcome::Initialized {
+        scope,
+        store_path: dir,
+    })
 }
 
 /// Create a persistent link from the current project's `.padz/` to another project's data.
@@ -38,7 +34,7 @@ pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
 ///
 /// `local_padz` is the **pre-resolution** `.padz/` directory (i.e., the CWD-based one,
 /// before any existing link is followed).
-pub fn link(local_padz: &Path, target: &Path) -> Result<CmdResult> {
+pub fn link(local_padz: &Path, target: &Path) -> Result<InitializationOutcome> {
     // Canonicalize target
     let target = target.canonicalize().map_err(|_| {
         PadzError::Store(format!(
@@ -90,18 +86,15 @@ pub fn link(local_padz: &Path, target: &Path) -> Result<CmdResult> {
         target_root.to_string_lossy().as_bytes(),
     )?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!(
-        "Linked to {}",
-        target_padz.display()
-    )));
-    Ok(result)
+    Ok(InitializationOutcome::Linked {
+        target: target_padz,
+    })
 }
 
 /// Remove an existing link file.
 ///
 /// `local_padz` is the **pre-resolution** `.padz/` directory.
-pub fn unlink(local_padz: &Path) -> Result<CmdResult> {
+pub fn unlink(local_padz: &Path) -> Result<InitializationOutcome> {
     let link_file = local_padz.join("link");
 
     if !link_file.exists() {
@@ -112,9 +105,7 @@ pub fn unlink(local_padz: &Path) -> Result<CmdResult> {
 
     fs::remove_file(&link_file)?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success("Unlinked.".to_string()));
-    Ok(result)
+    Ok(InitializationOutcome::Unlinked)
 }
 
 #[cfg(test)]
@@ -127,6 +118,28 @@ mod tests {
         fs::create_dir_all(dir.join("active")).unwrap();
         fs::create_dir_all(dir.join("archived")).unwrap();
         fs::create_dir_all(dir.join("deleted")).unwrap();
+    }
+
+    #[test]
+    fn initialization_returns_scope_and_store_path() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project").join(".padz");
+        let paths = PadzPaths {
+            project: Some(project.clone()),
+            global: temp.path().join("global"),
+            home: None,
+        };
+
+        let outcome = run(&paths, Scope::Project).unwrap();
+
+        assert_eq!(
+            outcome,
+            InitializationOutcome::Initialized {
+                scope: Scope::Project,
+                store_path: project.clone(),
+            }
+        );
+        assert!(project.join("active").is_dir());
     }
 
     #[test]
@@ -150,7 +163,12 @@ mod tests {
             PathBuf::from(link_content.trim()),
             target.canonicalize().unwrap()
         );
-        assert!(result.messages[0].content.contains("Linked to"));
+        assert_eq!(
+            result,
+            InitializationOutcome::Linked {
+                target: target.join(".padz").canonicalize().unwrap()
+            }
+        );
     }
 
     #[test]
@@ -234,7 +252,7 @@ mod tests {
         let result = unlink(&padz_dir).unwrap();
 
         assert!(!padz_dir.join("link").exists());
-        assert!(result.messages[0].content.contains("Unlinked"));
+        assert_eq!(result, InitializationOutcome::Unlinked);
     }
 
     #[test]

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -8,7 +8,7 @@
 //! Commands are where the real work happens:
 //! - Implement the actual logic for each operation
 //! - Operate on `Pad`, `Metadata`, and other domain types
-//! - Return structured `CmdResult` with affected pads and messages
+//! - Return structured `CmdResult` values or operation-specific semantic outcomes
 //! - Are completely UI-agnostic
 //!
 //! ## What Commands Do NOT Do
@@ -21,7 +21,7 @@
 //!
 //! ## Structured Returns
 //!
-//! Commands return [`CmdResult`], not strings. This struct carries:
+//! Most commands return [`CmdResult`], not strings. This struct carries:
 //! - `affected_pads`: Pads that were modified (as `DisplayPad` with post-operation index)
 //! - `listed_pads`: Pads to display (as `DisplayPad` with current index)
 //! - `messages`: Structured messages with levels (info, success, warning, error)
@@ -31,7 +31,9 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! The UI layer (CLI, web, etc.) then decides how to render this data.
+//! Initialization, doctor, purge, and artifact-producing commands use dedicated
+//! outcome types where a generic result would obscure the operation's facts. The
+//! UI layer (CLI, web, etc.) decides how to render every result.
 //!
 //! ## Testing Strategy
 //!

--- a/crates/padzapp/src/commands/purge.rs
+++ b/crates/padzapp/src/commands/purge.rs
@@ -1,12 +1,22 @@
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
-use crate::index::{DisplayIndex, PadSelector};
+use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
 use crate::store::Bucket;
 use crate::store::DataStore;
 use uuid::Uuid;
 
 use super::helpers::{indexed_pads, pads_by_selectors, TitleBucket};
+
+/// Semantic result of a permanent-deletion request.
+#[derive(Debug, Clone)]
+pub enum PurgeOutcome {
+    Empty,
+    Purged {
+        selected_pads: Vec<DisplayPad>,
+        total_purged: usize,
+        descendant_count: usize,
+    },
+}
 
 /// Permanently removes pads from the store.
 ///
@@ -27,7 +37,7 @@ pub fn run<S: DataStore>(
     recursive: bool,
     confirmed: bool,
     include_done: bool,
-) -> Result<CmdResult> {
+) -> Result<PurgeOutcome> {
     // 1. Resolve targets
     let pads_to_purge = if selectors.is_empty() {
         let all_pads = indexed_pads(store, scope)?;
@@ -43,9 +53,7 @@ pub fn run<S: DataStore>(
     };
 
     if pads_to_purge.is_empty() {
-        let mut res = CmdResult::default();
-        res.add_message(CmdMessage::info("No pads to purge."));
-        return Ok(res);
+        return Ok(PurgeOutcome::Empty);
     }
 
     // 2. Find descendants
@@ -85,14 +93,6 @@ pub fn run<S: DataStore>(
     all_ids.sort();
     all_ids.dedup();
 
-    let mut result = CmdResult::default();
-
-    // Add the "Purging X padz..." message first
-    result.add_message(CmdMessage::info(format!(
-        "Purging {} pad(s)...",
-        total_count
-    )));
-
     for id in all_ids {
         // Try each bucket (deleted first, then active for Done pads, then archived)
         for &bucket in &[Bucket::Deleted, Bucket::Active, Bucket::Archived] {
@@ -103,20 +103,11 @@ pub fn run<S: DataStore>(
         }
     }
 
-    for dp in pads_to_purge {
-        result.add_message(CmdMessage::success(format!(
-            "Purged: {} {}",
-            dp.index, dp.pad.metadata.title
-        )));
-    }
-    if !descendants.is_empty() {
-        result.add_message(CmdMessage::success(format!(
-            "And purged {} descendant(s)",
-            descendants.len()
-        )));
-    }
-
-    Ok(result)
+    Ok(PurgeOutcome::Purged {
+        selected_pads: pads_to_purge,
+        total_purged: total_count,
+        descendant_count: descendants.len(),
+    })
 }
 
 #[cfg(test)]
@@ -127,6 +118,29 @@ mod tests {
     use crate::model::Scope;
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
+
+    fn assert_purged(
+        outcome: PurgeOutcome,
+        selected: &[&str],
+        total_purged: usize,
+        descendant_count: usize,
+    ) {
+        let PurgeOutcome::Purged {
+            selected_pads,
+            total_purged: actual_total,
+            descendant_count: actual_descendants,
+        } = outcome
+        else {
+            panic!("expected PurgeOutcome::Purged");
+        };
+        let actual_selected: Vec<String> = selected_pads
+            .iter()
+            .map(|pad| format!("{} {}", pad.index, pad.pad.metadata.title))
+            .collect();
+        assert_eq!(actual_selected, selected);
+        assert_eq!(actual_total, total_purged);
+        assert_eq!(actual_descendants, descendant_count);
+    }
 
     #[test]
     fn purges_deleted_pads_when_confirmed() {
@@ -170,12 +184,7 @@ mod tests {
         )
         .unwrap();
 
-        // Should have "Purging 1 pad(s)..." and "Purged: d1 A"
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 1")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Purged: d1 A")));
+        assert_purged(res, &["d1 A"], 1, 0);
 
         // Verify empty
         let deleted_after = get::run(
@@ -260,10 +269,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Purged: 1 A")));
+        assert_purged(res, &["1 A"], 1, 0);
 
         // Verify gone
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -283,8 +289,7 @@ mod tests {
         // Purge deleted (none) - even with confirmed=true, should just say "No pads"
         let res = run(&mut store, Scope::Project, &[], false, true, false).unwrap();
 
-        assert_eq!(res.messages.len(), 1);
-        assert!(res.messages[0].content.contains("No pads to purge"));
+        assert!(matches!(res, PurgeOutcome::Empty));
 
         // A still exists
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -330,15 +335,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 2"))); // parent + child
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Purged: d1 Parent")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("And purged 1 descendant")));
+        assert_purged(res, &["d1 Parent"], 2, 1);
 
         // Verify Store is empty (both Active and Deleted)
         assert_eq!(
@@ -430,7 +427,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 1")));
+        assert_purged(res, &["d1 B"], 1, 0);
 
         let remaining = store.list_pads(Scope::Project, Bucket::Deleted).unwrap();
         assert_eq!(remaining.len(), 1); // One remains in Deleted bucket
@@ -446,7 +443,7 @@ mod tests {
         );
         // Empty store - even with confirmed=true
         let res = run(&mut store, Scope::Project, &[], false, true, false).unwrap();
-        assert!(res.messages[0].content.contains("No pads to purge"));
+        assert!(matches!(res, PurgeOutcome::Empty));
     }
 
     #[test]
@@ -516,8 +513,7 @@ mod tests {
         // Purge with include_done=true (no selectors)
         let res = run(&mut store, Scope::Project, &[], false, true, true).unwrap();
 
-        // Should purge the Done pad
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 1")));
+        assert_purged(res, &["1 Complete Me"], 1, 0);
 
         // "Keep Me" (Planned) should still exist
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -546,8 +542,7 @@ mod tests {
         // Purge with include_done=false (default / notes mode)
         let res = run(&mut store, Scope::Project, &[], false, true, false).unwrap();
 
-        // No pads to purge (Done but not Deleted, and include_done is false)
-        assert!(res.messages[0].content.contains("No pads to purge"));
+        assert!(matches!(res, PurgeOutcome::Empty));
 
         // A still exists
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -609,7 +604,7 @@ mod tests {
         // Purge with include_done=true - should get both Done and Deleted
         let res = run(&mut store, Scope::Project, &[], false, true, true).unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 2")));
+        assert_purged(res, &["2 Done Pad", "d1 Deleted Pad"], 2, 0);
 
         // Only "Active Pad" should remain
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();

--- a/crates/padzapp/src/commands/purge.rs
+++ b/crates/padzapp/src/commands/purge.rs
@@ -3,6 +3,7 @@ use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
 use crate::store::Bucket;
 use crate::store::DataStore;
+use std::collections::HashSet;
 use uuid::Uuid;
 
 use super::helpers::{indexed_pads, pads_by_selectors, TitleBucket};
@@ -12,8 +13,11 @@ use super::helpers::{indexed_pads, pads_by_selectors, TitleBucket};
 pub enum PurgeOutcome {
     Empty,
     Purged {
+        /// Explicitly selected pads, de-duplicated by UUID in display order.
         selected_pads: Vec<DisplayPad>,
+        /// Total number of unique pads permanently deleted.
         total_purged: usize,
+        /// Unique deleted descendants that were not explicitly selected.
         descendant_count: usize,
     },
 }
@@ -30,6 +34,7 @@ pub enum PurgeOutcome {
 /// - If `recursive` is false and any target has children, returns an error
 /// - If `confirmed` is false, returns an error (no pads are deleted)
 /// - `include_done`: when true and no selectors given, also purges pads with Done status
+/// - Duplicate display indexes and selected/descendant overlap count each UUID once
 pub fn run<S: DataStore>(
     store: &mut S,
     scope: Scope,
@@ -39,7 +44,7 @@ pub fn run<S: DataStore>(
     include_done: bool,
 ) -> Result<PurgeOutcome> {
     // 1. Resolve targets
-    let pads_to_purge = if selectors.is_empty() {
+    let mut pads_to_purge = if selectors.is_empty() {
         let all_pads = indexed_pads(store, scope)?;
         all_pads
             .into_iter()
@@ -51,6 +56,11 @@ pub fn run<S: DataStore>(
     } else {
         pads_by_selectors(store, scope, selectors, true, TitleBucket::Deleted)?
     };
+
+    // Pinned active pads appear under both pinned and regular display indexes.
+    // Preserve the first display identity while keeping semantic selections unique.
+    let mut seen_targets = HashSet::new();
+    pads_to_purge.retain(|dp| seen_targets.insert(dp.pad.metadata.id));
 
     if pads_to_purge.is_empty() {
         return Ok(PurgeOutcome::Empty);
@@ -76,8 +86,15 @@ pub fn run<S: DataStore>(
         )));
     }
 
-    // 4. Calculate total count for message
-    let total_count = pads_to_purge.len() + descendants.len();
+    // 4. Build the unique deletion set. A selected child can also be returned as
+    // a descendant of another selected pad, but remains an explicit selection.
+    let mut all_ids = target_ids;
+    all_ids.extend(descendants);
+    all_ids.sort();
+    all_ids.dedup();
+
+    let total_count = all_ids.len();
+    let descendant_count = total_count - pads_to_purge.len();
 
     // 5. Confirmation check - must come after we know the count
     if !confirmed {
@@ -88,11 +105,6 @@ pub fn run<S: DataStore>(
     }
 
     // 6. Execute the purge
-    let mut all_ids = target_ids;
-    all_ids.extend(descendants.clone());
-    all_ids.sort();
-    all_ids.dedup();
-
     for id in all_ids {
         // Try each bucket (deleted first, then active for Done pads, then archived)
         for &bucket in &[Bucket::Deleted, Bucket::Active, Bucket::Archived] {
@@ -106,14 +118,14 @@ pub fn run<S: DataStore>(
     Ok(PurgeOutcome::Purged {
         selected_pads: pads_to_purge,
         total_purged: total_count,
-        descendant_count: descendants.len(),
+        descendant_count,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::{create, delete, get};
+    use crate::commands::{create, delete, get, pinning};
     use crate::index::DisplayIndex;
     use crate::model::Scope;
     use crate::store::bucketed::BucketedStore;
@@ -355,6 +367,40 @@ mod tests {
     }
 
     #[test]
+    fn selected_child_is_not_counted_again_as_a_descendant() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let res = run(
+            &mut store,
+            Scope::Project,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)]),
+            ],
+            true,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_purged(res, &["1 Parent", "1 Child"], 2, 0);
+    }
+
+    #[test]
     fn purge_without_recursive_fails_when_has_children() {
         let mut store = BucketedStore::new(
             MemBackend::new(),
@@ -519,6 +565,40 @@ mod tests {
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(listed.listed_pads.len(), 1);
         assert_eq!(listed.listed_pads[0].pad.metadata.title, "Keep Me");
+    }
+
+    #[test]
+    fn purge_include_done_reports_a_pinned_pad_once() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Complete Me".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        crate::commands::status::complete(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+        pinning::pin(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        let res = run(&mut store, Scope::Project, &[], false, true, true).unwrap();
+
+        assert_purged(res, &["p1 Complete Me"], 1, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Context

for #213

Why this approach: WS01 applies the semantic-result pattern established by #207 at the complete initialization and maintenance boundary. `padzapp` now returns typed initialization, link/unlink, doctor, and purge facts; thin CLI adapters project those facts into mode-independent result DTOs; command-specific MiniJinja templates retain the established human wording, ordering, pluralization, styles, and initialization blank-line/completion layout.

Structured contracts are intentionally changed from prose-only `messages` arrays to tagged factual outcomes. External JSON fixtures pin initialization, clean doctor, empty purge, and completed purge schemas, and the unreleased changelog documents the transition. Confirmation, recursive-safety, invalid-link, unlink, and store failures continue through the existing non-zero error path.

Out of scope: the remaining STD02 semantic-result families in #214-#219 and the later presentation audit/test-pyramid workstreams. Do not broaden this PR into those command families or redesign human output.

Verification:
- `env RUSTC_WRAPPER= pixi run test` — 848 passed, 1 skipped
- commit and push hooks — all 12 lint checks passed

Governing-doc self-check: reviewed the compatibility constraints and non-goals in epic #208 and every acceptance criterion in #213, plus the #207 pattern already present on the epic base. No separate ADR/spec list was supplied in the implementer brief; this mandatory brief-slot gap is recorded here rather than guessed.