### PR TITLE
STD02: Complete Standout Semantic Outcome Ownership

### DIFF
--- a/CHANGELOG/unreleased-semantic-copy-create-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-copy-create-outcomes.md
@@ -1,0 +1,9 @@
+- `copy` structured output now reports CLI-owned `root_pad_count` and ordered
+  `titles` facts instead of a prose-only `messages` result. Nested descendants
+  remain in the single ordered clipboard payload but do not increase the selected
+  root count. Human wording and clipboard bytes remain compatible.
+- Empty piped-input and editor creates now return `{ "kind": "aborted",
+  "reason": "empty_content" }` in structured modes instead of an empty generic
+  modification plus an English warning message. Human `Aborted: empty content`
+  wording and successful exit behavior remain unchanged; no pad, editor fallback,
+  or clipboard write occurs for an empty pipe.

--- a/CHANGELOG/unreleased-semantic-import-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-import-outcomes.md
@@ -1,0 +1,5 @@
+- Import results now expose a semantic report in structured output: overall
+  full/partial/no-import status and total, per-source status and counts, typed
+  metadata warnings, inline-metadata application, skipped archive and directory
+  entries, and tag-registry merge outcomes. Human output retains its existing
+  wording, ordering, and semantic styles.

--- a/CHANGELOG/unreleased-semantic-maintenance-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-maintenance-outcomes.md
@@ -1,0 +1,7 @@
+- Initialization, link/unlink, doctor, and purge now expose semantic structured
+  outcomes instead of prose-only `messages` arrays. Initialization reports its
+  action plus scope/store path or resolved link target; doctor reports a distinct
+  `clean`/`repaired` status with missing/recovered file counts; purge reports a
+  distinct `empty`/`purged` status with selected pad identities, total count, and
+  descendant count. Human wording, ordering, styles, confirmation and recursive
+  safety errors remain unchanged and are rendered by command-specific templates.

--- a/CHANGELOG/unreleased-semantic-pad-mutation-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-pad-mutation-outcomes.md
@@ -1,0 +1,9 @@
+- Pad updates now expose an `outcomes` array with an `updated` kind, canonical
+  display path, title, and `structured`/`content`/`refresh` update kind. Repeated
+  complete/reopen requests, same-parent moves, and empty `delete --completed`
+  requests now expose typed `notices` instead of prose-only `messages`; mixed
+  status requests expose `status_changed` outcomes alongside the paths and
+  requested statuses that were no-ops. This intentionally extends the structured
+  modification schema and removes the migrated English messages. Human wording,
+  status display, and semantic `info`/`success` styling remain unchanged and are
+  rendered by `modification_result.jinja`.

--- a/CHANGELOG/unreleased-semantic-tag-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-tag-outcomes.md
@@ -1,0 +1,8 @@
+- Tag listing now exposes an ordered `tags` array with an explicit
+  `empty`/`listed` status. Tag registry mutations expose `created`/`deleted`/`renamed`
+  actions with their relevant names and affected-pad counts; per-pad assignment and
+  removal expose requested tag arrays, modified-pad counts, and distinct
+  `all_already_present`/`none_present` no-ops. These dedicated structured schemas
+  replace the former prose-only `messages` and generic modification results. Human
+  wording, ordering, brackets, pluralization, pad rows, and semantic `info`/`success`
+  styling remain unchanged through CLI-owned MiniJinja templates.

--- a/CHANGELOG/unreleased-semantic-transfer-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-transfer-outcomes.md
@@ -1,0 +1,9 @@
+- Clone and migrate now expose one semantic cross-store transfer report in
+  structured output. The report identifies operation, direction, resolved peer
+  store, requested selection, copied pad IDs/count, and explicit empty,
+  full-success, partial-success, or no-copy status. Ordered typed diagnostics
+  distinguish source-read and destination-write copy failures, parent orphaning,
+  destination bucket enumeration failures, tag-registry merge failures, and
+  migrate source-delete failures. This intentionally replaces the former
+  prose-only `messages` schema; human wording, ordering, and styles remain
+  compatible through the CLI-owned transfer template.

--- a/crates/padz/src/cli/clipboard.rs
+++ b/crates/padz/src/cli/clipboard.rs
@@ -2,8 +2,9 @@
 //!
 //! A user-environment concern owned by the CLI: each supported platform shells
 //! out to its clipboard *write* tool (`pbcopy`, `xclip`/`xsel`, `clip`); any
-//! other platform is an error. The library never touches the clipboard —
-//! handlers hand pad text to these functions at the CLI boundary.
+//! other platform is an error. The library never touches the clipboard — the
+//! CLI injects a [`ClipboardWriter`] into application state and handlers hand it
+//! semantic pad text at that boundary.
 //!
 //! Write-only by design: padz copies pad text *to* the clipboard after a pad is
 //! saved or viewed, and never reads it back to pre-fill one. There is no
@@ -12,6 +13,25 @@
 
 use padzapp::error::{PadzError, Result};
 use std::process::Command;
+
+/// A CLI-owned destination for semantic clipboard payloads.
+///
+/// The production implementation writes to the platform clipboard. Keeping the
+/// dependency behind this one-method interface lets in-process CLI tests observe
+/// write count and ordering without making rendered output the clipboard source.
+pub trait ClipboardWriter {
+    fn write(&self, text: &str) -> Result<()>;
+}
+
+/// The real platform clipboard used by ordinary Padz invocations.
+#[derive(Debug, Default)]
+pub struct SystemClipboardWriter;
+
+impl ClipboardWriter for SystemClipboardWriter {
+    fn write(&self, text: &str) -> Result<()> {
+        copy_to_clipboard(text)
+    }
+}
 
 /// Copies text to the system clipboard in an OS-specific way.
 /// - macOS: uses pbcopy

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -18,8 +18,8 @@
 
 use super::handlers::AppState;
 use super::render::{
-    list_view_provider, modification_view_provider, terminal_provider, LIST_VIEW,
-    MODIFICATION_VIEW, TERMINAL,
+    list_view_provider, modification_view_provider, tagging_view_provider, terminal_provider,
+    LIST_VIEW, MODIFICATION_VIEW, TAGGING_VIEW, TERMINAL,
 };
 use super::setup::{
     build_command, invocation_default_command, parse_cli, Cli, Commands, CompletionAction,
@@ -93,6 +93,7 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
         .context_fn(TERMINAL, terminal_provider)
         .context_fn(LIST_VIEW, list_view_provider)
         .context_fn(MODIFICATION_VIEW, modification_view_provider)
+        .context_fn(TAGGING_VIEW, tagging_view_provider)
         .commands(Commands::dispatch_config())
         .expect("Failed to configure commands")
         .command_with("create", super::handlers::create__handler, |config| {

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -14,10 +14,10 @@
 // Allow non_snake_case for macro-generated __handler wrapper functions
 #![allow(non_snake_case)]
 
-use crate::cli::clipboard::{copy_to_clipboard, format_for_clipboard};
+use crate::cli::clipboard::{format_for_clipboard, ClipboardWriter, SystemClipboardWriter};
 use crate::cli::errors::to_anyhow;
 use crate::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
-use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
+use padzapp::api::{PadFilter, PadStatusFilter, PadzApi, TodoStatus};
 use padzapp::commands::{CmdOutcome, CmdResult, NestingMode, UpdateKind};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
@@ -26,12 +26,14 @@ use padzapp::store::fs::FileStore;
 use standout::cli::{Artifact, CommandContext, CommandContextInput, Output};
 use standout_macros::handler;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 use super::result::{
+    CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateAbortResult, CreateResult,
     DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
-    MessagesResult, ModificationRequest, ModificationResult, PadContent, PadContentResult,
-    PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
-    TransferResult, UuidResult,
+    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
+    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferResult,
+    UuidResult,
 };
 
 // =============================================================================
@@ -42,14 +44,17 @@ use super::result::{
 #[derive(Clone)]
 pub struct ImportExtensions(pub Vec<String>);
 
-/// Shared application state injected via app_state
-/// Contains the API instance wrapped in RefCell for interior mutability
+/// Shared application state injected via app_state.
+///
+/// Contains the API instance wrapped in `RefCell` for interior mutability and
+/// the CLI-owned clipboard destination used for best-effort final writes.
 ///
 /// State is deliberately free of `OutputMode`: handlers return one typed result
 /// regardless of `--output`, and the output mode is resolved at the app-execution
 /// boundary (see [`super::commands`]).
 pub struct AppState {
     api: RefCell<PadzApi<FileStore>>,
+    clipboard: Rc<dyn ClipboardWriter>,
     pub scope: Scope,
     pub import_extensions: ImportExtensions,
     pub mode: PadzMode,
@@ -67,11 +72,27 @@ impl AppState {
     ) -> Self {
         Self {
             api: RefCell::new(api),
+            clipboard: Rc::new(SystemClipboardWriter),
             scope,
             import_extensions: ImportExtensions(import_extensions),
             mode,
             local_padz_dir,
         }
+    }
+
+    /// Replace the platform clipboard destination.
+    ///
+    /// Production assembly keeps the default system writer. In-process CLI tests
+    /// supply a recording writer so they can prove one ordered write from semantic
+    /// pad data without invoking an OS clipboard command.
+    pub fn with_clipboard_writer(mut self, clipboard: Rc<dyn ClipboardWriter>) -> Self {
+        self.clipboard = clipboard;
+        self
+    }
+
+    /// Best-effort clipboard write, preserving Padz's established failure semantics.
+    fn copy_to_clipboard(&self, text: &str) {
+        let _ = self.clipboard.write(text);
     }
 
     /// Whether todo status icons are part of this invocation's request.
@@ -455,7 +476,7 @@ impl<'a> ScopedApi<'a> {
         // clipboard source.
         let clipboard_text = view_clipboard_text(&view);
         if !clipboard_text.is_empty() {
-            let _ = copy_to_clipboard(&clipboard_text);
+            self.state.copy_to_clipboard(&clipboard_text);
         }
 
         Ok(Output::Render(view))
@@ -467,7 +488,7 @@ impl<'a> ScopedApi<'a> {
         &self,
         indexes: &[String],
         nesting: NestingMode,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<CopyResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
         let indent_per_level: usize = match nesting {
@@ -501,28 +522,23 @@ impl<'a> ScopedApi<'a> {
             }
         }
 
-        let _ = copy_to_clipboard(&clipboard_text);
+        self.state.copy_to_clipboard(&clipboard_text);
 
-        // Report using only the root-level (depth 0) pad titles
-        let root_titles: Vec<&str> = result
+        // Report using only the root-level (depth 0) pad titles. These are the
+        // selected roots; descendants belong in the nested payload but are not
+        // additional selections.
+        let titles: Vec<String> = result
             .listed_pads
             .iter()
             .enumerate()
             .filter(|(i, _)| result.listed_depths.get(*i).copied().unwrap_or(0) == 0)
-            .map(|(_, dp)| dp.pad.metadata.title.as_str())
+            .map(|(_, dp)| dp.pad.metadata.title.clone())
             .collect();
-        let count = root_titles.len();
-        let label = if count == 1 { "pad" } else { "pads" };
-        let msg = format!(
-            "Copied {} {} to clipboard: {}",
-            count,
-            label,
-            root_titles.join(", ")
-        );
 
-        Ok(Output::Render(MessagesResult::new(vec![CmdMessage::info(
-            msg,
-        )])))
+        Ok(Output::Render(CopyResult {
+            root_pad_count: titles.len(),
+            titles,
+        }))
     }
 }
 
@@ -561,10 +577,10 @@ fn parse_nesting_mode(flat: bool, _tree: bool, indented: bool) -> NestingMode {
 }
 
 /// Helper to copy pad content to clipboard (from content string)
-fn copy_content_to_clipboard(content: &str) {
+fn copy_content_to_clipboard(state: &AppState, content: &str) {
     if let Some((title, body)) = extract_title_and_body(content) {
         let clipboard_text = format_for_clipboard(&title, &body);
-        let _ = copy_to_clipboard(&clipboard_text);
+        state.copy_to_clipboard(&clipboard_text);
     }
 }
 
@@ -626,14 +642,15 @@ pub(crate) fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<St
 /// decided here: `cli::input`'s chain resolves it before dispatch and this
 /// handler matches on the resulting [`RequestContent`]. The `editor` /
 /// `no_editor` flags are part of that chain's availability rules, so they are
-/// not read here either.
+/// not read here either. Successful creates preserve the modification schema;
+/// empty piped/editor content returns a typed [`CreateResult::Aborted`] outcome.
 #[handler]
 pub fn create(
     #[ctx] ctx: &CommandContext,
     #[arg] inside: Option<String>,
     #[arg] format: Option<String>,
     #[arg] title: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<CreateResult>, anyhow::Error> {
     let state = get_state(ctx);
     let content = ctx.input::<RequestContent>(CREATE_CONTENT)?;
     let title_arg = if title.is_empty() {
@@ -675,7 +692,7 @@ pub fn create(
             state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
             // Copy to clipboard
             let clipboard_text = format_for_clipboard(&title, &body);
-            let _ = copy_to_clipboard(&clipboard_text);
+            state.copy_to_clipboard(&clipboard_text);
             result
         }
 
@@ -693,7 +710,7 @@ pub fn create(
             let parent_id = result.affected_pads[0].pad.metadata.parent_id;
             state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
             // Copy to clipboard
-            copy_content_to_clipboard(raw);
+            copy_content_to_clipboard(state, raw);
             result
         }
 
@@ -730,7 +747,7 @@ pub fn create(
                             .map_err(to_anyhow)
                     })?;
                     // Copy to clipboard
-                    copy_content_to_clipboard(&pad.content);
+                    copy_content_to_clipboard(state, &pad.content);
                     // Build result
                     let display_pad = padzapp::index::DisplayPad {
                         pad,
@@ -751,23 +768,19 @@ pub fn create(
         }
     };
 
-    Ok(Output::Render(
+    Ok(Output::Render(CreateResult::Created(
         api(ctx).modification_result("Created", result, false),
-    ))
+    )))
 }
 
 /// The result of a `create` the user abandoned by supplying no content.
 ///
-/// No pad was created, so there is nothing to report but the warning.
-fn aborted_create() -> ModificationResult {
-    ModificationResult {
-        action: "Created".to_string(),
-        pads: Vec::new(),
-        messages: vec![CmdMessage::warning("Aborted: empty content")],
-        notices: Vec::new(),
-        outcomes: Vec::new(),
-        request: ModificationRequest::default(),
-    }
+/// No pad was created, so the result carries only the semantic abort facts.
+fn aborted_create() -> CreateResult {
+    CreateResult::Aborted(CreateAbortResult {
+        kind: CreateAbortKindResult::Aborted,
+        reason: CreateAbortReasonResult::EmptyContent,
+    })
 }
 
 /// List all pads with optional filtering.
@@ -894,6 +907,7 @@ pub fn view(
     api(ctx).view_pads(&indexes, uuid, nesting)
 }
 
+/// Copy selected pads to one ordered clipboard payload and return root-selection facts.
 #[handler]
 pub fn copy(
     #[ctx] ctx: &CommandContext,
@@ -902,7 +916,7 @@ pub fn copy(
     #[flag] flat: bool,
     #[flag] tree: bool,
     #[flag] indented: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<CopyResult>, anyhow::Error> {
     let nesting = parse_nesting_mode(flat, tree, indented);
     api(ctx).copy_pads(&indexes, nesting)
 }
@@ -942,7 +956,7 @@ pub fn edit(
         // Quick-edit (todos mode, inline words): the raw text is copied as typed.
         RequestContent::Direct(raw) => {
             let result = update(raw)?;
-            let _ = copy_to_clipboard(raw);
+            state.copy_to_clipboard(raw);
             return Ok(Output::Render(
                 api(ctx).modification_result("Updated", result, false),
             ));
@@ -951,7 +965,7 @@ pub fn edit(
         // Piped content is copied in the pad's title/body shape.
         RequestContent::Piped(raw) => {
             let result = update(raw)?;
-            copy_content_to_clipboard(raw);
+            copy_content_to_clipboard(state, raw);
             return Ok(Output::Render(
                 api(ctx).modification_result("Updated", result, false),
             ));
@@ -995,7 +1009,7 @@ pub fn edit(
     // Refresh pad from disk (re-reads content, updates title)
     match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
         Some(pad) => {
-            copy_content_to_clipboard(&pad.content);
+            copy_content_to_clipboard(state, &pad.content);
             let title = pad.metadata.title.clone();
 
             let display_pad = padzapp::index::DisplayPad {

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -28,9 +28,10 @@ use standout_macros::handler;
 use std::cell::RefCell;
 
 use super::result::{
-    DoctorResult, ExportReportResult, InitializationResult, ListRequest, MessagesResult,
-    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
-    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UuidResult,
+    DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
+    MessagesResult, ModificationRequest, ModificationResult, PadContent, PadContentResult,
+    PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
+    UuidResult,
 };
 
 // =============================================================================
@@ -334,13 +335,14 @@ impl<'a> ScopedApi<'a> {
         })
     }
 
+    /// Project the core semantic import report into the CLI's public DTO.
     pub fn import_pads(
         &self,
         paths: Vec<std::path::PathBuf>,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<ImportResult>, anyhow::Error> {
         let extensions = &self.state.import_extensions.0;
-        let result = self.call(|api, scope| api.import_pads(scope, paths.clone(), extensions))?;
-        self.messages(result)
+        let report = self.call(|api, scope| api.import_pads(scope, paths.clone(), extensions))?;
+        Ok(Output::Render(report.into()))
     }
 
     pub fn transfer_pads(
@@ -1174,11 +1176,12 @@ pub fn export(
     )
 }
 
+/// Import requested paths and return mode-independent semantic facts.
 #[handler]
 pub fn import(
     #[ctx] ctx: &CommandContext,
     #[arg] paths: Vec<String>,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<ImportResult>, anyhow::Error> {
     let paths: Vec<std::path::PathBuf> = paths.into_iter().map(std::path::PathBuf::from).collect();
     api(ctx).import_pads(paths)
 }

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -30,7 +30,7 @@ use std::cell::RefCell;
 use super::result::{
     DoctorResult, ExportReportResult, InitializationResult, ListRequest, MessagesResult,
     ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
-    PathResult, PurgeResult, UuidResult,
+    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UuidResult,
 };
 
 // =============================================================================
@@ -370,23 +370,23 @@ impl<'a> ScopedApi<'a> {
 
     // --- Tags subcommand operations ---
 
-    pub fn list_tags(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.list_tags(scope))?;
-        self.messages(result)
+    pub fn list_tags(&self) -> Result<Output<TagCatalogResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.list_tags(scope))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn delete_tag(&self, name: &str) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.delete_tag(scope, name))?;
-        self.messages(result)
+    pub fn delete_tag(&self, name: &str) -> Result<Output<TagRegistryResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.delete_tag(scope, name))?;
+        Ok(Output::Render(outcome.into()))
     }
 
     pub fn rename_tag(
         &self,
         old_name: &str,
         new_name: &str,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.rename_tag(scope, old_name, new_name))?;
-        self.messages(result)
+    ) -> Result<Output<TagRegistryResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.rename_tag(scope, old_name, new_name))?;
+        Ok(Output::Render(outcome.into()))
     }
 
     // --- List operations ---
@@ -1285,32 +1285,28 @@ pub mod tag {
     pub fn add(
         #[ctx] ctx: &CommandContext,
         #[arg] args: Vec<String>,
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<TaggingResult>, anyhow::Error> {
         let (indexes, tags) = split_indexes_and_tags(&args)?;
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.add_tags_to_pads(state.scope, &indexes, &tags)
                 .map_err(to_anyhow)
         })?;
-        Ok(Output::Render(
-            api(ctx).modification_result("Tagged", result, false),
-        ))
+        Ok(Output::Render(result.into()))
     }
 
     #[handler]
     pub fn remove(
         #[ctx] ctx: &CommandContext,
         #[arg] args: Vec<String>,
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<TaggingResult>, anyhow::Error> {
         let (indexes, tags) = split_indexes_and_tags(&args)?;
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.remove_tags_from_pads(state.scope, &indexes, &tags)
                 .map_err(to_anyhow)
         })?;
-        Ok(Output::Render(
-            api(ctx).modification_result("Untagged", result, false),
-        ))
+        Ok(Output::Render(result.into()))
     }
 
     #[handler]
@@ -1318,7 +1314,7 @@ pub mod tag {
         #[ctx] ctx: &CommandContext,
         #[arg(name = "old_name")] old_name: String,
         #[arg(name = "new_name")] new_name: String,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TagRegistryResult>, anyhow::Error> {
         api(ctx).rename_tag(&old_name, &new_name)
     }
 
@@ -1326,7 +1322,7 @@ pub mod tag {
     pub fn delete(
         #[ctx] ctx: &CommandContext,
         #[arg] name: String,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TagRegistryResult>, anyhow::Error> {
         api(ctx).delete_tag(&name)
     }
 
@@ -1334,14 +1330,14 @@ pub mod tag {
     pub fn list(
         #[ctx] ctx: &CommandContext,
         #[arg] ids: Vec<String>,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TagCatalogResult>, anyhow::Error> {
         if ids.is_empty() {
             api(ctx).list_tags()
         } else {
             let state = get_state(ctx);
-            let result =
+            let outcome =
                 state.with_api(|api| api.list_pad_tags(state.scope, &ids).map_err(to_anyhow))?;
-            Ok(Output::Render(MessagesResult::new(result.messages)))
+            Ok(Output::Render(outcome.into()))
         }
     }
 }

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -1105,7 +1105,7 @@ pub fn path(
     }))
 }
 
-/// Returns the UUID of each selected pad.
+/// Maps each selected domain UUID into the CLI's stable textual UUID result.
 #[handler]
 pub fn uuid(
     #[ctx] ctx: &CommandContext,
@@ -1115,7 +1115,7 @@ pub fn uuid(
     let result = state.with_api(|api| api.pad_uuids(state.scope, &indexes).map_err(to_anyhow))?;
 
     Ok(Output::Render(UuidResult {
-        uuids: result.messages.iter().map(|m| m.content.clone()).collect(),
+        uuids: result.into_iter().map(|uuid| uuid.to_string()).collect(),
     }))
 }
 

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -18,7 +18,7 @@ use crate::cli::clipboard::{copy_to_clipboard, format_for_clipboard};
 use crate::cli::errors::to_anyhow;
 use crate::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
-use padzapp::commands::{CmdResult, NestingMode};
+use padzapp::commands::{CmdOutcome, CmdResult, NestingMode, UpdateKind};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
 use padzapp::model::{extract_title_and_body, Scope};
@@ -163,7 +163,8 @@ impl<'a> ScopedApi<'a> {
             action: action.to_string(),
             pads: result.affected_pads,
             messages: result.messages,
-            notices: result.notices,
+            notices: result.notices.into_iter().map(Into::into).collect(),
+            outcomes: result.outcomes.into_iter().map(Into::into).collect(),
             request: ModificationRequest {
                 status: self.state.wants_status(force_show_status),
             },
@@ -202,14 +203,7 @@ impl<'a> ScopedApi<'a> {
     }
 
     pub fn delete_completed_pads(&self) -> Result<Output<ModificationResult>, anyhow::Error> {
-        let mut result = self.call(|api, scope| api.delete_completed_pads(scope))?;
-
-        if result.affected_pads.is_empty() {
-            result
-                .messages
-                .push(CmdMessage::info("No completed pads to delete."));
-        }
-
+        let result = self.call(|api, scope| api.delete_completed_pads(scope))?;
         self.modification("Deleted", result, false)
     }
 
@@ -774,6 +768,7 @@ fn aborted_create() -> ModificationResult {
         pads: Vec::new(),
         messages: vec![CmdMessage::warning("Aborted: empty content")],
         notices: Vec::new(),
+        outcomes: Vec::new(),
         request: ModificationRequest::default(),
     }
 }
@@ -989,6 +984,10 @@ pub fn edit(
         .ok_or_else(|| anyhow::anyhow!("No pad found"))?;
     let pad_id = pad.pad.metadata.id;
     let display_index = pad.index.clone();
+    let display_path = state.with_api(|api| {
+        api.display_path_by_id(state.scope, pad_id)
+            .map_err(to_anyhow)
+    })?;
 
     let pad_path =
         state.with_api(|api| api.get_path_by_id(state.scope, pad_id).map_err(to_anyhow))?;
@@ -1000,6 +999,7 @@ pub fn edit(
     match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
         Some(pad) => {
             copy_content_to_clipboard(&pad.content);
+            let title = pad.metadata.title.clone();
 
             let display_pad = padzapp::index::DisplayPad {
                 pad,
@@ -1009,6 +1009,11 @@ pub fn edit(
             };
             let result = CmdResult {
                 affected_pads: vec![display_pad],
+                outcomes: vec![CmdOutcome::Updated {
+                    path: display_path,
+                    title,
+                    update_kind: UpdateKind::Refresh,
+                }],
                 ..Default::default()
             };
             Ok(Output::Render(
@@ -1631,15 +1636,18 @@ mod tests {
     }
 
     #[test]
-    fn delete_completed_with_nothing_to_delete_reports_a_message() {
+    fn delete_completed_with_nothing_to_delete_reports_a_semantic_no_op() {
         let app = TestApp::new(PadzMode::Todos);
         app.seed("Still open", "body");
 
         let result = rendered(delete(&app.ctx, vec![], true).unwrap());
 
         assert!(result.pads.is_empty());
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("No completed pads"));
+        assert!(result.messages.is_empty());
+        assert_eq!(
+            result.notices,
+            vec![super::super::result::ModificationNoticeResult::NoCompletedPads]
+        );
     }
 
     // --- path / uuid ----------------------------------------------------------

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -28,8 +28,9 @@ use standout_macros::handler;
 use std::cell::RefCell;
 
 use super::result::{
-    ExportReportResult, ListRequest, MessagesResult, ModificationRequest, ModificationResult,
-    PadContent, PadContentResult, PadListResult, PathResult, UuidResult,
+    DoctorResult, ExportReportResult, InitializationResult, ListRequest, MessagesResult,
+    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
+    PathResult, PurgeResult, UuidResult,
 };
 
 // =============================================================================
@@ -271,41 +272,41 @@ impl<'a> ScopedApi<'a> {
         self.modification("Moved", result, false)
     }
 
-    // --- Message-only operations ---
+    // --- Maintenance outcomes ---
 
     pub fn purge_pads(
         &self,
         indexes: &[String],
         yes: bool,
         recursive: bool,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<PurgeResult>, anyhow::Error> {
         let include_done = self.state.mode == PadzMode::Todos;
-        let result =
+        let outcome =
             self.call(|api, scope| api.purge_pads(scope, indexes, recursive, yes, include_done))?;
-        self.messages(result)
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn doctor(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.doctor(scope))?;
-        self.messages(result)
+    pub fn doctor(&self) -> Result<Output<DoctorResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.doctor(scope))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn init(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.init(scope))?;
-        self.messages(result)
+    pub fn init(&self) -> Result<Output<InitializationResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.init(scope))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn init_link(&self, target: &str) -> Result<Output<MessagesResult>, anyhow::Error> {
+    pub fn init_link(&self, target: &str) -> Result<Output<InitializationResult>, anyhow::Error> {
         let target_path = std::path::PathBuf::from(target);
         let local_padz = &self.state.local_padz_dir;
-        let result = self.call(|api, _scope| api.init_link(local_padz, &target_path))?;
-        self.messages(result)
+        let outcome = self.call(|api, _scope| api.init_link(local_padz, &target_path))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn init_unlink(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
+    pub fn init_unlink(&self) -> Result<Output<InitializationResult>, anyhow::Error> {
         let local_padz = &self.state.local_padz_dir;
-        let result = self.call(|api, _scope| api.init_unlink(local_padz))?;
-        self.messages(result)
+        let outcome = self.call(|api, _scope| api.init_unlink(local_padz))?;
+        Ok(Output::Render(outcome.into()))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1142,7 +1143,7 @@ pub fn purge(
     #[arg] indexes: Vec<String>,
     #[flag] yes: bool,
     #[flag] recursive: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<PurgeResult>, anyhow::Error> {
     api(ctx).purge_pads(&indexes, yes, recursive)
 }
 
@@ -1212,7 +1213,7 @@ pub fn migrate(
 // =============================================================================
 
 #[handler]
-pub fn doctor(#[ctx] ctx: &CommandContext) -> Result<Output<MessagesResult>, anyhow::Error> {
+pub fn doctor(#[ctx] ctx: &CommandContext) -> Result<Output<DoctorResult>, anyhow::Error> {
     api(ctx).doctor()
 }
 
@@ -1221,7 +1222,7 @@ pub fn init(
     #[ctx] ctx: &CommandContext,
     #[arg] link: Option<String>,
     #[flag] unlink: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<InitializationResult>, anyhow::Error> {
     if let Some(target) = link {
         api(ctx).init_link(&target)
     } else if unlink {

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -31,7 +31,7 @@ use super::result::{
     DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
     MessagesResult, ModificationRequest, ModificationResult, PadContent, PadContentResult,
     PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
-    UuidResult,
+    TransferResult, UuidResult,
 };
 
 // =============================================================================
@@ -170,11 +170,6 @@ impl<'a> ScopedApi<'a> {
                 status: self.state.wants_status(force_show_status),
             },
         }
-    }
-
-    /// Map a CmdResult (messages only) into the typed messages result
-    fn messages(&self, result: CmdResult) -> Result<Output<MessagesResult>, anyhow::Error> {
-        Ok(Output::Render(MessagesResult::new(result.messages)))
     }
 
     // --- Modification operations ---
@@ -351,19 +346,19 @@ impl<'a> ScopedApi<'a> {
         to: Option<&str>,
         from: Option<&str>,
         mode: padzapp::commands::transfer::TransferMode,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TransferResult>, anyhow::Error> {
         match (to, from) {
             (Some(dest), None) => {
                 let path = std::path::PathBuf::from(dest);
                 let result =
                     self.call(|api, scope| api.transfer_pads_to(scope, indexes, &path, mode))?;
-                self.messages(result)
+                Ok(Output::Render(result.into()))
             }
             (None, Some(src)) => {
                 let path = std::path::PathBuf::from(src);
                 let result =
                     self.call(|api, scope| api.transfer_pads_from(scope, indexes, &path, mode))?;
-                self.messages(result)
+                Ok(Output::Render(result.into()))
             }
             (Some(_), Some(_)) => Err(anyhow::anyhow!("--to and --from are mutually exclusive")),
             (None, None) => Err(anyhow::anyhow!("exactly one of --to or --from is required")),
@@ -1192,7 +1187,7 @@ pub fn clone(
     #[arg] indexes: Vec<String>,
     #[arg] to: Option<String>,
     #[arg] from: Option<String>,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<TransferResult>, anyhow::Error> {
     api(ctx).transfer_pads(
         &indexes,
         to.as_deref(),
@@ -1207,7 +1202,7 @@ pub fn migrate(
     #[arg] indexes: Vec<String>,
     #[arg] to: Option<String>,
     #[arg] from: Option<String>,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<TransferResult>, anyhow::Error> {
     api(ctx).transfer_pads(
         &indexes,
         to.as_deref(),

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -47,7 +47,7 @@
 
 use super::result::{
     ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadListResult, UpdateKindResult,
+    PadListResult, TaggingResult, UpdateKindResult,
 };
 use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
@@ -68,6 +68,8 @@ pub const DEFAULT_LINE_WIDTH: usize = 80;
 pub const LIST_VIEW: &str = "list_view";
 /// The context name `modification_result.jinja` reads its view data from.
 pub const MODIFICATION_VIEW: &str = "modification_view";
+/// The context name `tagging.jinja` reads its view data from.
+pub const TAGGING_VIEW: &str = "tagging_view";
 /// The context name every template reads layout width from.
 pub const TERMINAL: &str = "terminal";
 
@@ -241,6 +243,15 @@ pub struct MutationOutcomeView {
     pub update_kind: &'static str,
 }
 
+/// Template-ready view for per-pad tag assignment and removal.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaggingView {
+    pub action: &'static str,
+    pub requested_tags: Vec<String>,
+    pub modified_pads: usize,
+    pub rows: Vec<PadRow>,
+}
+
 // =============================================================================
 // Context providers (the render-time seam)
 // =============================================================================
@@ -267,6 +278,14 @@ pub fn list_view_provider(ctx: &RenderContext) -> Value {
 pub fn modification_view_provider(ctx: &RenderContext) -> Value {
     match serde_json::from_value::<ModificationResult>(ctx.data.clone()) {
         Ok(result) => Value::from_serialize(build_modification_view(&result)),
+        Err(_) => Value::UNDEFINED,
+    }
+}
+
+/// Context provider for `tagging.jinja`.
+pub fn tagging_view_provider(ctx: &RenderContext) -> Value {
+    match serde_json::from_value::<TaggingResult>(ctx.data.clone()) {
+        Ok(result) => Value::from_serialize(build_tagging_view(&result)),
         Err(_) => Value::UNDEFINED,
     }
 }
@@ -324,6 +343,43 @@ pub fn build_modification_view(result: &ModificationResult) -> ModificationView 
             .outcomes
             .iter()
             .filter_map(mutation_outcome)
+            .collect(),
+    }
+}
+
+/// Builds the template-ready view for a tag assignment or removal.
+pub fn build_tagging_view(result: &TaggingResult) -> TaggingView {
+    let (action, requested_tags, modified_pads, pads) = match result {
+        TaggingResult::Assigned {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("assigned", requested_tags, *modified_pads, pads),
+        TaggingResult::AllAlreadyPresent {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("all_already_present", requested_tags, *modified_pads, pads),
+        TaggingResult::Removed {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("removed", requested_tags, *modified_pads, pads),
+        TaggingResult::NonePresent {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("none_present", requested_tags, *modified_pads, pads),
+    };
+    let options = super::result::ListRequest::default();
+
+    TaggingView {
+        action,
+        requested_tags: requested_tags.clone(),
+        modified_pads,
+        rows: pads
+            .iter()
+            .map(|pad| row(pad, 0, SectionKind::of(&pad.index), &options))
             .collect(),
     }
 }

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -45,12 +45,14 @@
 //!
 //! Everything a template can decide, a template decides.
 
-use super::result::{ModificationResult, PadListResult};
+use super::result::{
+    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
+    PadListResult, UpdateKindResult,
+};
 use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
 use minijinja::Value;
 use padzapp::api::CmdMessage;
-use padzapp::commands::CmdNotice;
 use padzapp::index::{DisplayIndex, DisplayPad, SearchMatch};
 use padzapp::model::TodoStatus;
 use padzapp::peek::{format_as_peek, PeekResult};
@@ -218,6 +220,8 @@ pub struct ModificationView {
     pub messages: Vec<CmdMessage>,
     /// Presentation-ready projections of semantic core notices.
     pub notices: Vec<ModificationNoticeView>,
+    /// Presentation-ready projections of semantic successful outcomes.
+    pub outcomes: Vec<MutationOutcomeView>,
 }
 
 /// The small amount of display shaping a semantic modification notice needs.
@@ -225,6 +229,16 @@ pub struct ModificationView {
 pub struct ModificationNoticeView {
     pub kind: &'static str,
     pub index: String,
+    pub status: &'static str,
+}
+
+/// The small amount of display shaping a semantic update outcome needs.
+#[derive(Debug, Clone, Serialize)]
+pub struct MutationOutcomeView {
+    pub kind: &'static str,
+    pub index: String,
+    pub title: String,
+    pub update_kind: &'static str,
 }
 
 // =============================================================================
@@ -306,13 +320,37 @@ pub fn build_modification_view(result: &ModificationResult) -> ModificationView 
         show_status: result.request.status,
         messages: result.messages.clone(),
         notices: result.notices.iter().map(modification_notice).collect(),
+        outcomes: result
+            .outcomes
+            .iter()
+            .filter_map(mutation_outcome)
+            .collect(),
     }
 }
 
-fn modification_notice(notice: &CmdNotice) -> ModificationNoticeView {
-    let (kind, path) = match notice {
-        CmdNotice::AlreadyPinned { path } => ("already_pinned", path),
-        CmdNotice::AlreadyUnpinned { path } => ("already_unpinned", path),
+fn modification_notice(notice: &ModificationNoticeResult) -> ModificationNoticeView {
+    let (kind, path, status) = match notice {
+        ModificationNoticeResult::AlreadyPinned { path } => ("already_pinned", path, ""),
+        ModificationNoticeResult::AlreadyUnpinned { path } => ("already_unpinned", path, ""),
+        ModificationNoticeResult::AlreadyAtDestination { path } => {
+            ("already_at_destination", path, "")
+        }
+        ModificationNoticeResult::AlreadyInStatus { path, status } => (
+            "already_in_status",
+            path,
+            match status {
+                MutationStatusResult::Planned => "planned",
+                MutationStatusResult::InProgress => "in progress",
+                MutationStatusResult::Done => "done",
+            },
+        ),
+        ModificationNoticeResult::NoCompletedPads => {
+            return ModificationNoticeView {
+                kind: "no_completed_pads",
+                index: String::new(),
+                status: "",
+            };
+        }
     };
     ModificationNoticeView {
         kind,
@@ -321,6 +359,31 @@ fn modification_notice(notice: &CmdNotice) -> ModificationNoticeView {
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join("."),
+        status,
+    }
+}
+
+fn mutation_outcome(outcome: &MutationOutcomeResult) -> Option<MutationOutcomeView> {
+    match outcome {
+        MutationOutcomeResult::Updated {
+            path,
+            title,
+            update_kind,
+        } => Some(MutationOutcomeView {
+            kind: "updated",
+            index: path
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("."),
+            title: title.clone(),
+            update_kind: match update_kind {
+                UpdateKindResult::Structured => "structured",
+                UpdateKindResult::Content => "content",
+                UpdateKindResult::Refresh => "refresh",
+            },
+        }),
+        MutationOutcomeResult::StatusChanged { .. } => None,
     }
 }
 
@@ -617,6 +680,7 @@ mod tests {
             )],
             messages: vec![],
             notices: vec![],
+            outcomes: vec![],
             request: ModificationRequest { status: true },
         };
         let view = build_modification_view(&result);

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -340,6 +340,341 @@ impl From<padzapp::commands::tagging::TaggingResult> for TaggingResult {
     }
 }
 
+/// CLI projection of a semantic import report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportResult {
+    pub status: ImportStatusResult,
+    pub total_imported: usize,
+    pub sources: Vec<ImportSourceResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportStatusResult {
+    FullSuccess,
+    PartialSuccess,
+    NoImports,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceKindResult {
+    File,
+    Directory,
+    JsonArchive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceStatusResult {
+    Imported,
+    Skipped,
+    Missing,
+    Unreadable,
+    Invalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportSourceResult {
+    pub source: String,
+    pub source_kind: ImportSourceKindResult,
+    pub status: ImportSourceStatusResult,
+    pub imported: usize,
+    pub processed_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub diagnostics: Vec<ImportDiagnosticResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportBucketResult {
+    Active,
+    Archived,
+    Deleted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningSeverityResult {
+    Info,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningCategoryResult {
+    Metadata,
+    Field,
+    Tags,
+    Parent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningReasonResult {
+    NotAnObject,
+    InvalidValue,
+    NonStringEntries,
+    OutsideImportSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetadataWarningResult {
+    pub source_label: String,
+    pub category: MetadataWarningCategoryResult,
+    pub reason: MetadataWarningReasonResult,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    pub severity: MetadataWarningSeverityResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArchiveEntrySkipReasonResult {
+    MissingFile,
+    InvalidEncoding,
+    EmptyContent,
+    StoreFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectoryEntrySkipReasonResult {
+    ReadEntry,
+    InspectEntry,
+    ImportFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagRegistryMergeStatusResult {
+    Merged,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportDiagnosticResult {
+    InlineMetadataApplied {
+        source_label: String,
+        bucket: ImportBucketResult,
+        warning_count: usize,
+    },
+    ArchiveMetadataSummary {
+        pad_id: String,
+        warning_count: usize,
+    },
+    MetadataWarning {
+        warning: MetadataWarningResult,
+    },
+    ArchiveEntrySkipped {
+        entry: String,
+        reason: ArchiveEntrySkipReasonResult,
+        detail: String,
+    },
+    DirectoryEntrySkipped {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        entry: Option<String>,
+        reason: DirectoryEntrySkipReasonResult,
+        detail: String,
+    },
+    TagRegistryMerge {
+        status: TagRegistryMergeStatusResult,
+        /// Number of registry entries successfully persisted by this merge.
+        /// Failed merges always report zero.
+        added: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+impl From<padzapp::commands::import::ImportReport> for ImportResult {
+    fn from(report: padzapp::commands::import::ImportReport) -> Self {
+        Self {
+            status: report.status.into(),
+            total_imported: report.total_imported,
+            sources: report.sources.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::import::ImportStatus> for ImportStatusResult {
+    fn from(status: padzapp::commands::import::ImportStatus) -> Self {
+        use padzapp::commands::import::ImportStatus;
+        match status {
+            ImportStatus::FullSuccess => Self::FullSuccess,
+            ImportStatus::PartialSuccess => Self::PartialSuccess,
+            ImportStatus::NoImports => Self::NoImports,
+        }
+    }
+}
+
+impl From<padzapp::commands::import::ImportSourceReport> for ImportSourceResult {
+    fn from(source: padzapp::commands::import::ImportSourceReport) -> Self {
+        Self {
+            source: source.source.display().to_string(),
+            source_kind: match source.source_kind {
+                padzapp::commands::import::ImportSourceKind::File => ImportSourceKindResult::File,
+                padzapp::commands::import::ImportSourceKind::Directory => {
+                    ImportSourceKindResult::Directory
+                }
+                padzapp::commands::import::ImportSourceKind::JsonArchive => {
+                    ImportSourceKindResult::JsonArchive
+                }
+            },
+            status: match source.status {
+                padzapp::commands::import::ImportSourceStatus::Imported => {
+                    ImportSourceStatusResult::Imported
+                }
+                padzapp::commands::import::ImportSourceStatus::Skipped => {
+                    ImportSourceStatusResult::Skipped
+                }
+                padzapp::commands::import::ImportSourceStatus::Missing => {
+                    ImportSourceStatusResult::Missing
+                }
+                padzapp::commands::import::ImportSourceStatus::Unreadable => {
+                    ImportSourceStatusResult::Unreadable
+                }
+                padzapp::commands::import::ImportSourceStatus::Invalid => {
+                    ImportSourceStatusResult::Invalid
+                }
+            },
+            imported: source.imported,
+            processed_files: source
+                .processed_files
+                .into_iter()
+                .map(|path| path.display().to_string())
+                .collect(),
+            detail: source.detail,
+            diagnostics: source.diagnostics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::import::ImportDiagnostic> for ImportDiagnosticResult {
+    fn from(diagnostic: padzapp::commands::import::ImportDiagnostic) -> Self {
+        use padzapp::commands::import::ImportDiagnostic;
+        match diagnostic {
+            ImportDiagnostic::InlineMetadataApplied {
+                source_label,
+                bucket,
+                warning_count,
+            } => Self::InlineMetadataApplied {
+                source_label,
+                bucket: match bucket {
+                    padzapp::store::Bucket::Active => ImportBucketResult::Active,
+                    padzapp::store::Bucket::Archived => ImportBucketResult::Archived,
+                    padzapp::store::Bucket::Deleted => ImportBucketResult::Deleted,
+                },
+                warning_count,
+            },
+            ImportDiagnostic::ArchiveMetadataSummary {
+                pad_id,
+                warning_count,
+            } => Self::ArchiveMetadataSummary {
+                pad_id: pad_id.to_string(),
+                warning_count,
+            },
+            ImportDiagnostic::MetadataWarning { warning } => Self::MetadataWarning {
+                warning: warning.into(),
+            },
+            ImportDiagnostic::ArchiveEntrySkipped {
+                entry,
+                reason,
+                detail,
+            } => Self::ArchiveEntrySkipped {
+                entry,
+                reason: match reason {
+                    padzapp::commands::import::ArchiveEntrySkipReason::MissingFile => {
+                        ArchiveEntrySkipReasonResult::MissingFile
+                    }
+                    padzapp::commands::import::ArchiveEntrySkipReason::InvalidEncoding => {
+                        ArchiveEntrySkipReasonResult::InvalidEncoding
+                    }
+                    padzapp::commands::import::ArchiveEntrySkipReason::EmptyContent => {
+                        ArchiveEntrySkipReasonResult::EmptyContent
+                    }
+                    padzapp::commands::import::ArchiveEntrySkipReason::StoreFailure => {
+                        ArchiveEntrySkipReasonResult::StoreFailure
+                    }
+                },
+                detail,
+            },
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry,
+                reason,
+                detail,
+            } => Self::DirectoryEntrySkipped {
+                entry: entry.map(|path| path.display().to_string()),
+                reason: match reason {
+                    padzapp::commands::import::DirectoryEntrySkipReason::ReadEntry => {
+                        DirectoryEntrySkipReasonResult::ReadEntry
+                    }
+                    padzapp::commands::import::DirectoryEntrySkipReason::InspectEntry => {
+                        DirectoryEntrySkipReasonResult::InspectEntry
+                    }
+                    padzapp::commands::import::DirectoryEntrySkipReason::ImportFile => {
+                        DirectoryEntrySkipReasonResult::ImportFile
+                    }
+                },
+                detail,
+            },
+            ImportDiagnostic::TagRegistryMerge {
+                status,
+                added,
+                detail,
+            } => Self::TagRegistryMerge {
+                status: match status {
+                    padzapp::commands::import::TagRegistryMergeStatus::Merged => {
+                        TagRegistryMergeStatusResult::Merged
+                    }
+                    padzapp::commands::import::TagRegistryMergeStatus::Failed => {
+                        TagRegistryMergeStatusResult::Failed
+                    }
+                },
+                added,
+                detail,
+            },
+        }
+    }
+}
+
+impl From<padzapp::commands::metadata_apply::MetadataApplicationWarning> for MetadataWarningResult {
+    fn from(warning: padzapp::commands::metadata_apply::MetadataApplicationWarning) -> Self {
+        use padzapp::commands::metadata_apply::{
+            MetadataWarningCategory, MetadataWarningReason, MetadataWarningSeverity,
+        };
+        Self {
+            source_label: warning.source_label,
+            category: match warning.category {
+                MetadataWarningCategory::Metadata => MetadataWarningCategoryResult::Metadata,
+                MetadataWarningCategory::Field => MetadataWarningCategoryResult::Field,
+                MetadataWarningCategory::Tags => MetadataWarningCategoryResult::Tags,
+                MetadataWarningCategory::Parent => MetadataWarningCategoryResult::Parent,
+            },
+            reason: match warning.reason {
+                MetadataWarningReason::NotAnObject => MetadataWarningReasonResult::NotAnObject,
+                MetadataWarningReason::InvalidValue => MetadataWarningReasonResult::InvalidValue,
+                MetadataWarningReason::NonStringEntries => {
+                    MetadataWarningReasonResult::NonStringEntries
+                }
+                MetadataWarningReason::OutsideImportSet => {
+                    MetadataWarningReasonResult::OutsideImportSet
+                }
+            },
+            field: warning.field,
+            count: warning.count,
+            severity: match warning.severity {
+                MetadataWarningSeverity::Info => MetadataWarningSeverityResult::Info,
+                MetadataWarningSeverity::Warning => MetadataWarningSeverityResult::Warning,
+            },
+        }
+    }
+}
+
 /// A command whose whole result is user-facing messages.
 ///
 /// Rendered by `messages.jinja`, which reads `CmdMessage` directly — no view

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -10,8 +10,8 @@
 //!
 //! These are CLI-only adapter types: they exist purely to establish the shell's
 //! result contract, so they live in the binary rather than in `padzapp`. The data
-//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`) is reusable domain data and
-//! stays in `padzapp`.
+//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`, semantic tag outcomes) is
+//! reusable domain data and stays in `padzapp`.
 //!
 //! ## Presentation is not in here
 //!
@@ -198,6 +198,144 @@ impl From<UpdateKind> for UpdateKindResult {
             UpdateKind::Structured => Self::Structured,
             UpdateKind::Content => Self::Content,
             UpdateKind::Refresh => Self::Refresh,
+        }
+    }
+}
+
+/// CLI projection of an ordered tag catalog with an explicit empty state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum TagCatalogResult {
+    Empty { tags: Vec<String> },
+    Listed { tags: Vec<String> },
+}
+
+impl From<padzapp::commands::tags::TagCatalogOutcome> for TagCatalogResult {
+    fn from(outcome: padzapp::commands::tags::TagCatalogOutcome) -> Self {
+        use padzapp::commands::tags::TagCatalogOutcome;
+
+        match outcome {
+            TagCatalogOutcome::Empty => Self::Empty { tags: Vec::new() },
+            TagCatalogOutcome::Listed { tags } => Self::Listed { tags },
+        }
+    }
+}
+
+/// CLI projection of a tag-registry mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum TagRegistryResult {
+    Created {
+        name: String,
+        affected_pads: usize,
+    },
+    Deleted {
+        name: String,
+        affected_pads: usize,
+    },
+    Renamed {
+        old_name: String,
+        new_name: String,
+        affected_pads: usize,
+    },
+}
+
+impl From<padzapp::commands::tags::TagRegistryOutcome> for TagRegistryResult {
+    fn from(outcome: padzapp::commands::tags::TagRegistryOutcome) -> Self {
+        use padzapp::commands::tags::TagRegistryOutcome;
+
+        match outcome {
+            TagRegistryOutcome::Created {
+                name,
+                affected_pads,
+            } => Self::Created {
+                name,
+                affected_pads,
+            },
+            TagRegistryOutcome::Deleted {
+                name,
+                affected_pads,
+            } => Self::Deleted {
+                name,
+                affected_pads,
+            },
+            TagRegistryOutcome::Renamed {
+                old_name,
+                new_name,
+                affected_pads,
+            } => Self::Renamed {
+                old_name,
+                new_name,
+                affected_pads,
+            },
+        }
+    }
+}
+
+/// CLI projection of a per-pad tag mutation or its explicit no-op.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum TaggingResult {
+    Assigned {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+    AllAlreadyPresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+    Removed {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+    NonePresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+}
+
+impl From<padzapp::commands::tagging::TaggingResult> for TaggingResult {
+    fn from(result: padzapp::commands::tagging::TaggingResult) -> Self {
+        use padzapp::commands::tagging::TaggingOutcome;
+
+        let pads = result.affected_pads;
+        match result.outcome {
+            TaggingOutcome::Assigned {
+                requested_tags,
+                modified_pads,
+            } => Self::Assigned {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
+            TaggingOutcome::AllAlreadyPresent {
+                requested_tags,
+                modified_pads,
+            } => Self::AllAlreadyPresent {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
+            TaggingOutcome::Removed {
+                requested_tags,
+                modified_pads,
+            } => Self::Removed {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
+            TaggingOutcome::NonePresent {
+                requested_tags,
+                modified_pads,
+            } => Self::NonePresent {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
         }
     }
 }

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -1002,9 +1002,9 @@ impl From<padzapp::commands::purge::PurgeOutcome> for PurgeResult {
                 selected_pads: selected_pads
                     .into_iter()
                     .map(|selected| PurgePadResult {
-                        selector: selected.index.to_string(),
-                        id: selected.pad.metadata.id.to_string(),
-                        title: selected.pad.metadata.title,
+                        selector: selected.selector(),
+                        id: selected.pad.pad.metadata.id.to_string(),
+                        title: selected.pad.pad.metadata.title,
                     })
                     .collect(),
                 total_purged,

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -102,6 +102,119 @@ impl MessagesResult {
     }
 }
 
+/// CLI projection of explicit store initialization and link maintenance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum InitializationResult {
+    Initialized { scope: String, store_path: String },
+    Linked { target: String },
+    Unlinked,
+}
+
+impl From<padzapp::commands::init::InitializationOutcome> for InitializationResult {
+    fn from(outcome: padzapp::commands::init::InitializationOutcome) -> Self {
+        use padzapp::commands::init::InitializationOutcome;
+
+        match outcome {
+            InitializationOutcome::Initialized { scope, store_path } => Self::Initialized {
+                scope: match scope {
+                    padzapp::model::Scope::Project => "project",
+                    padzapp::model::Scope::Global => "global",
+                }
+                .to_string(),
+                store_path: store_path.display().to_string(),
+            },
+            InitializationOutcome::Linked { target } => Self::Linked {
+                target: target.display().to_string(),
+            },
+            InitializationOutcome::Unlinked => Self::Unlinked,
+        }
+    }
+}
+
+/// CLI projection of a store reconciliation report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DoctorResult {
+    Clean {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+    Repaired {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+}
+
+impl From<padzapp::commands::doctor::DoctorOutcome> for DoctorResult {
+    fn from(outcome: padzapp::commands::doctor::DoctorOutcome) -> Self {
+        use padzapp::commands::doctor::DoctorOutcome;
+
+        match outcome {
+            DoctorOutcome::Clean {
+                missing_files,
+                recovered_files,
+            } => Self::Clean {
+                missing_files,
+                recovered_files,
+            },
+            DoctorOutcome::Repaired {
+                missing_files,
+                recovered_files,
+            } => Self::Repaired {
+                missing_files,
+                recovered_files,
+            },
+        }
+    }
+}
+
+/// Identity facts for one unique, explicitly selected pad in a purge report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PurgePadResult {
+    pub selector: String,
+    pub id: String,
+    pub title: String,
+}
+
+/// CLI projection of a permanent-deletion request with UUID-unique counts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum PurgeResult {
+    Empty,
+    Purged {
+        selected_pads: Vec<PurgePadResult>,
+        total_purged: usize,
+        descendant_count: usize,
+    },
+}
+
+impl From<padzapp::commands::purge::PurgeOutcome> for PurgeResult {
+    fn from(outcome: padzapp::commands::purge::PurgeOutcome) -> Self {
+        use padzapp::commands::purge::PurgeOutcome;
+
+        match outcome {
+            PurgeOutcome::Empty => Self::Empty,
+            PurgeOutcome::Purged {
+                selected_pads,
+                total_purged,
+                descendant_count,
+            } => Self::Purged {
+                selected_pads: selected_pads
+                    .into_iter()
+                    .map(|selected| PurgePadResult {
+                        selector: selected.index.to_string(),
+                        id: selected.pad.metadata.id.to_string(),
+                        title: selected.pad.metadata.title,
+                    })
+                    .collect(),
+                total_purged,
+                descendant_count,
+            },
+        }
+    }
+}
+
 /// The machine-readable report carried by an export artifact.
 ///
 /// Standout wraps this value with its own `receipt` after the final write. An

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -1095,5 +1095,6 @@ pub struct PathResult {
 /// UUIDs of the selected pads, one per selector match.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UuidResult {
+    /// Canonical UUID strings in selector order, with ranges in display order.
     pub uuids: Vec<String>,
 }

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -10,7 +10,7 @@
 //!
 //! These are CLI-only adapter types: they exist purely to establish the shell's
 //! result contract, so they live in the binary rather than in `padzapp`. The data
-//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`, semantic tag outcomes) is
+//! they carry (`DisplayPad`, `CmdMessage`, semantic tag/transfer outcomes) is
 //! reusable domain data and stays in `padzapp`.
 //!
 //! ## Presentation is not in here
@@ -670,6 +670,173 @@ impl From<padzapp::commands::metadata_apply::MetadataApplicationWarning> for Met
             severity: match warning.severity {
                 MetadataWarningSeverity::Info => MetadataWarningSeverityResult::Info,
                 MetadataWarningSeverity::Warning => MetadataWarningSeverityResult::Warning,
+            },
+        }
+    }
+}
+
+/// CLI-owned projection of a complete cross-store clone/migrate report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferResult {
+    pub status: TransferStatusResult,
+    pub operation: TransferOperationResult,
+    pub direction: TransferDirectionResult,
+    pub peer_store: String,
+    pub requested_selection: TransferSelectionResult,
+    pub copied_pad_ids: Vec<String>,
+    pub copied_count: usize,
+    pub diagnostics: Vec<TransferDiagnosticResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferStatusResult {
+    Empty,
+    FullSuccess,
+    PartialSuccess,
+    NoCopies,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferOperationResult {
+    Clone,
+    Migrate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirectionResult {
+    To,
+    From,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferSelectionResult {
+    AllNonDeleted,
+    Explicit { selectors: Vec<String> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferBucketResult {
+    Active,
+    Archived,
+    Deleted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopyFailureCategoryResult {
+    SourceRead,
+    DestinationWrite,
+}
+
+/// Ordered transfer diagnostics; the template renders the compatible prose.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferDiagnosticResult {
+    DestinationBucketEnumerationFailed {
+        bucket: TransferBucketResult,
+        detail: String,
+    },
+    ParentOrphaned {
+        pad_id: String,
+        parent_id: String,
+    },
+    CopyFailed {
+        pad_id: String,
+        category: CopyFailureCategoryResult,
+        detail: String,
+    },
+    TagRegistryMergeFailed {
+        detail: String,
+    },
+    SourceDeleteFailed {
+        pad_id: String,
+        detail: String,
+    },
+}
+
+impl From<padzapp::commands::transfer::TransferReport> for TransferResult {
+    fn from(report: padzapp::commands::transfer::TransferReport) -> Self {
+        use padzapp::commands::transfer::{
+            TransferDirection, TransferMode, TransferSelection, TransferStatus,
+        };
+
+        Self {
+            status: match report.status {
+                TransferStatus::Empty => TransferStatusResult::Empty,
+                TransferStatus::FullSuccess => TransferStatusResult::FullSuccess,
+                TransferStatus::PartialSuccess => TransferStatusResult::PartialSuccess,
+                TransferStatus::NoCopies => TransferStatusResult::NoCopies,
+            },
+            operation: match report.operation {
+                TransferMode::Clone => TransferOperationResult::Clone,
+                TransferMode::Migrate => TransferOperationResult::Migrate,
+            },
+            direction: match report.direction {
+                TransferDirection::To => TransferDirectionResult::To,
+                TransferDirection::From => TransferDirectionResult::From,
+            },
+            peer_store: report.peer_store.display().to_string(),
+            requested_selection: match report.requested_selection {
+                TransferSelection::AllNonDeleted => TransferSelectionResult::AllNonDeleted,
+                TransferSelection::Explicit { selectors } => {
+                    TransferSelectionResult::Explicit { selectors }
+                }
+            },
+            copied_pad_ids: report
+                .copied_pad_ids
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect(),
+            copied_count: report.copied_count,
+            diagnostics: report.diagnostics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::transfer::TransferDiagnostic> for TransferDiagnosticResult {
+    fn from(diagnostic: padzapp::commands::transfer::TransferDiagnostic) -> Self {
+        use padzapp::commands::transfer::{CopyFailureCategory, TransferDiagnostic};
+
+        match diagnostic {
+            TransferDiagnostic::DestinationBucketEnumerationFailed { bucket, detail } => {
+                Self::DestinationBucketEnumerationFailed {
+                    bucket: match bucket {
+                        padzapp::store::Bucket::Active => TransferBucketResult::Active,
+                        padzapp::store::Bucket::Archived => TransferBucketResult::Archived,
+                        padzapp::store::Bucket::Deleted => TransferBucketResult::Deleted,
+                    },
+                    detail,
+                }
+            }
+            TransferDiagnostic::ParentOrphaned { pad_id, parent_id } => Self::ParentOrphaned {
+                pad_id: pad_id.to_string(),
+                parent_id: parent_id.to_string(),
+            },
+            TransferDiagnostic::CopyFailed {
+                pad_id,
+                category,
+                detail,
+            } => Self::CopyFailed {
+                pad_id: pad_id.to_string(),
+                category: match category {
+                    CopyFailureCategory::SourceRead => CopyFailureCategoryResult::SourceRead,
+                    CopyFailureCategory::DestinationWrite => {
+                        CopyFailureCategoryResult::DestinationWrite
+                    }
+                },
+                detail,
+            },
+            TransferDiagnostic::TagRegistryMergeFailed { detail } => {
+                Self::TagRegistryMergeFailed { detail }
+            }
+            TransferDiagnostic::SourceDeleteFailed { pad_id, detail } => Self::SourceDeleteFailed {
+                pad_id: pad_id.to_string(),
+                detail,
             },
         }
     }

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -857,6 +857,50 @@ impl MessagesResult {
     }
 }
 
+/// Semantic facts reported after copying pads to the system clipboard.
+///
+/// Only selected roots contribute to the count and titles. Descendants remain in
+/// the clipboard payload according to the requested nesting mode, but they are not
+/// additional user selections.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CopyResult {
+    pub root_pad_count: usize,
+    pub titles: Vec<String>,
+}
+
+/// The typed outcome of `create`.
+///
+/// `Created` deliberately serializes exactly like the existing
+/// [`ModificationResult`] so successful-create automation remains compatible.
+/// `Aborted` replaces the former prose-only warning with semantic facts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CreateResult {
+    Created(ModificationResult),
+    Aborted(CreateAbortResult),
+}
+
+/// Why a create invocation stopped without creating a pad.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateAbortResult {
+    pub kind: CreateAbortKindResult,
+    pub reason: CreateAbortReasonResult,
+}
+
+/// The top-level outcome class for a create abort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CreateAbortKindResult {
+    Aborted,
+}
+
+/// The semantic reason a create invocation aborted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CreateAbortReasonResult {
+    EmptyContent,
+}
+
 /// CLI projection of explicit store initialization and link maintenance.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -27,8 +27,9 @@
 //! it is part of the result and visible in structured output.
 
 use padzapp::api::CmdMessage;
-use padzapp::commands::{CmdNotice, NestingMode};
-use padzapp::index::DisplayPad;
+use padzapp::commands::{CmdNotice, CmdOutcome, NestingMode, UpdateKind};
+use padzapp::index::{DisplayIndex, DisplayPad};
+use padzapp::model::TodoStatus;
 use serde::{Deserialize, Serialize};
 
 /// What the user asked a listing to show.
@@ -83,8 +84,122 @@ pub struct ModificationResult {
     pub messages: Vec<CmdMessage>,
     /// Machine-readable facts emitted by the core; templates own their prose.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub notices: Vec<CmdNotice>,
+    pub notices: Vec<ModificationNoticeResult>,
+    /// Machine-readable successful outcomes emitted by the core.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outcomes: Vec<MutationOutcomeResult>,
     pub request: ModificationRequest,
+}
+
+/// CLI projection of a semantic mutation no-op.
+///
+/// This keeps the shell's structured schema independent from the core enum while
+/// retaining the `kind` and canonical display-path shape established for pinning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModificationNoticeResult {
+    AlreadyPinned {
+        path: Vec<DisplayIndex>,
+    },
+    AlreadyUnpinned {
+        path: Vec<DisplayIndex>,
+    },
+    AlreadyAtDestination {
+        path: Vec<DisplayIndex>,
+    },
+    AlreadyInStatus {
+        path: Vec<DisplayIndex>,
+        status: MutationStatusResult,
+    },
+    NoCompletedPads,
+}
+
+impl From<CmdNotice> for ModificationNoticeResult {
+    fn from(notice: CmdNotice) -> Self {
+        match notice {
+            CmdNotice::AlreadyPinned { path } => Self::AlreadyPinned { path },
+            CmdNotice::AlreadyUnpinned { path } => Self::AlreadyUnpinned { path },
+            CmdNotice::AlreadyAtDestination { path } => Self::AlreadyAtDestination { path },
+            CmdNotice::AlreadyInStatus { path, status } => Self::AlreadyInStatus {
+                path,
+                status: status.into(),
+            },
+            CmdNotice::NoCompletedPads => Self::NoCompletedPads,
+        }
+    }
+}
+
+/// Requested status exposed by a semantic no-op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationStatusResult {
+    Planned,
+    InProgress,
+    Done,
+}
+
+impl From<TodoStatus> for MutationStatusResult {
+    fn from(status: TodoStatus) -> Self {
+        match status {
+            TodoStatus::Planned => Self::Planned,
+            TodoStatus::InProgress => Self::InProgress,
+            TodoStatus::Done => Self::Done,
+        }
+    }
+}
+
+/// CLI projection of a successful semantic pad mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MutationOutcomeResult {
+    Updated {
+        path: Vec<DisplayIndex>,
+        title: String,
+        update_kind: UpdateKindResult,
+    },
+    StatusChanged {
+        path: Vec<DisplayIndex>,
+        status: MutationStatusResult,
+    },
+}
+
+impl From<CmdOutcome> for MutationOutcomeResult {
+    fn from(outcome: CmdOutcome) -> Self {
+        match outcome {
+            CmdOutcome::Updated {
+                path,
+                title,
+                update_kind,
+            } => Self::Updated {
+                path,
+                title,
+                update_kind: update_kind.into(),
+            },
+            CmdOutcome::StatusChanged { path, status } => Self::StatusChanged {
+                path,
+                status: status.into(),
+            },
+        }
+    }
+}
+
+/// How an update reached the core, as part of the shell's public result schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateKindResult {
+    Structured,
+    Content,
+    Refresh,
+}
+
+impl From<UpdateKind> for UpdateKindResult {
+    fn from(kind: UpdateKind) -> Self {
+        match kind {
+            UpdateKind::Structured => Self::Structured,
+            UpdateKind::Content => Self::Content,
+            UpdateKind::Refresh => Self::Refresh,
+        }
+    }
 }
 
 /// A command whose whole result is user-facing messages.

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -713,7 +713,7 @@ pub enum Commands {
 
     /// Import files as pads
     #[command(display_order = 22)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "import")]
     Import {
         /// Paths to files or directories to import
         #[arg(required = true, num_args = 1..)]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -722,7 +722,7 @@ pub enum Commands {
 
     /// Copy pads to (or from) another padz store (source is kept)
     #[command(display_order = 23)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "transfer")]
     Clone {
         /// Indexes of the pads (e.g. 1 2) - if omitted, all non-deleted pads (active + archived)
         #[arg(required = false, num_args = 0.., add = active_pads_completer())]
@@ -739,7 +739,7 @@ pub enum Commands {
 
     /// Move pads to (or from) another padz store (source is removed on success)
     #[command(display_order = 24)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "transfer")]
     Migrate {
         /// Indexes of the pads (e.g. 1 2) - if omitted, all non-deleted pads (active + archived)
         #[arg(required = false, num_args = 0.., add = active_pads_completer())]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -501,9 +501,9 @@ pub enum Commands {
         indented: bool,
     },
 
-    /// Copy one or more pads to the clipboard (without printing)
+    /// Copy one or more pads to the clipboard without printing their contents
     #[command(alias = "cp", display_order = 10)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "copy")]
     Copy {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -832,7 +832,7 @@ pub enum ConfigSubcommand {
 pub enum TagCommands {
     /// Add tags to pads (auto-creates tags if needed)
     #[command(display_order = 25)]
-    #[dispatch(pure, template = "modification_result")]
+    #[dispatch(pure, template = "tagging")]
     Add {
         /// Pad selectors followed by tag names (e.g. 1 2 feature work)
         #[arg(required = true, num_args = 1..)]
@@ -841,7 +841,7 @@ pub enum TagCommands {
 
     /// Remove tags from pads
     #[command(display_order = 26)]
-    #[dispatch(pure, template = "modification_result")]
+    #[dispatch(pure, template = "tagging")]
     Remove {
         /// Pad selectors followed by tag names (e.g. 1 2 feature work)
         #[arg(required = true, num_args = 1..)]
@@ -850,7 +850,7 @@ pub enum TagCommands {
 
     /// Rename a tag (updates all pads)
     #[command(alias = "mv", display_order = 27)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "tag_registry")]
     Rename {
         /// Current name of the tag
         old_name: String,
@@ -860,7 +860,7 @@ pub enum TagCommands {
 
     /// Delete a tag (removes from all pads)
     #[command(alias = "rm", display_order = 28)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "tag_registry")]
     Delete {
         /// Name of the tag to delete
         name: String,
@@ -868,7 +868,7 @@ pub enum TagCommands {
 
     /// List all defined tags, or tags for specific pads
     #[command(alias = "ls", display_order = 29)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "tag_catalog")]
     List {
         /// Pad IDs to show tags for (e.g. 1, 2 3, 1-3). If omitted, lists all tags.
         #[arg(num_args = 0..)]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -658,7 +658,7 @@ pub enum Commands {
     // --- Data operations ---
     /// Permanently delete pads
     #[command(display_order = 20)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "purge")]
     Purge {
         /// Indexes of the pads (e.g. d1 d2) - if omitted, purges all deleted pads
         #[arg(required = false, num_args = 0.., add = deleted_pads_completer())]
@@ -763,7 +763,7 @@ pub enum Commands {
     // --- Misc commands ---
     /// Check and fix data inconsistencies
     #[command(display_order = 30)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "doctor")]
     Doctor,
 
     /// Manage configuration
@@ -776,7 +776,7 @@ pub enum Commands {
 
     /// Initialize the store (optional utility)
     #[command(display_order = 32)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "initialization")]
     Init {
         /// Link to another project's padz data
         #[arg(long, value_name = "PATH", conflicts_with = "unlink")]

--- a/crates/padz/src/cli/templates/copy.jinja
+++ b/crates/padz/src/cli/templates/copy.jinja
@@ -1,0 +1,2 @@
+{#- Copy reports selected-root facts; descendants belong only to the payload. -#}
+[info]Copied {{ root_pad_count }} {{ "pad" if root_pad_count == 1 else "pads" }} to clipboard: {{ titles | join(", ") }}[/info]

--- a/crates/padz/src/cli/templates/doctor.jinja
+++ b/crates/padz/src/cli/templates/doctor.jinja
@@ -1,0 +1,12 @@
+{#- Human projection of DoctorResult; counts and status remain structured facts. -#}
+{%- if status == "clean" -%}
+[success]No inconsistencies found.[/success]{{ "" | nl }}
+{%- else -%}
+[warning]Inconsistencies found and fixed:[/warning]{{ "" | nl }}
+{%- if missing_files > 0 -%}
+[info]  - Removed {{ missing_files }} pad(s) listed in DB but missing from disk.[/info]{{ "" | nl }}
+{%- endif -%}
+{%- if recovered_files > 0 -%}
+[success]  - Recovered {{ recovered_files }} pad(s) found on disk but missing from DB.[/success]{{ "" | nl }}
+{%- endif -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/import.jinja
+++ b/crates/padz/src/cli/templates/import.jinja
@@ -1,0 +1,51 @@
+{#- Semantic import facts rendered with the historical human wording/order. -#}
+{% for source in sources -%}
+{% if source.source_kind == "json_archive" -%}
+{% if source.status == "imported" or source.status == "skipped" -%}
+[info]Imported {{ source.imported }} pads from {{ source.source }}[/info]
+{% else -%}
+[warning]Failed to import JSON archive {{ source.source }}: {{ source.detail }}[/warning]
+{% endif -%}
+{% else -%}
+{% for file in source.processed_files -%}
+[info]Imported: {{ file }}[/info]
+{% endfor -%}
+{% if source.status == "missing" -%}
+[warning]Path not found: {{ source.source }}[/warning]
+{% elif source.status == "unreadable" or source.status == "invalid" -%}
+[warning]Failed to import: {{ source.source }}[/warning]
+{% endif -%}
+{% endif -%}
+{% for diagnostic in source.diagnostics -%}
+{% if diagnostic.kind == "inline_metadata_applied" and diagnostic.warning_count > 0 -%}
+[info]{{ diagnostic.source_label }}: applied inline metadata[/info]
+{% elif diagnostic.kind == "archive_metadata_summary" -%}
+[info]Pad {{ diagnostic.pad_id }} imported; {{ diagnostic.warning_count }} metadata warning(s)[/info]
+{% elif diagnostic.kind == "metadata_warning" -%}
+{% set warning = diagnostic.warning -%}
+{% if warning.reason == "not_an_object" -%}
+{% set message = warning.source_label ~ ": metadata is not an object, keeping existing fields" -%}
+{% elif warning.reason == "invalid_value" and warning.field == "id" -%}
+{% set message = warning.source_label ~ ": invalid id field, keeping existing UUID" -%}
+{% elif warning.reason == "invalid_value" -%}
+{% set message = warning.source_label ~ ": invalid " ~ warning.field -%}
+{% elif warning.reason == "non_string_entries" -%}
+{% set message = warning.source_label ~ ": " ~ warning.count ~ " non-string tag entries ignored" -%}
+{% else -%}
+{% set message = warning.source_label ~ ": parent not in import set, orphaned to root" -%}
+{% endif -%}
+{{ message | style_as(warning.severity) }}
+{% elif diagnostic.kind == "archive_entry_skipped" -%}
+[warning]Skipping pad entry {{ diagnostic.entry }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "directory_entry_skipped" and diagnostic.entry -%}
+[warning]Skipping directory entry {{ diagnostic.entry }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "directory_entry_skipped" -%}
+[warning]Skipping unreadable directory entry: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "tag_registry_merge" and diagnostic.status == "failed" -%}
+[warning]Failed to merge tag registry: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "tag_registry_merge" and diagnostic.added > 0 -%}
+[info]Merged {{ diagnostic.added }} tag registry entry/entries[/info]
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+[success]Total imported: {{ total_imported }}[/success]{{ "" | nl }}

--- a/crates/padz/src/cli/templates/initialization.jinja
+++ b/crates/padz/src/cli/templates/initialization.jinja
@@ -1,0 +1,12 @@
+{#- Human projection of InitializationResult. Completion guidance and layout are CLI-owned. -#}
+{%- if action == "initialized" -%}
+[success]Initialized padz store at {{ store_path }}[/success]{{ "" | nl -}}
+{{ "" | nl -}}
+[info]Tip: Enable shell completions for padz:[/info]{{ "" | nl -}}
+[info]  eval "$(padz completions bash)"  # add to ~/.bashrc[/info]{{ "" | nl -}}
+[info]  eval "$(padz completions zsh)"   # add to ~/.zshrc[/info]{{ "" | nl }}
+{%- elif action == "linked" -%}
+[success]Linked to {{ target }}[/success]{{ "" | nl }}
+{%- elif action == "unlinked" -%}
+[success]Unlinked.[/success]{{ "" | nl }}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -19,11 +19,27 @@
 {{ msg.content | style_as(msg.level) }}{{ "" | nl }}
 {%- endfor -%}
 
+{#- Semantic successful outcomes: wording stays here; refresh updates deliberately -#}
+{#- add no extra line, preserving the interactive editor's established output. -#}
+{%- for outcome in view.outcomes -%}
+{%- if outcome.kind == "updated" and outcome.update_kind == "structured" -%}
+[success]Pad updated ({{ outcome.index }}): {{ outcome.title }}[/success]{{ "" | nl }}
+{%- elif outcome.kind == "updated" and outcome.update_kind == "content" -%}
+[success]Updated ({{ outcome.index }}): {{ outcome.title }}[/success]{{ "" | nl }}
+{%- endif -%}
+{%- endfor -%}
+
 {#- Semantic notices: wording stays here; structured modes receive kind + fields. -#}
 {%- for notice in view.notices -%}
 {%- if notice.kind == "already_pinned" -%}
 [info]Pad {{ notice.index }} is already pinned[/info]{{ "" | nl }}
 {%- elif notice.kind == "already_unpinned" -%}
 [info]Pad {{ notice.index }} is already unpinned[/info]{{ "" | nl }}
+{%- elif notice.kind == "already_at_destination" -%}
+[info]Pad '{{ notice.index }}' is already at destination[/info]{{ "" | nl }}
+{%- elif notice.kind == "already_in_status" -%}
+[info]Pad {{ notice.index }} is already {{ notice.status }}[/info]{{ "" | nl }}
+{%- elif notice.kind == "no_completed_pads" -%}
+[info]No completed pads to delete.[/info]{{ "" | nl }}
 {%- endif -%}
 {%- endfor -%}

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -1,5 +1,9 @@
 {#- Unified rendering for modification commands. `modification_view` is derived at -#}
 {#- render time from the handler's ModificationResult; see cli::render. -#}
+{#- An empty piped/editor create is a typed abort, not a modification. -#}
+{%- if kind == "aborted" and reason == "empty_content" -%}
+[warning]Aborted: empty content[/warning]{{ "" | nl }}
+{%- else -%}
 {%- set view = modification_view -%}
 {%- set show_status = view.show_status -%}
 {%- set peek_mode = false -%}
@@ -43,3 +47,4 @@
 [info]No completed pads to delete.[/info]{{ "" | nl }}
 {%- endif -%}
 {%- endfor -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/purge.jinja
+++ b/crates/padz/src/cli/templates/purge.jinja
@@ -1,0 +1,12 @@
+{#- Human projection of PurgeResult; the core returns no progress or success prose. -#}
+{%- if status == "empty" -%}
+[info]No pads to purge.[/info]{{ "" | nl }}
+{%- else -%}
+[info]Purging {{ total_purged }} pad(s)...[/info]{{ "" | nl }}
+{%- for selected in selected_pads -%}
+[success]Purged: {{ selected.selector }} {{ selected.title }}[/success]{{ "" | nl }}
+{%- endfor -%}
+{%- if descendant_count > 0 -%}
+[success]And purged {{ descendant_count }} descendant(s)[/success]{{ "" | nl }}
+{%- endif -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/tag_catalog.jinja
+++ b/crates/padz/src/cli/templates/tag_catalog.jinja
@@ -1,0 +1,8 @@
+{#- Ordered tag catalog. The core supplies names and an explicit empty state. -#}
+{%- if status == "empty" -%}
+[info]No tags defined[/info]{{ "" | nl }}
+{%- else -%}
+{%- for tag in tags -%}
+[info]{{ tag }}[/info]{{ "" | nl }}
+{%- endfor -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/tag_registry.jinja
+++ b/crates/padz/src/cli/templates/tag_registry.jinja
@@ -1,0 +1,14 @@
+{#- Human wording for semantic tag-registry mutations. -#}
+{%- if action == "created" -%}
+[success]Created tag '{{ name }}'[/success]{{ "" | nl }}
+{%- elif action == "deleted" -%}
+[success]Deleted tag '{{ name }}'[/success]{{ "" | nl }}
+{%- if affected_pads > 0 -%}
+[info]Removed from {{ affected_pads }} {{ "pad" if affected_pads == 1 else "pads" }}[/info]{{ "" | nl }}
+{%- endif -%}
+{%- elif action == "renamed" -%}
+[success]Renamed tag '{{ old_name }}' to '{{ new_name }}'[/success]{{ "" | nl }}
+{%- if affected_pads > 0 -%}
+[info]Updated {{ affected_pads }} {{ "pad" if affected_pads == 1 else "pads" }}[/info]{{ "" | nl }}
+{%- endif -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/tagging.jinja
+++ b/crates/padz/src/cli/templates/tagging.jinja
@@ -1,0 +1,25 @@
+{#- Per-pad tag changes. `tagging_view` is derived only for human rendering. -#}
+{%- set view = tagging_view -%}
+{%- set show_status = false -%}
+{%- set peek_mode = false -%}
+{%- set count = view.rows | length -%}
+
+{%- if count > 0 -%}
+[info]{{ "Untagged" if view.action in ["removed", "none_present"] else "Tagged" }} {{ count }} {{ "pad" if count == 1 else "pads" }}...[/info]{{ "" | nl }}
+{%- endif -%}
+
+{%- for pad in view.rows -%}
+{%- include "_pad_line.jinja" -%}
+{%- endfor -%}
+
+{%- set tag_count = view.requested_tags | length -%}
+{%- set tag_names = view.requested_tags | join(", ") -%}
+{%- if view.action == "assigned" -%}
+[success]Added {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}] to {{ view.modified_pads }} {{ "pad" if view.modified_pads == 1 else "pads" }}[/success]{{ "" | nl }}
+{%- elif view.action == "all_already_present" -%}
+[info]All pads already have {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}][/info]{{ "" | nl }}
+{%- elif view.action == "removed" -%}
+[success]Removed {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}] from {{ view.modified_pads }} {{ "pad" if view.modified_pads == 1 else "pads" }}[/success]{{ "" | nl }}
+{%- elif view.action == "none_present" -%}
+[info]No pads had {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}][/info]{{ "" | nl }}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/transfer.jinja
+++ b/crates/padz/src/cli/templates/transfer.jinja
@@ -1,0 +1,28 @@
+{#- Semantic cross-store facts rendered with the historical wording/order. -#}
+{% for diagnostic in diagnostics -%}
+{% if diagnostic.kind == "destination_bucket_enumeration_failed" -%}
+{% if diagnostic.bucket == "active" -%}
+{% set bucket = "Active" -%}
+{% elif diagnostic.bucket == "archived" -%}
+{% set bucket = "Archived" -%}
+{% else -%}
+{% set bucket = "Deleted" -%}
+{% endif -%}
+[warning]Could not enumerate destination bucket {{ bucket }}: {{ diagnostic.detail }}. Parent relationships that cross this bucket may be orphaned.[/warning]
+{% elif diagnostic.kind == "parent_orphaned" -%}
+[info]Pad {{ diagnostic.pad_id }}: parent not in move set, orphaned to root[/info]
+{% elif diagnostic.kind == "copy_failed" -%}
+[warning]Failed to {{ operation }} pad {{ diagnostic.pad_id }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "tag_registry_merge_failed" -%}
+[warning]Tag registry merge failed: {{ diagnostic.detail }}[/warning]
+{% else -%}
+[warning]Copied but failed to remove from source, pad {{ diagnostic.pad_id }}: {{ diagnostic.detail }}[/warning]
+{% endif -%}
+{% endfor -%}
+{% if status == "empty" -%}
+[info]No pads to transfer.[/info]
+{% elif status == "no_copies" -%}
+[warning]No pads were {{ "cloned" if operation == "clone" else "migrated" }} to {{ peer_store }}[/warning]
+{% else -%}
+[success]{{ "Cloned" if operation == "clone" else "Migrated" }} {{ copied_count }} pad(s) to {{ peer_store }}[/success]
+{% endif %}

--- a/crates/padz/src/cli/templates/transfer.jinja
+++ b/crates/padz/src/cli/templates/transfer.jinja
@@ -15,8 +15,10 @@
 [warning]Failed to {{ operation }} pad {{ diagnostic.pad_id }}: {{ diagnostic.detail }}[/warning]
 {% elif diagnostic.kind == "tag_registry_merge_failed" -%}
 [warning]Tag registry merge failed: {{ diagnostic.detail }}[/warning]
-{% else -%}
+{% elif diagnostic.kind == "source_delete_failed" -%}
 [warning]Copied but failed to remove from source, pad {{ diagnostic.pad_id }}: {{ diagnostic.detail }}[/warning]
+{% else -%}
+[warning]Transfer reported an unrecognized diagnostic: {{ diagnostic.kind }}[/warning]
 {% endif -%}
 {% endfor -%}
 {% if status == "empty" -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/clone-success.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/clone-success.json
@@ -1,0 +1,13 @@
+{
+  "status": "full_success",
+  "operation": "clone",
+  "direction": "to",
+  "peer_store": "<PEER_STORE>",
+  "requested_selection": {
+    "kind": "explicit",
+    "selectors": ["1"]
+  },
+  "copied_pad_ids": ["<PAD_ID>"],
+  "copied_count": 1,
+  "diagnostics": []
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/complete-mixed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/complete-mixed.json
@@ -1,0 +1,16 @@
+{
+  "notices": [
+    {
+      "kind": "already_in_status",
+      "path": [{ "type": "Regular", "value": 1 }],
+      "status": "done"
+    }
+  ],
+  "outcomes": [
+    {
+      "kind": "status_changed",
+      "path": [{ "type": "Regular", "value": 2 }],
+      "status": "done"
+    }
+  ]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/copy-multiple.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/copy-multiple.json
@@ -1,0 +1,4 @@
+{
+  "root_pad_count": 2,
+  "titles": ["second", "first"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/copy-nested.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/copy-nested.json
@@ -1,0 +1,4 @@
+{
+  "root_pad_count": 1,
+  "titles": ["parent"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/copy-singleton.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/copy-singleton.json
@@ -1,0 +1,4 @@
+{
+  "root_pad_count": 1,
+  "titles": ["single"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/create-aborted.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/create-aborted.json
@@ -1,0 +1,4 @@
+{
+  "kind": "aborted",
+  "reason": "empty_content"
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/delete-completed-empty.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/delete-completed-empty.json
@@ -1,0 +1,1 @@
+[{ "kind": "no_completed_pads" }]

--- a/crates/padz/tests/fixtures/semantic_outcomes/doctor-clean.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/doctor-clean.json
@@ -1,0 +1,5 @@
+{
+  "status": "clean",
+  "missing_files": 0,
+  "recovered_files": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/edit-content.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/edit-content.json
@@ -1,0 +1,11 @@
+[
+  {
+    "kind": "updated",
+    "path": [
+      { "type": "Regular", "value": 1 },
+      { "type": "Regular", "value": 1 }
+    ],
+    "title": "Edited child",
+    "update_kind": "content"
+  }
+]

--- a/crates/padz/tests/fixtures/semantic_outcomes/import-partial.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/import-partial.json
@@ -1,0 +1,31 @@
+{
+  "status": "partial_success",
+  "total_imported": 1,
+  "sources": [
+    {
+      "source": "<SOURCE>",
+      "source_kind": "file",
+      "status": "imported",
+      "imported": 1,
+      "processed_files": ["<SOURCE>"],
+      "diagnostics": [
+        {
+          "kind": "inline_metadata_applied",
+          "source_label": "<SOURCE>",
+          "bucket": "active",
+          "warning_count": 1
+        },
+        {
+          "kind": "metadata_warning",
+          "warning": {
+            "source_label": "<SOURCE>",
+            "category": "field",
+            "reason": "invalid_value",
+            "field": "status",
+            "severity": "warning"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/initialization.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/initialization.json
@@ -1,0 +1,5 @@
+{
+  "action": "initialized",
+  "scope": "project",
+  "store_path": "<STORE_PATH>"
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/move-no-op.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/move-no-op.json
@@ -1,0 +1,9 @@
+[
+  {
+    "kind": "already_at_destination",
+    "path": [
+      { "type": "Regular", "value": 1 },
+      { "type": "Regular", "value": 1 }
+    ]
+  }
+]

--- a/crates/padz/tests/fixtures/semantic_outcomes/purge-completed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/purge-completed.json
@@ -1,0 +1,12 @@
+{
+  "status": "purged",
+  "selected_pads": [
+    {
+      "selector": "d1",
+      "id": "<UUID>",
+      "title": "gone"
+    }
+  ],
+  "total_purged": 1,
+  "descendant_count": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/purge-empty.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/purge-empty.json
@@ -1,0 +1,3 @@
+{
+  "status": "empty"
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/reopen-no-op.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/reopen-no-op.json
@@ -1,0 +1,7 @@
+[
+  {
+    "kind": "already_in_status",
+    "path": [{ "type": "Regular", "value": 1 }],
+    "status": "planned"
+  }
+]

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-all-already-present.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-all-already-present.json
@@ -1,0 +1,5 @@
+{
+  "action": "all_already_present",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-assigned.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-assigned.json
@@ -1,0 +1,5 @@
+{
+  "action": "assigned",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 2
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-empty.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-empty.json
@@ -1,0 +1,4 @@
+{
+  "status": "empty",
+  "tags": []
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-listed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-listed.json
@@ -1,0 +1,4 @@
+{
+  "status": "listed",
+  "tags": ["work", "rust"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-singleton.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-singleton.json
@@ -1,0 +1,4 @@
+{
+  "status": "listed",
+  "tags": ["work"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-deleted.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-deleted.json
@@ -1,0 +1,5 @@
+{
+  "action": "deleted",
+  "name": "new",
+  "affected_pads": 1
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-none-present.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-none-present.json
@@ -1,0 +1,5 @@
+{
+  "action": "none_present",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-removed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-removed.json
@@ -1,0 +1,5 @@
+{
+  "action": "removed",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 1
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-renamed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-renamed.json
@@ -1,0 +1,6 @@
+{
+  "action": "renamed",
+  "old_name": "old",
+  "new_name": "new",
+  "affected_pads": 1
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,8 +26,8 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    ExportFormat, ExportStatus, ExportWarning, MessagesResult, ModificationResult,
-    PadContentResult, PadListResult, PathResult, UuidResult,
+    DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
+    ModificationResult, PadContentResult, PadListResult, PathResult, PurgeResult, UuidResult,
 };
 use padzapp::commands::{CmdNotice, NestingMode};
 use standout::cli::Output;
@@ -546,22 +546,96 @@ fn empty_export_stays_a_non_artifact_result() {
 }
 
 // =============================================================================
-// Message-only family
+// Initialization and maintenance outcomes
 // =============================================================================
 
 #[test]
-fn doctor_maps_a_healthy_store_to_messages() {
+fn initialization_maps_scope_and_store_path() {
+    let fx = Fixture::new();
+    let ctx = support::ctx_with_state(fx.app_state_for(&["init"]));
+
+    let result: InitializationResult = rendered(handlers::init(&ctx, None, false));
+
+    assert_eq!(
+        result,
+        InitializationResult::Initialized {
+            scope: "project".to_string(),
+            store_path: fx.project().join(".padz").display().to_string(),
+        }
+    );
+}
+
+#[test]
+fn link_and_unlink_map_typed_actions_and_resolved_target() {
+    let fx = Fixture::new();
+    let target = fx.root().join("target");
+    padzapp::init::create_bucket_layout(&target.join(".padz")).unwrap();
+    let ctx = fx.ctx();
+
+    let linked: InitializationResult = rendered(handlers::init(
+        &ctx,
+        Some(target.display().to_string()),
+        false,
+    ));
+    assert_eq!(
+        linked,
+        InitializationResult::Linked {
+            target: target
+                .join(".padz")
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string(),
+        }
+    );
+
+    let unlinked: InitializationResult = rendered(handlers::init(&ctx, None, true));
+    assert_eq!(unlinked, InitializationResult::Unlinked);
+}
+
+#[test]
+fn doctor_maps_a_healthy_store_to_a_clean_result() {
     let fx = Fixture::new();
     let state = fx.app_state();
     fx.seed_pad(&state, "note", "");
     let ctx = support::ctx_with_state(state);
 
-    let result: MessagesResult = rendered(handlers::doctor(&ctx));
+    let result: DoctorResult = rendered(handlers::doctor(&ctx));
 
-    assert!(
-        !result.messages.is_empty(),
-        "doctor always reports what it checked"
+    assert_eq!(
+        result,
+        DoctorResult::Clean {
+            missing_files: 0,
+            recovered_files: 0,
+        }
     );
+}
+
+#[test]
+fn purge_maps_selected_pads_and_counts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "gone", "");
+    state
+        .with_api(|api| api.delete_pads(state.scope, &["1"]))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let result: PurgeResult = rendered(handlers::purge(&ctx, vec![], true, false));
+
+    let PurgeResult::Purged {
+        selected_pads,
+        total_purged,
+        descendant_count,
+    } = result
+    else {
+        panic!("expected a completed purge");
+    };
+    assert_eq!(selected_pads.len(), 1);
+    assert_eq!(selected_pads[0].selector, "d1");
+    assert_eq!(selected_pads[0].title, "gone");
+    assert_eq!(total_purged, 1);
+    assert_eq!(descendant_count, 0);
 }
 
 // =============================================================================

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -30,7 +30,9 @@ use padz::cli::result::{
     ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
     MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
     MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
-    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UpdateKindResult, UuidResult,
+    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferDirectionResult,
+    TransferOperationResult, TransferResult, TransferSelectionResult, TransferStatusResult,
+    UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -803,6 +805,49 @@ fn import_maps_core_source_and_metadata_warning_facts() {
                 if warning.reason == MetadataWarningReasonResult::InvalidValue
                     && warning.field.as_deref() == Some("status")
         )));
+}
+
+// =============================================================================
+// Cross-store transfer reports
+// =============================================================================
+
+#[test]
+fn clone_maps_operation_direction_peer_selection_and_copied_ids() {
+    let source = Fixture::new();
+    let peer = Fixture::new();
+    let state = source.app_state();
+    source.seed_pad(&state, "transfer me", "body");
+    let ctx = support::ctx_with_state(state);
+
+    let result: TransferResult = rendered(handlers::clone(
+        &ctx,
+        vec!["1".to_string()],
+        Some(peer.project().display().to_string()),
+        None,
+    ));
+
+    assert_eq!(result.status, TransferStatusResult::FullSuccess);
+    assert_eq!(result.operation, TransferOperationResult::Clone);
+    assert_eq!(result.direction, TransferDirectionResult::To);
+    assert_eq!(
+        result.peer_store,
+        peer.project()
+            .join(".padz")
+            .canonicalize()
+            .unwrap()
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        result.requested_selection,
+        TransferSelectionResult::Explicit {
+            selectors: vec!["1".to_string()]
+        }
+    );
+    assert_eq!(result.copied_count, 1);
+    assert_eq!(result.copied_pad_ids.len(), 1);
+    assert!(uuid::Uuid::parse_str(&result.copied_pad_ids[0]).is_ok());
+    assert!(result.diagnostics.is_empty());
 }
 
 // =============================================================================

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,10 +26,11 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
-    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadContentResult, PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult,
-    TaggingResult, UpdateKindResult, UuidResult,
+    DoctorResult, ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
+    ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
+    MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
+    MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
+    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -768,6 +769,40 @@ fn empty_export_stays_a_non_artifact_result() {
     assert_eq!(report.status, ExportStatus::Empty);
     assert_eq!(report.format, ExportFormat::Archive);
     assert_eq!(report.exported, 0);
+}
+
+// =============================================================================
+// Semantic import reports
+// =============================================================================
+
+#[test]
+fn import_maps_core_source_and_metadata_warning_facts() {
+    let fx = Fixture::new();
+    let source = fx.root().join("bad.md");
+    std::fs::write(
+        &source,
+        "---\npadz.status: NotAThing\n---\n\nImported title\n\nBody",
+    )
+    .unwrap();
+    let state = fx.app_state_for(&["import", source.to_str().unwrap()]);
+    let ctx = support::ctx_with_state(state);
+
+    let result: ImportResult = rendered(handlers::import(&ctx, vec![source.display().to_string()]));
+
+    assert_eq!(result.status, ImportStatusResult::PartialSuccess);
+    assert_eq!(result.total_imported, 1);
+    assert_eq!(result.sources[0].source, source.display().to_string());
+    assert_eq!(result.sources[0].source_kind, ImportSourceKindResult::File);
+    assert_eq!(result.sources[0].status, ImportSourceStatusResult::Imported);
+    assert!(result.sources[0]
+        .diagnostics
+        .iter()
+        .any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnosticResult::MetadataWarning { warning }
+                if warning.reason == MetadataWarningReasonResult::InvalidValue
+                    && warning.field.as_deref() == Some("status")
+        )));
 }
 
 // =============================================================================

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -1048,6 +1048,24 @@ fn purge_maps_selected_pads_and_counts() {
     assert_eq!(descendant_count, 0);
 }
 
+#[test]
+fn purge_maps_a_nested_selection_with_its_complete_path() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    let ctx = support::ctx_with_state(state);
+
+    let result: PurgeResult = rendered(handlers::purge(&ctx, vec!["1.1".to_string()], true, false));
+
+    let PurgeResult::Purged { selected_pads, .. } = result else {
+        panic!("expected a completed purge");
+    };
+    assert_eq!(selected_pads.len(), 1);
+    assert_eq!(selected_pads[0].selector, "1.1");
+    assert_eq!(selected_pads[0].title, "child");
+}
+
 // =============================================================================
 // Input-chain consumers — create / edit
 // =============================================================================

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -27,9 +27,10 @@ use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
     DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
-    ModificationResult, PadContentResult, PadListResult, PathResult, PurgeResult, UuidResult,
+    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
+    PadContentResult, PadListResult, PathResult, PurgeResult, UpdateKindResult, UuidResult,
 };
-use padzapp::commands::{CmdNotice, NestingMode};
+use padzapp::commands::NestingMode;
 use standout::cli::Output;
 use support::Fixture;
 
@@ -373,7 +374,7 @@ fn repeated_pin_maps_the_core_notice_without_parsing_prose() {
 
     assert_eq!(
         result.notices,
-        vec![CmdNotice::AlreadyPinned {
+        vec![ModificationNoticeResult::AlreadyPinned {
             path: vec![padzapp::index::DisplayIndex::Pinned(1)]
         }]
     );
@@ -444,6 +445,81 @@ fn move_to_root_needs_only_the_sources() {
     assert!(
         result.pads[0].pad.metadata.parent_id.is_none(),
         "--root detaches the pad from its parent"
+    );
+}
+
+#[test]
+fn same_parent_move_maps_the_nested_no_op_path() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::move_pads(
+        &ctx,
+        vec!["1.1".to_string(), "1".to_string()],
+        false,
+    ));
+
+    assert!(result.pads.is_empty());
+    assert_eq!(
+        result.notices,
+        vec![ModificationNoticeResult::AlreadyAtDestination {
+            path: vec![
+                padzapp::index::DisplayIndex::Regular(1),
+                padzapp::index::DisplayIndex::Regular(1),
+            ],
+        }]
+    );
+    assert!(result.outcomes.is_empty());
+}
+
+#[test]
+fn mixed_complete_maps_changed_pads_and_requested_status_no_ops() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "changed", "");
+    fx.seed_pad(&state, "no op", "");
+    let ctx = support::ctx_with_state(state);
+    rendered(handlers::complete(&ctx, vec!["1".to_string()]));
+
+    let result = rendered(handlers::complete(
+        &ctx,
+        vec!["1".to_string(), "2".to_string()],
+    ));
+
+    assert_eq!(result.pads.len(), 2);
+    assert_eq!(
+        result.notices,
+        vec![ModificationNoticeResult::AlreadyInStatus {
+            path: vec![padzapp::index::DisplayIndex::Regular(1)],
+            status: MutationStatusResult::Done,
+        }]
+    );
+    assert_eq!(
+        result.outcomes,
+        vec![MutationOutcomeResult::StatusChanged {
+            path: vec![padzapp::index::DisplayIndex::Regular(2)],
+            status: MutationStatusResult::Done,
+        }]
+    );
+}
+
+#[test]
+fn empty_delete_completed_maps_the_core_no_op() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "still open", "");
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::delete(&ctx, vec![], true));
+
+    assert!(result.pads.is_empty());
+    assert!(result.messages.is_empty());
+    assert_eq!(
+        result.notices,
+        vec![ModificationNoticeResult::NoCompletedPads]
     );
 }
 
@@ -749,4 +825,39 @@ fn edit_with_direct_content_replaces_the_selected_pads_text() {
 
     assert_eq!(result.pads[0].pad.metadata.title, "after");
     assert!(result.pads[0].pad.content.contains("new body"));
+    assert_eq!(
+        result.outcomes,
+        vec![MutationOutcomeResult::Updated {
+            path: vec![padzapp::index::DisplayIndex::Regular(1)],
+            title: "after".to_string(),
+            update_kind: UpdateKindResult::Content,
+        }]
+    );
+}
+
+#[test]
+fn edit_maps_a_nested_canonical_path_without_parsing_prose() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    let ctx = support::ctx_with_input(
+        state,
+        EDIT_CONTENT,
+        RequestContent::Direct("edited child".to_string()),
+    );
+
+    let result = rendered(handlers::edit(&ctx, vec!["1.1".to_string()]));
+
+    assert_eq!(
+        result.outcomes,
+        vec![MutationOutcomeResult::Updated {
+            path: vec![
+                padzapp::index::DisplayIndex::Regular(1),
+                padzapp::index::DisplayIndex::Regular(1),
+            ],
+            title: "edited child".to_string(),
+            update_kind: UpdateKindResult::Content,
+        }]
+    );
 }

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -28,7 +28,8 @@ use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
     DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
     ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadContentResult, PadListResult, PathResult, PurgeResult, UpdateKindResult, UuidResult,
+    PadContentResult, PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult,
+    TaggingResult, UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -520,6 +521,154 @@ fn empty_delete_completed_maps_the_core_no_op() {
     assert_eq!(
         result.notices,
         vec![ModificationNoticeResult::NoCompletedPads]
+    );
+}
+
+// =============================================================================
+// Tag catalog and mutation outcomes
+// =============================================================================
+
+#[test]
+fn tag_list_maps_empty_and_ordered_catalog_states() {
+    let empty = Fixture::new();
+    let result = rendered(handlers::tag::list(&empty.ctx(), vec![]));
+    assert_eq!(result, TagCatalogResult::Empty { tags: vec![] });
+
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    state
+        .with_api(|api| api.create_tag(state.scope, "work"))
+        .unwrap();
+    state
+        .with_api(|api| api.create_tag(state.scope, "rust"))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::tag::list(&ctx, vec![]));
+    assert_eq!(
+        result,
+        TagCatalogResult::Listed {
+            tags: vec!["work".into(), "rust".into()]
+        }
+    );
+}
+
+#[test]
+fn tag_list_maps_selected_pad_tags_to_a_singleton_catalog() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into()]))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::tag::list(&ctx, vec!["1".into()]));
+    assert_eq!(
+        result,
+        TagCatalogResult::Listed {
+            tags: vec!["work".into()]
+        }
+    );
+}
+
+#[test]
+fn tag_assignment_maps_requested_tags_counts_and_no_op_kind() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    let ctx = support::ctx_with_state(state);
+    let args = vec!["1".into(), "work".into(), "rust".into()];
+
+    let changed = rendered(handlers::tag::add(&ctx, args.clone()));
+    match changed {
+        TaggingResult::Assigned {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => {
+            assert_eq!(requested_tags, vec!["work", "rust"]);
+            assert_eq!(modified_pads, 1);
+            assert_eq!(pads.len(), 1);
+        }
+        other => panic!("expected assigned outcome, got {other:?}"),
+    }
+
+    let no_op = rendered(handlers::tag::add(&ctx, args));
+    match no_op {
+        TaggingResult::AllAlreadyPresent {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => {
+            assert_eq!(requested_tags, vec!["work", "rust"]);
+            assert_eq!(modified_pads, 0);
+            assert_eq!(pads.len(), 1);
+        }
+        other => panic!("expected all-already-present outcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn tag_removal_maps_requested_tags_counts_and_no_op_kind() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    let ctx = support::ctx_with_state(state);
+    let args = vec!["1".into(), "work".into()];
+    rendered(handlers::tag::add(&ctx, args.clone()));
+
+    let changed = rendered(handlers::tag::remove(&ctx, args.clone()));
+    assert!(matches!(
+        changed,
+        TaggingResult::Removed {
+            requested_tags,
+            modified_pads: 1,
+            ..
+        } if requested_tags == vec!["work"]
+    ));
+
+    let no_op = rendered(handlers::tag::remove(&ctx, args));
+    assert!(matches!(
+        no_op,
+        TaggingResult::NonePresent {
+            requested_tags,
+            modified_pads: 0,
+            ..
+        } if requested_tags == vec!["work"]
+    ));
+}
+
+#[test]
+fn tag_registry_handlers_map_names_and_affected_pad_counts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.create_tag(state.scope, "old"))
+        .unwrap();
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["old".into()]))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let renamed = rendered(handlers::tag::rename(&ctx, "old".into(), "new".into()));
+    assert_eq!(
+        renamed,
+        TagRegistryResult::Renamed {
+            old_name: "old".into(),
+            new_name: "new".into(),
+            affected_pads: 1,
+        }
+    );
+
+    let deleted = rendered(handlers::tag::delete(&ctx, "new".into()));
+    assert_eq!(
+        deleted,
+        TagRegistryResult::Deleted {
+            name: "new".into(),
+            affected_pads: 1,
+        }
     );
 }
 

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -699,20 +699,34 @@ fn path_maps_selectors_to_one_filesystem_path_each() {
 }
 
 #[test]
-fn uuid_maps_selectors_to_one_uuid_each() {
+fn uuid_maps_single_multiple_and_range_selectors_in_order() {
     let fx = Fixture::new();
     let state = fx.app_state();
-    fx.seed_pad(&state, "first", "");
+    let first = state
+        .with_api(|api| api.create_pad(state.scope, "first".into(), "".into(), None))
+        .unwrap()
+        .affected_pads[0]
+        .pad
+        .metadata
+        .id;
+    let second = state
+        .with_api(|api| api.create_pad(state.scope, "second".into(), "".into(), None))
+        .unwrap()
+        .affected_pads[0]
+        .pad
+        .metadata
+        .id;
     let ctx = support::ctx_with_state(state);
 
-    let result: UuidResult = rendered(handlers::uuid(&ctx, vec!["1".to_string()]));
+    let single: UuidResult = rendered(handlers::uuid(&ctx, vec!["1".to_string()]));
+    assert_eq!(single.uuids, vec![second.to_string()]);
 
-    assert_eq!(result.uuids.len(), 1);
-    assert!(
-        uuid::Uuid::parse_str(&result.uuids[0]).is_ok(),
-        "uuid handler should return a parseable uuid, got {:?}",
-        result.uuids[0]
-    );
+    let multiple: UuidResult =
+        rendered(handlers::uuid(&ctx, vec!["2".to_string(), "1".to_string()]));
+    assert_eq!(multiple.uuids, vec![first.to_string(), second.to_string()],);
+
+    let range: UuidResult = rendered(handlers::uuid(&ctx, vec!["1-2".to_string()]));
+    assert_eq!(range.uuids, vec![second.to_string(), first.to_string()]);
 }
 
 // =============================================================================

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,7 +26,8 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    DoctorResult, ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
+    CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateResult, DoctorResult,
+    ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
     ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
     MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
     MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
@@ -60,6 +61,16 @@ fn titles(result: &PadListResult) -> Vec<String> {
         .iter()
         .map(|p| p.pad.metadata.title.clone())
         .collect()
+}
+
+/// Unwraps the successful modification arm of create without changing its public
+/// serialized shape.
+#[track_caller]
+fn created(out: Result<Output<CreateResult>, anyhow::Error>) -> ModificationResult {
+    match rendered(out) {
+        CreateResult::Created(result) => result,
+        CreateResult::Aborted(abort) => panic!("expected created pad, got {abort:?}"),
+    }
 }
 
 // =============================================================================
@@ -289,6 +300,86 @@ fn view_of_an_unknown_selector_is_an_error_not_an_empty_result() {
         err.to_string().to_lowercase().contains("99")
             || err.to_string().to_lowercase().contains("not found"),
         "error should name the bad selector, got: {err}"
+    );
+}
+
+// =============================================================================
+// Content family — copy
+// =============================================================================
+
+#[test]
+fn copy_maps_a_single_root_to_typed_facts_and_one_semantic_write() {
+    let fx = Fixture::new();
+    let (state, clipboard) = fx.app_state_with_recording_clipboard_for(&["copy", "1"]);
+    fx.seed_pad(&state, "single", "body");
+    let ctx = support::ctx_with_state(state);
+
+    let result: CopyResult = rendered(handlers::copy(
+        &ctx,
+        vec!["1".to_string()],
+        false,
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(
+        result,
+        CopyResult {
+            root_pad_count: 1,
+            titles: vec!["single".to_string()],
+        }
+    );
+    assert_eq!(clipboard.writes(), vec!["single\n\nbody"]);
+}
+
+#[test]
+fn copy_maps_multiple_roots_in_display_order() {
+    let fx = Fixture::new();
+    let (state, clipboard) = fx.app_state_with_recording_clipboard_for(&["copy", "1", "2"]);
+    fx.seed_pad(&state, "first", "one");
+    fx.seed_pad(&state, "second", "two");
+    let ctx = support::ctx_with_state(state);
+
+    let result: CopyResult = rendered(handlers::copy(
+        &ctx,
+        vec!["1".to_string(), "2".to_string()],
+        false,
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(result.root_pad_count, 2);
+    assert_eq!(result.titles, vec!["second", "first"]);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["second\n\ntwo\n---\n\nfirst\n\none"]
+    );
+}
+
+#[test]
+fn copy_keeps_nested_content_in_the_payload_but_counts_only_the_root() {
+    let fx = Fixture::new();
+    let (state, clipboard) = fx.app_state_with_recording_clipboard_for(&["copy", "1"]);
+    fx.seed_pad(&state, "parent", "parent body");
+    fx.seed_child(&state, "1", "child", "child body");
+    let ctx = support::ctx_with_state(state);
+
+    let result: CopyResult = rendered(handlers::copy(
+        &ctx,
+        vec!["1".to_string()],
+        false,
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(result.root_pad_count, 1);
+    assert_eq!(result.titles, vec!["parent"]);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["parent\n\nparent body\n\nchild\n\nchild body"]
     );
 }
 
@@ -974,7 +1065,7 @@ fn create_with_direct_content_splits_title_from_body() {
         RequestContent::Direct("the title\nthe body".to_string()),
     );
 
-    let result = rendered(handlers::create(&ctx, None, None, vec![]));
+    let result = created(handlers::create(&ctx, None, None, vec![]));
 
     assert_eq!(result.action, "Created");
     assert_eq!(result.pads[0].pad.metadata.title, "the title");
@@ -989,18 +1080,28 @@ fn create_with_an_empty_pipe_aborts_without_creating_a_pad() {
 
     let result = rendered(handlers::create(&ctx, None, None, vec![]));
 
-    assert!(
-        result.pads.is_empty(),
-        "an aborted create must report no pads"
-    );
-    assert!(
-        result
-            .messages
-            .iter()
-            .any(|m| m.content.to_lowercase().contains("aborted")),
-        "the abort must be visible to the user, got: {:?}",
-        result.messages
-    );
+    let CreateResult::Aborted(abort) = result else {
+        panic!("expected a semantic create abort")
+    };
+    assert_eq!(abort.kind, CreateAbortKindResult::Aborted);
+    assert_eq!(abort.reason, CreateAbortReasonResult::EmptyContent);
+
+    let listed = rendered(handlers::list(
+        &ctx,
+        vec![],
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        vec![],
+        false,
+        false,
+    ));
+    assert!(listed.pads.is_empty());
 }
 
 #[test]
@@ -1012,7 +1113,7 @@ fn create_piped_content_takes_its_title_from_the_first_line() {
         RequestContent::Piped("piped title\npiped body".to_string()),
     );
 
-    let result = rendered(handlers::create(&ctx, None, None, vec![]));
+    let result = created(handlers::create(&ctx, None, None, vec![]));
 
     assert_eq!(result.pads[0].pad.metadata.title, "piped title");
 }
@@ -1026,7 +1127,7 @@ fn create_prefers_the_title_argument_over_the_piped_title() {
         RequestContent::Piped("piped title\npiped body".to_string()),
     );
 
-    let result = rendered(handlers::create(
+    let result = created(handlers::create(
         &ctx,
         None,
         None,

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -499,6 +499,199 @@ fn import_report_serializes_in_every_structured_mode() {
 }
 
 // =============================================================================
+// Semantic cross-store transfer outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn clone_preserves_text_and_exposes_transfer_facts() {
+    let text_source = Fixture::new();
+    let text_peer = Fixture::new();
+    let state = text_source.app_state();
+    text_source.seed_pad(&state, "Alpha", "body");
+    drop(state);
+    let peer_arg = text_peer.project().display().to_string();
+    let peer_store = text_peer
+        .project()
+        .join(".padz")
+        .canonicalize()
+        .unwrap()
+        .display()
+        .to_string();
+    let (app, cmd) = text_source.app(&["clone", "1", "--to", &peer_arg]);
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        text_source.argv(&["clone", "1", "--to", &peer_arg, "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), format!("Cloned 1 pad(s) to {peer_store}\n"));
+    drop(text);
+
+    let (app, cmd) = text_source.app(&["clone", "1", "--to", &peer_arg]);
+    let styled = TestHarness::new().run(
+        &app,
+        cmd,
+        text_source.argv(&["clone", "1", "--to", &peer_arg, "--output", "term-debug"]),
+    );
+    styled.assert_success();
+    assert_eq!(
+        styled.stdout(),
+        format!("[success]Cloned 1 pad(s) to {peer_store}[/success]\n")
+    );
+    drop(styled);
+
+    let json_source = Fixture::new();
+    let json_peer = Fixture::new();
+    let state = json_source.app_state();
+    json_source.seed_pad(&state, "Alpha", "body");
+    drop(state);
+    let peer_arg = json_peer.project().display().to_string();
+    let (app, cmd) = json_source.app(&["clone", "1", "--to", &peer_arg]);
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        json_source.argv(&["clone", "1", "--to", &peer_arg, "--output", "json"]),
+    );
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    value["peer_store"] = serde_json::json!("<PEER_STORE>");
+    value["copied_pad_ids"][0] = serde_json::json!("<PAD_ID>");
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/clone-success.json"
+    ))
+    .unwrap();
+    assert_eq!(value, expected);
+    assert!(value.get("messages").is_none());
+}
+
+#[test]
+#[serial]
+fn clone_empty_and_parent_orphaning_are_explicit_states() {
+    let empty_source = Fixture::new();
+    let empty_peer = Fixture::new();
+    let peer_arg = empty_peer.project().display().to_string();
+    let (app, cmd) = empty_source.app(&["clone", "--to", &peer_arg]);
+    let empty = TestHarness::new().run(
+        &app,
+        cmd,
+        empty_source.argv(&["clone", "--to", &peer_arg, "--output", "json"]),
+    );
+    empty.assert_success();
+    let empty_value: serde_json::Value = serde_json::from_str(empty.stdout()).unwrap();
+    assert_eq!(empty_value["status"], "empty");
+    assert_eq!(
+        empty_value["requested_selection"]["kind"],
+        "all_non_deleted"
+    );
+    assert_eq!(empty_value["copied_count"], 0);
+    assert_eq!(empty_value["diagnostics"], serde_json::json!([]));
+    drop(empty);
+
+    let source = Fixture::new();
+    let peer = Fixture::new();
+    let state = source.app_state();
+    source.seed_pad(&state, "Parent", "");
+    source.seed_child(&state, "1", "Child", "");
+    drop(state);
+    let peer_arg = peer.project().display().to_string();
+    let (app, cmd) = source.app(&["clone", "1.1", "--to", &peer_arg]);
+    let orphaned = TestHarness::new().run(
+        &app,
+        cmd,
+        source.argv(&["clone", "1.1", "--to", &peer_arg, "--output", "json"]),
+    );
+    orphaned.assert_success();
+    let value: serde_json::Value = serde_json::from_str(orphaned.stdout()).unwrap();
+    assert_eq!(value["status"], "partial_success");
+    assert_eq!(value["copied_count"], 1);
+    assert_eq!(value["diagnostics"][0]["kind"], "parent_orphaned");
+    assert_eq!(
+        value["diagnostics"][0]["pad_id"],
+        value["copied_pad_ids"][0]
+    );
+    assert!(value["diagnostics"][0]["parent_id"].is_string());
+    drop(orphaned);
+
+    let styled_peer = Fixture::new();
+    let styled_peer_arg = styled_peer.project().display().to_string();
+    let (app, cmd) = source.app(&["clone", "1.1", "--to", &styled_peer_arg]);
+    let styled = TestHarness::new().run(
+        &app,
+        cmd,
+        source.argv(&[
+            "clone",
+            "1.1",
+            "--to",
+            &styled_peer_arg,
+            "--output",
+            "term-debug",
+        ]),
+    );
+    styled.assert_success();
+    let orphan_position = styled
+        .stdout()
+        .find("[info]Pad ")
+        .expect("orphan info style");
+    let summary_position = styled
+        .stdout()
+        .find("[success]Cloned 1 pad(s)")
+        .expect("success summary style");
+    assert!(orphan_position < summary_position);
+    assert!(styled
+        .stdout()
+        .contains("parent not in move set, orphaned to root[/info]"));
+}
+
+#[test]
+#[serial]
+fn transfer_report_serializes_in_every_structured_mode() {
+    for mode in ["json", "yaml", "xml", "csv"] {
+        let source = Fixture::new();
+        let peer = Fixture::new();
+        let state = source.app_state();
+        source.seed_pad(&state, "Alpha", "body");
+        drop(state);
+        let peer_arg = peer.project().display().to_string();
+        let (app, cmd) = source.app(&["clone", "1", "--to", &peer_arg]);
+        let result = TestHarness::new().run(
+            &app,
+            cmd,
+            source.argv(&["clone", "1", "--to", &peer_arg, "--output", mode]),
+        );
+        result.assert_success();
+        match mode {
+            "json" => {
+                serde_json::from_str::<serde_json::Value>(result.stdout()).unwrap();
+            }
+            "yaml" => {
+                serde_yaml::from_str::<serde_yaml::Value>(result.stdout()).unwrap();
+            }
+            "xml" => {
+                let mut reader = quick_xml::Reader::from_str(result.stdout());
+                loop {
+                    match reader.read_event() {
+                        Ok(quick_xml::events::Event::Eof) => break,
+                        Ok(_) => {}
+                        Err(error) => {
+                            panic!("invalid transfer XML: {error}\n{}", result.stdout())
+                        }
+                    }
+                }
+            }
+            "csv" => {
+                let mut reader = csv::Reader::from_reader(result.stdout().as_bytes());
+                reader.headers().unwrap();
+                for row in reader.records() {
+                    row.unwrap();
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+// =============================================================================
 // Semantic pad mutation outcomes
 // =============================================================================
 

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -265,6 +265,142 @@ fn search_flag_reaches_the_handler_as_a_filter() {
     assert_eq!(got, vec!["meeting notes"]);
 }
 
+// =============================================================================
+// Semantic initialization and maintenance outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn initialization_preserves_text_and_exposes_structured_facts() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.app(&["init"]);
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["init", "--output", "text"]),
+    );
+
+    text.assert_success();
+    assert_eq!(
+        text.stdout(),
+        format!(
+            "Initialized padz store at {}\n\nTip: Enable shell completions for padz:\n  \
+             eval \"$(padz completions bash)\"  # add to ~/.bashrc\n  \
+             eval \"$(padz completions zsh)\"   # add to ~/.zshrc\n",
+            fx.project().join(".padz").display()
+        )
+    );
+    drop(text);
+
+    let json = TestHarness::new().run(&app, cmd, fx.argv(&["init", "--output", "json"]));
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    value["store_path"] = serde_json::json!("<STORE_PATH>");
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/initialization.json"
+    ))
+    .unwrap();
+    assert_eq!(value, fixture);
+    assert!(
+        value.get("messages").is_none(),
+        "initialization schema must expose facts rather than prose"
+    );
+}
+
+#[test]
+#[serial]
+fn doctor_preserves_clean_text_and_exposes_counts() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["doctor", "--output", "text"]),
+    );
+
+    text.assert_success();
+    assert_eq!(text.stdout(), "No inconsistencies found.\n");
+    drop(text);
+
+    let json = TestHarness::new().run(&app, cmd, fx.argv(&["doctor", "--output", "json"]));
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/doctor-clean.json")).unwrap();
+    assert_eq!(value, fixture);
+}
+
+#[test]
+#[serial]
+fn purge_preserves_completed_text_and_exposes_selection_and_counts() {
+    let text_fx = Fixture::new();
+    let state = text_fx.app_state();
+    text_fx.seed_pad(&state, "gone", "");
+    state
+        .with_api(|api| api.delete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = text_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        text_fx.argv(&["purge", "--yes", "--output", "text"]),
+    );
+
+    text.assert_success();
+    assert_eq!(text.stdout(), "Purging 1 pad(s)...\nPurged: d1 gone\n");
+
+    let json_fx = Fixture::new();
+    let state = json_fx.app_state();
+    json_fx.seed_pad(&state, "gone", "");
+    state
+        .with_api(|api| api.delete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = json_fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        json_fx.argv(&["purge", "--yes", "--output", "json"]),
+    );
+
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    assert!(value["selected_pads"][0]["id"]
+        .as_str()
+        .is_some_and(|id| id.len() == 36));
+    value["selected_pads"][0]["id"] = serde_json::json!("<UUID>");
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/purge-completed.json"
+    ))
+    .unwrap();
+    assert_eq!(value, fixture);
+}
+
+#[test]
+#[serial]
+fn empty_purge_is_distinct_in_text_and_structured_output() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["purge", "--yes", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "No pads to purge.\n");
+    drop(text);
+
+    let json = TestHarness::new().run(&app, cmd, fx.argv(&["purge", "--yes", "--output", "json"]));
+    json.assert_success();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/purge-empty.json")).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        fixture
+    );
+}
+
 #[test]
 #[serial]
 fn uuid_flag_reaches_the_view_handler() {

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -2025,8 +2025,146 @@ fn term_debug_marks_a_deleted_pad_with_its_own_styles() {
 }
 
 // =============================================================================
+// UUID selections — selector ordering, human rendering, and structured data
+// =============================================================================
+
+#[test]
+#[serial]
+fn uuid_renders_single_multiple_and_range_selections_in_order() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "first", "");
+    fx.seed_pad(&state, "second", "");
+    fx.seed_pad(&state, "third", "");
+    drop(state);
+
+    let mut ids = Vec::new();
+    for selector in ["1", "2", "3"] {
+        let (app, cmd) = fx.read_app();
+        let result = TestHarness::new().no_color().text_output().run(
+            &app,
+            cmd,
+            fx.argv(&["uuid", selector]),
+        );
+        result.assert_success();
+        let lines: Vec<&str> = result.stdout().lines().collect();
+        assert_eq!(lines.len(), 1, "{selector}: one UUID per line");
+        uuid::Uuid::parse_str(lines[0])
+            .unwrap_or_else(|e| panic!("{selector}: invalid UUID {:?}: {e}", lines[0]));
+        ids.push(lines[0].to_string());
+    }
+
+    let (app, cmd) = fx.read_app();
+    let multiple =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["uuid", "3", "1"]));
+    multiple.assert_success();
+    assert_eq!(
+        multiple.stdout().lines().collect::<Vec<_>>(),
+        vec![ids[2].as_str(), ids[0].as_str()],
+        "multiple selectors must retain selector order"
+    );
+    drop(multiple);
+
+    let (app, cmd) = fx.read_app();
+    let range =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["uuid", "1-3"]));
+    range.assert_success();
+    assert_eq!(
+        range.stdout().lines().collect::<Vec<_>>(),
+        ids.iter().map(String::as_str).collect::<Vec<_>>(),
+        "ranges must expand in canonical display order"
+    );
+}
+
+// =============================================================================
 // Structured output — every mode parses with a real parser for that format
 // =============================================================================
+
+#[test]
+#[serial]
+fn uuid_preserves_its_array_contract_in_every_structured_mode() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "structured UUID", "");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let text = TestHarness::new()
+        .no_color()
+        .text_output()
+        .run(&app, cmd, fx.argv(&["uuid", "1"]));
+    text.assert_success();
+    let expected = text.stdout().trim().to_string();
+    uuid::Uuid::parse_str(&expected).expect("human output should contain a full UUID");
+    drop(text);
+
+    for mode in ["json", "yaml", "xml", "csv"] {
+        let (app, cmd) = fx.read_app();
+        let result =
+            TestHarness::new()
+                .no_color()
+                .run(&app, cmd, fx.argv(&["uuid", "1", "--output", mode]));
+        result.assert_success();
+
+        let actual = match mode {
+            "json" => {
+                let value: serde_json::Value = serde_json::from_str(result.stdout())
+                    .unwrap_or_else(|e| panic!("not JSON: {e}\n{}", result.stdout()));
+                value["uuids"][0].as_str().expect("uuids[0]").to_string()
+            }
+            "yaml" => {
+                let value: serde_json::Value = serde_yaml::from_str(result.stdout())
+                    .unwrap_or_else(|e| panic!("not YAML: {e}\n{}", result.stdout()));
+                value["uuids"][0].as_str().expect("uuids[0]").to_string()
+            }
+            "xml" => {
+                let mut reader = quick_xml::Reader::from_str(result.stdout());
+                reader.config_mut().trim_text(true);
+                let mut in_uuid = false;
+                let mut uuid = None;
+                loop {
+                    match reader.read_event() {
+                        Ok(quick_xml::events::Event::Start(e)) if e.name().as_ref() == b"uuids" => {
+                            in_uuid = true;
+                        }
+                        Ok(quick_xml::events::Event::Text(e)) if in_uuid => {
+                            uuid = Some(e.unescape().expect("UUID XML text").into_owned());
+                        }
+                        Ok(quick_xml::events::Event::End(e)) if e.name().as_ref() == b"uuids" => {
+                            in_uuid = false;
+                        }
+                        Ok(quick_xml::events::Event::Eof) => break,
+                        Ok(_) => {}
+                        Err(e) => panic!("not XML: {e}\n{}", result.stdout()),
+                    }
+                }
+                uuid.expect("XML uuids element")
+            }
+            "csv" => {
+                let mut reader = csv::Reader::from_reader(result.stdout().as_bytes());
+                assert_eq!(
+                    reader.headers().expect("CSV header").get(0),
+                    Some("uuids.0")
+                );
+                reader
+                    .records()
+                    .next()
+                    .expect("CSV row")
+                    .expect("valid CSV row")[0]
+                    .to_string()
+            }
+            other => unreachable!("unhandled mode {other}"),
+        };
+
+        assert_eq!(actual, expected, "{mode} UUID array changed");
+    }
+}
 
 #[test]
 #[serial]

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -373,6 +373,28 @@ fn purge_preserves_completed_text_and_exposes_selection_and_counts() {
 
 #[test]
 #[serial]
+fn purge_preserves_a_nested_selection_path_in_text_and_structured_output() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["purge", "1.1", "--yes", "--output", "json"]),
+    );
+
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    assert_eq!(value["selected_pads"][0]["selector"], "1.1");
+    assert_eq!(value["selected_pads"][0]["title"], "child");
+}
+
+#[test]
+#[serial]
 fn empty_purge_is_distinct_in_text_and_structured_output() {
     let fx = Fixture::new();
     let (app, cmd) = fx.read_app();

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -401,6 +401,200 @@ fn empty_purge_is_distinct_in_text_and_structured_output() {
     );
 }
 
+// =============================================================================
+// Semantic pad mutation outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn nested_edit_preserves_text_and_exposes_update_facts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    drop(state);
+    let (app, cmd) = fx.app(&["list"]);
+
+    let text = TestHarness::new()
+        .no_color()
+        .piped_stdin("Edited child")
+        .run(
+            &app,
+            cmd.clone(),
+            fx.argv(&["edit", "1.1", "--output", "text"]),
+        );
+    text.assert_success();
+    text.assert_stdout_contains("Updated 1 pad...");
+    text.assert_stdout_contains("Updated (1.1): Edited child");
+    drop(text);
+
+    let json = TestHarness::new().piped_stdin("Edited child").run(
+        &app,
+        cmd,
+        fx.argv(&["edit", "1.1", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/edit-content.json")).unwrap();
+    assert_eq!(value["outcomes"], fixture);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
+#[test]
+#[serial]
+fn same_parent_move_preserves_text_and_exposes_the_nested_no_op() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["move", "1.1", "1", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "Pad '1.1' is already at destination\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["move", "1.1", "1", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/move-no-op.json")).unwrap();
+    assert_eq!(value["notices"], fixture);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
+#[test]
+#[serial]
+fn mixed_complete_distinguishes_changed_pads_from_no_ops() {
+    let fx = Fixture::new();
+    fx.todos_mode();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "changed", "");
+    fx.seed_pad(&state, "no op", "");
+    state
+        .with_api(|api| api.complete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["complete", "1", "2", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/complete-mixed.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "notices": value["notices"].clone(),
+            "outcomes": value["outcomes"].clone(),
+        }),
+        fixture
+    );
+    assert_eq!(value["pads"].as_array().map(Vec::len), Some(2));
+    assert!(value["pads"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|pad| pad["pad"]["metadata"]["status"] == "Done"));
+}
+
+#[test]
+#[serial]
+fn repeated_complete_and_reopen_keep_compatible_text_and_typed_statuses() {
+    let complete_fx = Fixture::new();
+    complete_fx.todos_mode();
+    let state = complete_fx.app_state();
+    complete_fx.seed_pad(&state, "done", "");
+    state
+        .with_api(|api| api.complete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = complete_fx.read_app();
+    let complete = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        complete_fx.argv(&["complete", "1", "--output", "text"]),
+    );
+    complete.assert_success();
+    complete.assert_stdout_contains("Pad 1 is already done");
+    drop(complete);
+
+    let reopen_fx = Fixture::new();
+    reopen_fx.todos_mode();
+    let state = reopen_fx.app_state();
+    reopen_fx.seed_pad(&state, "planned", "");
+    drop(state);
+    let (app, cmd) = reopen_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        reopen_fx.argv(&["reopen", "1", "--output", "text"]),
+    );
+    text.assert_success();
+    text.assert_stdout_contains("Pad 1 is already planned");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        reopen_fx.argv(&["reopen", "1", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/reopen-no-op.json")).unwrap();
+    assert_eq!(value["notices"], fixture);
+}
+
+#[test]
+#[serial]
+fn empty_delete_completed_preserves_text_and_exposes_a_typed_no_op() {
+    let fx = Fixture::new();
+    fx.todos_mode();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "still open", "");
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["delete", "--completed", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "No completed pads to delete.\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["delete", "--completed", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/delete-completed-empty.json"
+    ))
+    .unwrap();
+    assert_eq!(value["notices"], fixture);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
 #[test]
 #[serial]
 fn uuid_flag_reaches_the_view_handler() {
@@ -1112,6 +1306,26 @@ fn status_glyphs_appear_only_when_the_listing_asks_for_them() {
 // =============================================================================
 // Styles — asserted semantically via term-debug, never by scraping ANSI
 // =============================================================================
+
+#[test]
+#[serial]
+fn mutation_outcomes_keep_the_established_info_and_success_styles() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "before", "");
+    drop(state);
+
+    let (app, cmd) = fx.app(&["list"]);
+    let result = TestHarness::new().piped_stdin("after").run(
+        &app,
+        cmd,
+        fx.argv(&["edit", "1", "--output", "term-debug"]),
+    );
+
+    result.assert_success();
+    result.assert_stdout_contains("[info]Updated 1 pad...[/info]");
+    result.assert_stdout_contains("[success]Updated (1): after[/success]");
+}
 
 #[test]
 #[serial]

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -401,6 +401,103 @@ fn empty_purge_is_distinct_in_text_and_structured_output() {
     );
 }
 
+#[test]
+#[serial]
+fn import_preserves_warning_text_and_exposes_partial_success_facts() {
+    let text_fx = Fixture::new();
+    let source = text_fx.root().join("bad.md");
+    std::fs::write(
+        &source,
+        "---\npadz.status: NotAThing\n---\n\nImported title\n\nBody",
+    )
+    .unwrap();
+    let source_text = source.display().to_string();
+    let (app, cmd) = text_fx.app(&["import", &source_text]);
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        text_fx.argv(&["import", &source_text, "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(
+        text.stdout(),
+        format!(
+            "Imported: {source_text}\n{source_text}: applied inline metadata\n\
+             {source_text}: invalid status\nTotal imported: 1\n"
+        )
+    );
+    drop(text);
+
+    let json_fx = Fixture::new();
+    let source = json_fx.root().join("bad.md");
+    std::fs::write(
+        &source,
+        "---\npadz.status: NotAThing\n---\n\nImported title\n\nBody",
+    )
+    .unwrap();
+    let source_text = source.display().to_string();
+    let (app, cmd) = json_fx.app(&["import", &source_text]);
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        json_fx.argv(&["import", &source_text, "--output", "json"]),
+    );
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    value["sources"][0]["source"] = serde_json::json!("<SOURCE>");
+    value["sources"][0]["processed_files"][0] = serde_json::json!("<SOURCE>");
+    value["sources"][0]["diagnostics"][0]["source_label"] = serde_json::json!("<SOURCE>");
+    value["sources"][0]["diagnostics"][1]["warning"]["source_label"] =
+        serde_json::json!("<SOURCE>");
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/import-partial.json"
+    ))
+    .unwrap();
+    assert_eq!(value, fixture);
+    assert!(value.get("messages").is_none());
+}
+
+#[test]
+#[serial]
+fn import_report_serializes_in_every_structured_mode() {
+    for mode in ["json", "yaml", "xml", "csv"] {
+        let fx = Fixture::new();
+        let source = fx.root().join("plain.md");
+        std::fs::write(&source, "Imported title\n\nBody").unwrap();
+        let source = source.display().to_string();
+        let (app, cmd) = fx.app(&["import", &source]);
+        let result =
+            TestHarness::new().run(&app, cmd, fx.argv(&["import", &source, "--output", mode]));
+        result.assert_success();
+        match mode {
+            "json" => {
+                serde_json::from_str::<serde_json::Value>(result.stdout()).unwrap();
+            }
+            "yaml" => {
+                serde_yaml::from_str::<serde_yaml::Value>(result.stdout()).unwrap();
+            }
+            "xml" => {
+                let mut reader = quick_xml::Reader::from_str(result.stdout());
+                loop {
+                    match reader.read_event() {
+                        Ok(quick_xml::events::Event::Eof) => break,
+                        Ok(_) => {}
+                        Err(error) => panic!("invalid import XML: {error}\n{}", result.stdout()),
+                    }
+                }
+            }
+            "csv" => {
+                let mut reader = csv::Reader::from_reader(result.stdout().as_bytes());
+                reader.headers().unwrap();
+                for row in reader.records() {
+                    row.unwrap();
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
 // =============================================================================
 // Semantic pad mutation outcomes
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -108,19 +108,6 @@ fn shape_of(v: &serde_json::Value) -> Shape {
     shape
 }
 
-/// The message strings a JSON result carries.
-fn messages(json: &str) -> Vec<String> {
-    let v: serde_json::Value = serde_json::from_str(json).unwrap();
-    v["messages"]
-        .as_array()
-        .map(|ms| {
-            ms.iter()
-                .map(|m| m["content"].as_str().unwrap_or_default().to_string())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 // =============================================================================
 // Command wiring — argv reaches the right handler with the right arguments
 // =============================================================================
@@ -217,10 +204,17 @@ fn a_naked_invocation_with_an_empty_pipe_aborts_create() {
         .run(&app, cmd, fx.argv(&["--output", "json"]));
 
     result.assert_success();
-    assert_eq!(pads(result.stdout()), Vec::<(String, String)>::new());
-    assert!(messages(result.stdout())
-        .iter()
-        .any(|message| message.contains("Aborted: empty content")));
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    drop(result);
+
+    let (app, cmd) = fx.read_app();
+    let listed = TestHarness::new().run(&app, cmd, fx.argv(&["list", "--output", "json"]));
+    assert_eq!(pads(listed.stdout()), vec![]);
 }
 
 #[test]
@@ -1246,6 +1240,112 @@ fn uuid_flag_reaches_the_view_handler() {
 }
 
 // =============================================================================
+// Copy — semantic result plus application-owned clipboard destination
+// =============================================================================
+
+#[test]
+#[serial]
+fn singleton_copy_reports_typed_facts_and_writes_once() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "single", "body");
+    drop(state);
+
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["copy", "1"]);
+    let result = TestHarness::new().run(&app, cmd, fx.argv(&["copy", "1", "--output", "json"]));
+
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/copy-singleton.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(clipboard.writes(), vec!["single\n\nbody"]);
+}
+
+#[test]
+#[serial]
+fn multiple_copy_preserves_root_order_in_facts_and_one_payload() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "first", "one");
+    fx.seed_pad(&state, "second", "two");
+    drop(state);
+
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["copy", "1", "2"]);
+    let result =
+        TestHarness::new().run(&app, cmd, fx.argv(&["copy", "1", "2", "--output", "json"]));
+
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/copy-multiple.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["second\n\ntwo\n---\n\nfirst\n\none"]
+    );
+}
+
+#[test]
+#[serial]
+fn nested_copy_keeps_descendants_in_one_payload_but_reports_one_root() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "parent body");
+    fx.seed_child(&state, "1", "child", "child body");
+    drop(state);
+
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["copy", "1"]);
+    let result = TestHarness::new().run(&app, cmd, fx.argv(&["copy", "1", "--output", "json"]));
+
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/copy-nested.json")).unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["parent\n\nparent body\n\nchild\n\nchild body"]
+    );
+}
+
+#[test]
+#[serial]
+fn copy_template_preserves_human_wording_and_pluralization() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "single", "body");
+    drop(state);
+
+    let (app, cmd, _clipboard) = fx.app_with_recording_clipboard(&["copy", "1"]);
+    TestHarness::new()
+        .no_color()
+        .text_output()
+        .run(&app, cmd, fx.argv(&["copy", "1"]))
+        .assert_stdout_contains("Copied 1 pad to clipboard: single");
+
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "first", "one");
+    fx.seed_pad(&state, "second", "two");
+    drop(state);
+
+    let (app, cmd, _clipboard) = fx.app_with_recording_clipboard(&["copy", "1", "2"]);
+    let result =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["copy", "1", "2"]));
+
+    result.assert_success();
+    result.assert_stdout_contains("Copied 2 pads to clipboard: second, first");
+}
+
+// =============================================================================
 // Input chain — the pre-dispatch hooks, driven through real argv and stdin
 // =============================================================================
 //
@@ -1361,22 +1461,23 @@ fn title_arg_overrides_the_piped_title() {
 #[serial]
 fn empty_pipe_aborts_and_creates_no_pad() {
     let fx = Fixture::new();
-    let (app, cmd) = fx.app(&["create"]);
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["create"]);
 
-    let result = TestHarness::new().no_color().piped_stdin("").run(
-        &app,
-        cmd,
-        fx.argv(&["create", "--output", "json"]),
-    );
+    let result = TestHarness::new()
+        .no_color()
+        .piped_stdin("")
+        .env("EDITOR", "/usr/bin/false")
+        .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
 
-    assert_eq!(pads(result.stdout()), vec![]);
-    assert!(
-        messages(result.stdout())
-            .iter()
-            .any(|m| m.contains("Aborted: empty content")),
-        "expected an abort warning, got: {}",
-        result.stdout()
-    );
+    result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert!(clipboard.writes().is_empty());
     drop(result);
 
     // The store must stay empty — the abort is not a create that rendered oddly.
@@ -1392,18 +1493,27 @@ fn empty_pipe_aborts_and_creates_no_pad() {
 #[serial]
 fn whitespace_only_pipe_aborts() {
     let fx = Fixture::new();
-    let (app, cmd) = fx.app(&["create"]);
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["create"]);
 
-    let result = TestHarness::new().no_color().piped_stdin("   \n  \n").run(
-        &app,
-        cmd,
-        fx.argv(&["create", "--output", "json"]),
-    );
+    let result = TestHarness::new()
+        .no_color()
+        .piped_stdin("   \n  \n")
+        .env("EDITOR", "/usr/bin/false")
+        .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
 
-    assert_eq!(pads(result.stdout()), vec![]);
-    assert!(messages(result.stdout())
-        .iter()
-        .any(|m| m.contains("Aborted: empty content")));
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert!(clipboard.writes().is_empty());
+    drop(result);
+
+    let (app, cmd) = fx.read_app();
+    let listed = TestHarness::new().run(&app, cmd, fx.argv(&["list", "--output", "json"]));
+    assert_eq!(pads(listed.stdout()), vec![]);
 }
 
 #[test]
@@ -1589,7 +1699,7 @@ fn a_terminal_stdin_routes_create_to_the_editor() {
     let result = TestHarness::new()
         .no_color()
         .interactive_stdin()
-        .env("EDITOR", "/bin/false")
+        .env("EDITOR", "/usr/bin/false")
         .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
 
     assert!(
@@ -1615,6 +1725,55 @@ fn a_terminal_stdin_routes_create_to_the_editor() {
         vec![],
         "a failed editor create must roll the pad back"
     );
+}
+
+#[test]
+#[serial]
+fn an_editor_save_with_empty_content_returns_the_typed_abort() {
+    let fx = Fixture::new();
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["create"]);
+
+    // `/usr/bin/true` accepts the scratch pad path and exits successfully without
+    // writing it, exactly like leaving the editor buffer empty and saving.
+    let result = TestHarness::new()
+        .no_color()
+        .interactive_stdin()
+        .env("EDITOR", "/usr/bin/true")
+        .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
+
+    result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert!(clipboard.writes().is_empty());
+    drop(result);
+
+    let (app, cmd) = fx.read_app();
+    let listed =
+        TestHarness::new()
+            .no_color()
+            .run(&app, cmd, fx.argv(&["list", "--output", "json"]));
+    assert_eq!(pads(listed.stdout()), vec![]);
+}
+
+#[test]
+#[serial]
+fn an_empty_create_abort_preserves_human_wording() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.app(&["create"]);
+
+    let result = TestHarness::new().no_color().piped_stdin("").run(
+        &app,
+        cmd,
+        fx.argv(&["create", "--output", "text"]),
+    );
+
+    result.assert_success();
+    result.assert_stdout_contains("Aborted: empty content");
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -595,6 +595,343 @@ fn empty_delete_completed_preserves_text_and_exposes_a_typed_no_op() {
     assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
 }
 
+// =============================================================================
+// Semantic tag catalog and mutation outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn tag_catalog_preserves_empty_and_ordered_human_and_structured_results() {
+    let empty_fx = Fixture::new();
+    let (app, cmd) = empty_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        empty_fx.argv(&["tag", "list", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "No tags defined\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        empty_fx.argv(&["tag", "list", "--output", "json"]),
+    );
+    json.assert_success();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-catalog-empty.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        expected
+    );
+    drop(json);
+
+    let listed_fx = Fixture::new();
+    let state = listed_fx.app_state();
+    state
+        .with_api(|api| api.create_tag(state.scope, "work"))
+        .unwrap();
+    state
+        .with_api(|api| api.create_tag(state.scope, "rust"))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = listed_fx.read_app();
+    let debug = TestHarness::new().run(
+        &app,
+        cmd.clone(),
+        listed_fx.argv(&["tag", "list", "--output", "term-debug"]),
+    );
+    debug.assert_success();
+    assert_eq!(debug.stdout(), "[info]work[/info]\n[info]rust[/info]\n");
+    drop(debug);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        listed_fx.argv(&["tag", "list", "--output", "json"]),
+    );
+    json.assert_success();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-catalog-listed.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        expected
+    );
+    drop(json);
+
+    let singleton_fx = Fixture::new();
+    let state = singleton_fx.app_state();
+    singleton_fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = singleton_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        singleton_fx.argv(&["tag", "list", "1", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "work\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        singleton_fx.argv(&["tag", "list", "1", "--output", "json"]),
+    );
+    json.assert_success();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-catalog-singleton.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        expected
+    );
+}
+
+#[test]
+#[serial]
+fn tag_assignment_preserves_wording_styles_counts_and_no_op_kind() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "one", "");
+    fx.seed_pad(&state, "two", "");
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let debug = TestHarness::new().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&[
+            "tag",
+            "add",
+            "1",
+            "2",
+            "work",
+            "rust",
+            "--output",
+            "term-debug",
+        ]),
+    );
+    debug.assert_success();
+    debug.assert_stdout_contains("[info]Tagged 2 pads...[/info]");
+    debug.assert_stdout_contains("[success]Added tags [work, rust] to 2 pads[/success]");
+    drop(debug);
+
+    let no_op = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "add", "1", "2", "work", "rust", "--output", "text"]),
+    );
+    no_op.assert_success();
+    no_op.assert_stdout_contains("Tagged 2 pads...");
+    no_op.assert_stdout_contains("All pads already have tags [work, rust]");
+    drop(no_op);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["tag", "add", "1", "2", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-all-already-present.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+    assert_eq!(value["pads"].as_array().map(Vec::len), Some(2));
+    drop(json);
+
+    let changed_fx = Fixture::new();
+    let state = changed_fx.app_state();
+    changed_fx.seed_pad(&state, "one", "");
+    changed_fx.seed_pad(&state, "two", "");
+    drop(state);
+    let (app, cmd) = changed_fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        changed_fx.argv(&["tag", "add", "1", "2", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-assigned.json")).unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+}
+
+#[test]
+#[serial]
+fn tag_removal_preserves_wording_counts_and_none_present_no_op() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into(), "rust".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "text"]),
+    );
+    text.assert_success();
+    text.assert_stdout_contains("Untagged 1 pad...");
+    text.assert_stdout_contains("Removed tags [work, rust] from 1 pad");
+    drop(text);
+
+    let no_op = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "text"]),
+    );
+    no_op.assert_success();
+    no_op.assert_stdout_contains("No pads had tags [work, rust]");
+    drop(no_op);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-none-present.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+    drop(json);
+
+    let changed_fx = Fixture::new();
+    let state = changed_fx.app_state();
+    changed_fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into(), "rust".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = changed_fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        changed_fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-removed.json")).unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+}
+
+#[test]
+#[serial]
+fn tag_registry_mutations_preserve_names_counts_and_human_wording() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["old".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let rename = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "rename", "old", "new", "--output", "text"]),
+    );
+    rename.assert_success();
+    assert_eq!(
+        rename.stdout(),
+        "Renamed tag 'old' to 'new'\nUpdated 1 pad\n"
+    );
+    drop(rename);
+
+    let delete = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        fx.argv(&["tag", "delete", "new", "--output", "text"]),
+    );
+    delete.assert_success();
+    assert_eq!(delete.stdout(), "Deleted tag 'new'\nRemoved from 1 pad\n");
+    drop(delete);
+
+    let structured_fx = Fixture::new();
+    let state = structured_fx.app_state();
+    structured_fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["old".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = structured_fx.read_app();
+
+    let rename = TestHarness::new().run(
+        &app,
+        cmd.clone(),
+        structured_fx.argv(&["tag", "rename", "old", "new", "--output", "json"]),
+    );
+    rename.assert_success();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-renamed.json")).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(rename.stdout()).unwrap(),
+        expected
+    );
+    drop(rename);
+
+    let delete = TestHarness::new().run(
+        &app,
+        cmd,
+        structured_fx.argv(&["tag", "delete", "new", "--output", "json"]),
+    );
+    delete.assert_success();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-deleted.json")).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(delete.stdout()).unwrap(),
+        expected
+    );
+}
+
 #[test]
 #[serial]
 fn uuid_flag_reaches_the_view_handler() {

--- a/crates/padz/tests/support/mod.rs
+++ b/crates/padz/tests/support/mod.rs
@@ -17,6 +17,7 @@
 #![allow(dead_code)] // Each test binary uses its own subset of these helpers.
 
 use clap::Parser;
+use padz::cli::clipboard::ClipboardWriter;
 use padz::cli::commands::{build_app_state, build_dispatch_app};
 use padz::cli::handlers::AppState;
 use padz::cli::input::RequestContent;
@@ -25,6 +26,7 @@ use padzapp::init::{create_bucket_layout, PadzEnv};
 use standout::cli::App;
 use standout::input::{InputSourceKind, Inputs, ResolvedInput};
 use standout_dispatch::{CommandContext, Extensions};
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use tempfile::TempDir;
@@ -37,6 +39,29 @@ pub struct Fixture {
     temp: TempDir,
     project: PathBuf,
     env: PadzEnv,
+}
+
+/// A CLI clipboard destination that records every complete payload.
+///
+/// Copy tests inspect the vector to prove both write count and byte ordering. It
+/// implements Padz's application-owned write seam because Standout's harness
+/// clipboard override is intentionally an input reader, not an output sink.
+#[derive(Clone, Default)]
+pub struct RecordingClipboard {
+    writes: Rc<RefCell<Vec<String>>>,
+}
+
+impl RecordingClipboard {
+    pub fn writes(&self) -> Vec<String> {
+        self.writes.borrow().clone()
+    }
+}
+
+impl ClipboardWriter for RecordingClipboard {
+    fn write(&self, text: &str) -> padzapp::error::Result<()> {
+        self.writes.borrow_mut().push(text.to_string());
+        Ok(())
+    }
 }
 
 impl Fixture {
@@ -130,6 +155,18 @@ impl Fixture {
         build_app_state(&cli, &self.env, &self.project).expect("failed to build app state")
     }
 
+    /// App state with an observable CLI clipboard destination.
+    pub fn app_state_with_recording_clipboard_for(
+        &self,
+        args: &[&str],
+    ) -> (AppState, RecordingClipboard) {
+        let clipboard = RecordingClipboard::default();
+        let state = self
+            .app_state_for(args)
+            .with_clipboard_writer(Rc::new(clipboard.clone()));
+        (state, clipboard)
+    }
+
     /// The real dispatch app (templates, styles, dispatch table) bound to this
     /// fixture's store, paired with the clap command — the two arguments
     /// `TestHarness::run` wants.
@@ -141,6 +178,15 @@ impl Fixture {
             build_dispatch_app(self.app_state_for(args)),
             build_command(),
         )
+    }
+
+    /// The real dispatch app with an observable CLI clipboard destination.
+    pub fn app_with_recording_clipboard(
+        &self,
+        args: &[&str],
+    ) -> (App, clap::Command, RecordingClipboard) {
+        let (state, clipboard) = self.app_state_with_recording_clipboard_for(args);
+        (build_dispatch_app(state), build_command(), clipboard)
     }
 
     /// The dispatch app for an ordinary read/modify command. See [`app_state`](Self::app_state).

--- a/crates/padzapp/src/api/crud.rs
+++ b/crates/padzapp/src/api/crud.rs
@@ -97,6 +97,7 @@ impl<S: DataStore> PadzApi<S> {
     /// Permanently deletes pads.
     ///
     /// **Confirmation required**: The `confirmed` parameter must be `true` to proceed.
+    /// Returns an empty outcome or unique selected pads and completed deletion counts.
     pub fn purge_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
@@ -104,7 +105,7 @@ impl<S: DataStore> PadzApi<S> {
         recursive: bool,
         confirmed: bool,
         include_done: bool,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::purge::PurgeOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::purge::run(
             &mut self.store,

--- a/crates/padzapp/src/api/crud.rs
+++ b/crates/padzapp/src/api/crud.rs
@@ -62,10 +62,13 @@ impl<S: DataStore> PadzApi<S> {
     }
 
     /// Soft-deletes all active pads marked as Done (completed).
+    ///
+    /// Returns a semantic `NoCompletedPads` notice when there are no matches.
     pub fn delete_completed_pads(&mut self, scope: Scope) -> Result<commands::CmdResult> {
         commands::delete::run_completed(&mut self.store, scope)
     }
 
+    /// Applies typed updates and returns affected pads plus semantic update facts.
     pub fn update_pads(
         &mut self,
         scope: Scope,
@@ -74,7 +77,8 @@ impl<S: DataStore> PadzApi<S> {
         commands::update::run(&mut self.store, scope, updates)
     }
 
-    /// Updates pads with raw content (e.g., from piped stdin).
+    /// Updates pads with raw content (e.g., from piped stdin), returning affected
+    /// pads plus semantic content-update facts.
     pub fn update_pads_from_content<I: AsRef<str>>(
         &mut self,
         scope: Scope,

--- a/crates/padzapp/src/api/init.rs
+++ b/crates/padzapp/src/api/init.rs
@@ -8,19 +8,25 @@ use crate::store::DataStore;
 use super::PadzApi;
 
 impl<S: DataStore> PadzApi<S> {
-    pub fn init(&self, scope: Scope) -> Result<commands::CmdResult> {
+    /// Initializes `scope` and returns its scope and resolved store path as data.
+    pub fn init(&self, scope: Scope) -> Result<commands::init::InitializationOutcome> {
         commands::init::run(&self.paths, scope)
     }
 
+    /// Creates a link and returns the canonical initialized target as data.
     pub fn init_link(
         &self,
         local_padz: &std::path::Path,
         target: &std::path::Path,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::init::InitializationOutcome> {
         commands::init::link(local_padz, target)
     }
 
-    pub fn init_unlink(&self, local_padz: &std::path::Path) -> Result<commands::CmdResult> {
+    /// Removes the local link and returns a typed unlink action.
+    pub fn init_unlink(
+        &self,
+        local_padz: &std::path::Path,
+    ) -> Result<commands::init::InitializationOutcome> {
         commands::init::unlink(local_padz)
     }
 }

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -80,6 +80,7 @@ impl<S: DataStore> PadzApi<S> {
 pub use crate::model::TodoStatus;
 pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
+pub use commands::import::ImportReport;
 pub use commands::init::InitializationOutcome;
 pub use commands::purge::PurgeOutcome;
 pub use commands::tagging::{TaggingOutcome, TaggingResult};

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -8,7 +8,7 @@
 //! The API facade:
 //! - **Dispatches** to the appropriate command function
 //! - **Normalizes inputs** (e.g., converting display indexes to UUIDs)
-//! - **Returns structured types** (`Result<CmdResult>`)
+//! - **Returns structured types** (`CmdResult` or operation-specific outcomes)
 //!
 //! ## What the API Does NOT Do
 //!
@@ -17,9 +17,9 @@
 //! - **I/O operations**: No stdout, stderr, or file formatting
 //! - **Presentation concerns**: Returns data structures, not strings
 //!
-//! ## Consistent Output Representation
+//! ## Consistent Pad Representation
 //!
-//! All pad data in [`CmdResult`] uses [`DisplayPad`], which pairs a [`Pad`] with its
+//! All pad data in [`CmdResult`] and semantic outcomes uses [`DisplayPad`], which pairs a [`Pad`] with its
 //! canonical [`DisplayIndex`]. This applies to both:
 //! - `affected_pads`: Pads modified by the operation (with post-operation index)
 //! - `listed_pads`: Pads returned for display (with current index)
@@ -78,7 +78,10 @@ impl<S: DataStore> PadzApi<S> {
 }
 
 pub use crate::model::TodoStatus;
+pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
+pub use commands::init::InitializationOutcome;
+pub use commands::purge::PurgeOutcome;
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
 
 #[cfg(test)]

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -19,8 +19,10 @@
 //!
 //! ## Consistent Pad Representation
 //!
-//! All pad data in [`CmdResult`] and semantic outcomes uses [`DisplayPad`], which pairs a [`Pad`] with its
-//! canonical [`DisplayIndex`]. This applies to both:
+//! Pad data in [`CmdResult`] and semantic outcomes uses [`DisplayPad`], which pairs a [`Pad`] with its
+//! local canonical [`DisplayIndex`]. Hierarchical semantic results additionally
+//! carry the complete display path when clients must preserve selector identity.
+//! This applies to both:
 //! - `affected_pads`: Pads modified by the operation (with post-operation index)
 //! - `listed_pads`: Pads returned for display (with current index)
 //!
@@ -82,7 +84,7 @@ pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
 pub use commands::import::ImportReport;
 pub use commands::init::InitializationOutcome;
-pub use commands::purge::PurgeOutcome;
+pub use commands::purge::{PurgeOutcome, PurgeSelection};
 pub use commands::tagging::{TaggingOutcome, TaggingResult};
 pub use commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -82,6 +82,8 @@ pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
 pub use commands::init::InitializationOutcome;
 pub use commands::purge::PurgeOutcome;
+pub use commands::tagging::{TaggingOutcome, TaggingResult};
+pub use commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
 
 #[cfg(test)]

--- a/crates/padzapp/src/api/status.rs
+++ b/crates/padzapp/src/api/status.rs
@@ -28,7 +28,7 @@ impl<S: DataStore> PadzApi<S> {
         commands::pinning::unpin(&mut self.store, scope, &selectors)
     }
 
-    /// Marks pads as Done (completed).
+    /// Marks pads as Done, reporting already-done selectors as semantic no-ops.
     pub fn complete_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
@@ -38,7 +38,7 @@ impl<S: DataStore> PadzApi<S> {
         commands::status::complete(&mut self.store, scope, &selectors)
     }
 
-    /// Reopens pads (sets them back to Planned).
+    /// Reopens pads, reporting already-planned selectors as semantic no-ops.
     pub fn reopen_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
@@ -48,6 +48,8 @@ impl<S: DataStore> PadzApi<S> {
         commands::status::reopen(&mut self.store, scope, &selectors)
     }
 
+    /// Moves pads under a parent (or root), reporting same-parent moves as
+    /// semantic no-ops with their canonical display paths.
     pub fn move_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,

--- a/crates/padzapp/src/api/tags.rs
+++ b/crates/padzapp/src/api/tags.rs
@@ -1,6 +1,11 @@
 //! Tag registry CRUD and per-pad tagging.
+//!
+//! The facade preserves selector parsing while returning dedicated catalog and
+//! mutation outcomes. It does not turn those facts into presentation messages.
 
 use crate::commands;
+use crate::commands::tagging::TaggingResult;
+use crate::commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
 use crate::error::Result;
 use crate::model::Scope;
 use crate::store::DataStore;
@@ -9,59 +14,59 @@ use super::selectors::parse_selectors;
 use super::PadzApi;
 
 impl<S: DataStore> PadzApi<S> {
-    /// List all tags in the registry.
-    pub fn list_tags(&self, scope: Scope) -> Result<commands::CmdResult> {
+    /// List all tags in registry order, including an explicit empty state.
+    pub fn list_tags(&self, scope: Scope) -> Result<TagCatalogOutcome> {
         commands::tags::list_tags(&self.store, scope)
     }
 
-    /// List tags for specific pads.
+    /// List the unique tags for specific pads in lexical order.
     pub fn list_pad_tags<I: AsRef<str>>(
         &self,
         scope: Scope,
         indexes: &[I],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TagCatalogOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::tags::list_pad_tags(&self.store, scope, &selectors)
     }
 
-    /// Create a new tag in the registry.
-    pub fn create_tag(&mut self, scope: Scope, name: &str) -> Result<commands::CmdResult> {
+    /// Create a new tag and return its semantic registry action.
+    pub fn create_tag(&mut self, scope: Scope, name: &str) -> Result<TagRegistryOutcome> {
         commands::tags::create_tag(&mut self.store, scope, name)
     }
 
-    /// Delete a tag from the registry (cascades to remove from all pads).
-    pub fn delete_tag(&mut self, scope: Scope, name: &str) -> Result<commands::CmdResult> {
+    /// Delete a tag and report how many pads the cascade changed.
+    pub fn delete_tag(&mut self, scope: Scope, name: &str) -> Result<TagRegistryOutcome> {
         commands::tags::delete_tag(&mut self.store, scope, name)
     }
 
-    /// Rename a tag in the registry (updates all pads).
+    /// Rename a tag and report how many pads were updated.
     pub fn rename_tag(
         &mut self,
         scope: Scope,
         old_name: &str,
         new_name: &str,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TagRegistryOutcome> {
         commands::tags::rename_tag(&mut self.store, scope, old_name, new_name)
     }
 
-    /// Add tags to pads.
+    /// Add requested tags and distinguish changed pads from an all-present no-op.
     pub fn add_tags_to_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         tags: &[String],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TaggingResult> {
         let selectors = parse_selectors(indexes)?;
         commands::tagging::add_tags(&mut self.store, scope, &selectors, tags)
     }
 
-    /// Remove tags from pads.
+    /// Remove requested tags and distinguish changed pads from a none-present no-op.
     pub fn remove_tags_from_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         tags: &[String],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TaggingResult> {
         let selectors = parse_selectors(indexes)?;
         commands::tagging::remove_tags(&mut self.store, scope, &selectors, tags)
     }
@@ -70,6 +75,8 @@ impl<S: DataStore> PadzApi<S> {
 #[cfg(test)]
 mod tests {
     use crate::api::test_support::make_api;
+    use crate::commands::tagging::TaggingOutcome;
+    use crate::commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
     use crate::model::Scope;
 
     #[test]
@@ -79,7 +86,12 @@ mod tests {
 
         let result = api.list_tags(Scope::Project).unwrap();
 
-        assert!(result.messages.iter().any(|m| m.content.contains("work")));
+        assert_eq!(
+            result,
+            TagCatalogOutcome::Listed {
+                tags: vec!["work".into()]
+            }
+        );
     }
 
     #[test]
@@ -88,7 +100,13 @@ mod tests {
 
         let result = api.create_tag(Scope::Project, "rust").unwrap();
 
-        assert!(result.messages[0].content.contains("Created tag 'rust'"));
+        assert_eq!(
+            result,
+            TagRegistryOutcome::Created {
+                name: "rust".into(),
+                affected_pads: 0,
+            }
+        );
     }
 
     #[test]
@@ -98,7 +116,13 @@ mod tests {
 
         let result = api.delete_tag(Scope::Project, "work").unwrap();
 
-        assert!(result.messages[0].content.contains("Deleted tag 'work'"));
+        assert_eq!(
+            result,
+            TagRegistryOutcome::Deleted {
+                name: "work".into(),
+                affected_pads: 0,
+            }
+        );
     }
 
     #[test]
@@ -110,9 +134,14 @@ mod tests {
             .rename_tag(Scope::Project, "old-name", "new-name")
             .unwrap();
 
-        assert!(result.messages[0]
-            .content
-            .contains("Renamed tag 'old-name' to 'new-name'"));
+        assert_eq!(
+            result,
+            TagRegistryOutcome::Renamed {
+                old_name: "old-name".into(),
+                new_name: "new-name".into(),
+                affected_pads: 0,
+            }
+        );
     }
 
     #[test]
@@ -126,7 +155,13 @@ mod tests {
             .add_tags_to_pads(Scope::Project, &["1"], &["work".to_string()])
             .unwrap();
 
-        assert!(result.messages[0].content.contains("Added tag"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Assigned {
+                requested_tags: vec!["work".into()],
+                modified_pads: 1,
+            }
+        );
         assert!(result.affected_pads[0]
             .pad
             .metadata
@@ -147,7 +182,13 @@ mod tests {
             .remove_tags_from_pads(Scope::Project, &["1"], &["work".to_string()])
             .unwrap();
 
-        assert!(result.messages[0].content.contains("Removed tag"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Removed {
+                requested_tags: vec!["work".into()],
+                modified_pads: 1,
+            }
+        );
         assert!(result.affected_pads[0].pad.metadata.tags.is_empty());
     }
 }

--- a/crates/padzapp/src/api/transfer.rs
+++ b/crates/padzapp/src/api/transfer.rs
@@ -52,16 +52,23 @@ impl<S: DataStore> PadzApi<S> {
         commands::import::run(&mut self.store, scope, paths, import_exts)
     }
 
-    /// Direction for clone/migrate: the external path is either the
-    /// destination (`--to`) or the source (`--from`).
+    /// Copy or migrate the requested selection into a resolved peer store.
+    ///
+    /// The returned report identifies the peer, direction, original selection,
+    /// copied IDs, and every partial-success diagnostic without presentation
+    /// prose.
     pub fn transfer_pads_to<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         dest_path: &std::path::Path,
         mode: commands::transfer::TransferMode,
-    ) -> Result<commands::CmdResult> {
-        let selectors = parse_selectors(indexes)?;
+    ) -> Result<commands::transfer::TransferReport> {
+        let requested: Vec<String> = indexes
+            .iter()
+            .map(|index| index.as_ref().to_string())
+            .collect();
+        let selectors = parse_selectors(&requested)?;
         let dest_padz =
             commands::transfer::resolve_target_dir(dest_path, self.paths.home.as_deref())?;
         // Refuse to transfer to the same store. For migrate the user would
@@ -81,20 +88,26 @@ impl<S: DataStore> PadzApi<S> {
             &mut dest_store,
             Scope::Project,
             &selectors,
-            &dest_padz,
-            mode,
+            commands::transfer::TransferRequest {
+                operation: mode,
+                direction: commands::transfer::TransferDirection::To,
+                peer_store: dest_padz,
+                requested_selection: requested_selection(requested),
+            },
         )
     }
 
-    /// `--from <path>`: read selectors from the external store, write into
-    /// the current store.
+    /// Copy or migrate the requested selection from a resolved peer store.
+    ///
+    /// Selectors resolve against the external source, while the report retains
+    /// the exact caller-supplied selector strings and resolved peer path.
     pub fn transfer_pads_from<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         source_path: &std::path::Path,
         mode: commands::transfer::TransferMode,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::transfer::TransferReport> {
         let source_padz =
             commands::transfer::resolve_target_dir(source_path, self.paths.home.as_deref())?;
         let current_padz = self.paths.scope_dir(scope)?;
@@ -105,16 +118,33 @@ impl<S: DataStore> PadzApi<S> {
             )));
         }
         let mut source_store = commands::transfer::open_target_store(&source_padz)?;
-        let selectors = parse_selectors(indexes).map_err(|e| PadzError::Api(format!("{}", e)))?;
+        let requested: Vec<String> = indexes
+            .iter()
+            .map(|index| index.as_ref().to_string())
+            .collect();
+        let selectors =
+            parse_selectors(&requested).map_err(|e| PadzError::Api(format!("{}", e)))?;
         commands::transfer::run(
             &mut source_store,
             Scope::Project,
             &mut self.store,
             scope,
             &selectors,
-            &source_padz,
-            mode,
+            commands::transfer::TransferRequest {
+                operation: mode,
+                direction: commands::transfer::TransferDirection::From,
+                peer_store: source_padz,
+                requested_selection: requested_selection(requested),
+            },
         )
+    }
+}
+
+fn requested_selection(selectors: Vec<String>) -> commands::transfer::TransferSelection {
+    if selectors.is_empty() {
+        commands::transfer::TransferSelection::AllNonDeleted
+    } else {
+        commands::transfer::TransferSelection::Explicit { selectors }
     }
 }
 
@@ -188,14 +218,18 @@ mod tests {
             .transfer_pads_to(Scope::Project, empty, &dest_padz, TransferMode::Clone)
             .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("Cloned 2 pad(s)")),
-            "expected Cloned message; got {:?}",
-            result.messages
+        assert_eq!(
+            result.status,
+            commands::transfer::TransferStatus::FullSuccess
         );
+        assert_eq!(result.operation, TransferMode::Clone);
+        assert_eq!(result.direction, commands::transfer::TransferDirection::To);
+        assert_eq!(result.peer_store, dest_padz.canonicalize().unwrap());
+        assert_eq!(
+            result.requested_selection,
+            commands::transfer::TransferSelection::AllNonDeleted
+        );
+        assert_eq!(result.copied_count, 2);
 
         // Source must still hold both pads after a clone.
         let still_there = api
@@ -269,14 +303,16 @@ mod tests {
             .transfer_pads_from(Scope::Project, empty, &src_padz, TransferMode::Clone)
             .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("Cloned 1 pad(s)")),
-            "expected Cloned message; got {:?}",
-            result.messages
+        assert_eq!(
+            result.status,
+            commands::transfer::TransferStatus::FullSuccess
         );
+        assert_eq!(
+            result.direction,
+            commands::transfer::TransferDirection::From
+        );
+        assert_eq!(result.peer_store, src_padz.canonicalize().unwrap());
+        assert_eq!(result.copied_count, 1);
 
         let landed = api
             .get_pads(Scope::Project, Default::default(), &[] as &[String])

--- a/crates/padzapp/src/api/transfer.rs
+++ b/crates/padzapp/src/api/transfer.rs
@@ -41,12 +41,14 @@ impl<S: DataStore> PadzApi<S> {
         commands::export::run_json(&self.store, scope, &selectors, nesting)
     }
 
+    /// Import independent filesystem sources into `scope` and retain partial
+    /// success, metadata, archive-entry, and tag-registry facts in one report.
     pub fn import_pads(
         &mut self,
         scope: Scope,
         paths: Vec<std::path::PathBuf>,
         import_exts: &[String],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::import::ImportReport> {
         commands::import::run(&mut self.store, scope, paths, import_exts)
     }
 
@@ -159,10 +161,8 @@ mod tests {
             .import_pads(Scope::Project, vec![file_path], &[".md".to_string()])
             .unwrap();
 
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(result.total_imported, 1);
+        assert_eq!(result.status, commands::import::ImportStatus::FullSuccess);
     }
 
     // ------------------------------------------------------------------------

--- a/crates/padzapp/src/api/util.rs
+++ b/crates/padzapp/src/api/util.rs
@@ -24,11 +24,9 @@ impl<S: DataStore> PadzApi<S> {
         commands::paths::run(&self.store, scope, &selectors)
     }
 
-    pub fn pad_uuids<I: AsRef<str>>(
-        &self,
-        scope: Scope,
-        indexes: &[I],
-    ) -> Result<commands::CmdResult> {
+    /// Resolves selectors to UUIDs in selector order, with ranges expanded in
+    /// canonical display order.
+    pub fn pad_uuids<I: AsRef<str>>(&self, scope: Scope, indexes: &[I]) -> Result<Vec<uuid::Uuid>> {
         let selectors = parse_selectors(indexes)?;
         commands::uuid::run(&self.store, scope, &selectors)
     }
@@ -104,6 +102,29 @@ mod tests {
 
         assert_eq!(paths.project, Some(PathBuf::from("/tmp/test")));
         assert_eq!(paths.global, PathBuf::from("/tmp/global"));
+    }
+
+    #[test]
+    fn test_api_pad_uuids_returns_values_in_selector_order() {
+        let mut api = make_api();
+        let first = api
+            .create_pad(Scope::Project, "first".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let second = api
+            .create_pad(Scope::Project, "second".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+
+        let uuids = api.pad_uuids(Scope::Project, &["2", "1"]).unwrap();
+
+        assert_eq!(uuids, vec![first, second]);
     }
 
     #[test]

--- a/crates/padzapp/src/api/util.rs
+++ b/crates/padzapp/src/api/util.rs
@@ -2,6 +2,7 @@
 
 use crate::commands;
 use crate::error::Result;
+use crate::index::{DisplayIndex, PadSelector};
 use crate::model::{Pad, Scope};
 use crate::store::DataStore;
 
@@ -35,6 +36,18 @@ impl<S: DataStore> PadzApi<S> {
     pub fn get_path_by_id(&self, scope: Scope, id: uuid::Uuid) -> Result<std::path::PathBuf> {
         use crate::store::Bucket;
         self.store.get_pad_path(&id, scope, Bucket::Active)
+    }
+
+    /// Resolves an active pad's canonical display path from its durable identity.
+    pub fn display_path_by_id(&self, scope: Scope, id: uuid::Uuid) -> Result<Vec<DisplayIndex>> {
+        let mut resolved = commands::helpers::resolve_selectors(
+            &self.store,
+            scope,
+            &[PadSelector::Uuid(id)],
+            false,
+            commands::helpers::TitleBucket::Active,
+        )?;
+        Ok(resolved.remove(0).0)
     }
 
     /// Re-reads a pad from disk and syncs metadata (title, updated_at).

--- a/crates/padzapp/src/api/util.rs
+++ b/crates/padzapp/src/api/util.rs
@@ -9,7 +9,8 @@ use super::selectors::parse_selectors;
 use super::PadzApi;
 
 impl<S: DataStore> PadzApi<S> {
-    pub fn doctor(&mut self, scope: Scope) -> Result<commands::CmdResult> {
+    /// Reconciles the store and returns a clean/repaired outcome with direct counts.
+    pub fn doctor(&mut self, scope: Scope) -> Result<commands::doctor::DoctorOutcome> {
         commands::doctor::run(&mut self.store, scope)
     }
 
@@ -73,7 +74,13 @@ mod tests {
 
         let result = api.doctor(Scope::Project).unwrap();
 
-        assert!(!result.messages.is_empty());
+        assert_eq!(
+            result,
+            crate::commands::doctor::DoctorOutcome::Clean {
+                missing_files: 0,
+                recovered_files: 0
+            }
+        );
     }
 
     #[test]

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -1,4 +1,4 @@
-use crate::commands::CmdResult;
+use crate::commands::{CmdNotice, CmdResult};
 use crate::error::Result;
 use crate::index::{DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
@@ -75,7 +75,10 @@ pub fn run_completed<S: DataStore>(store: &mut S, scope: Scope) -> Result<CmdRes
         .collect();
 
     if done_ids.is_empty() {
-        return Ok(CmdResult::default());
+        return Ok(CmdResult {
+            notices: vec![CmdNotice::NoCompletedPads],
+            ..Default::default()
+        });
     }
 
     let selectors: Vec<PadSelector> = done_ids.iter().map(|id| PadSelector::Uuid(*id)).collect();
@@ -367,6 +370,8 @@ mod tests {
 
         let result = run_completed(&mut store, Scope::Project).unwrap();
         assert!(result.affected_pads.is_empty());
+        assert!(result.messages.is_empty());
+        assert_eq!(result.notices, vec![CmdNotice::NoCompletedPads]);
 
         // Pad should still be active
         let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();

--- a/crates/padzapp/src/commands/doctor.rs
+++ b/crates/padzapp/src/commands/doctor.rs
@@ -1,31 +1,33 @@
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::Result;
 use crate::model::Scope;
 use crate::store::DataStore;
 
-pub fn run<S: DataStore>(store: &mut S, scope: Scope) -> Result<CmdResult> {
+/// Semantic result of reconciling a store's index and content files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorOutcome {
+    Clean {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+    Repaired {
+        missing_files: usize,
+        recovered_files: usize,
+    },
+}
+
+pub fn run<S: DataStore>(store: &mut S, scope: Scope) -> Result<DoctorOutcome> {
     let report = store.doctor(scope)?;
-    let mut result = CmdResult::default();
-
     if report.fixed_missing_files == 0 && report.recovered_files == 0 {
-        result.add_message(CmdMessage::success("No inconsistencies found."));
+        Ok(DoctorOutcome::Clean {
+            missing_files: 0,
+            recovered_files: 0,
+        })
     } else {
-        result.add_message(CmdMessage::warning("Inconsistencies found and fixed:"));
-        if report.fixed_missing_files > 0 {
-            result.add_message(CmdMessage::info(format!(
-                "  - Removed {} pad(s) listed in DB but missing from disk.",
-                report.fixed_missing_files
-            )));
-        }
-        if report.recovered_files > 0 {
-            result.add_message(CmdMessage::success(format!(
-                "  - Recovered {} pad(s) found on disk but missing from DB.",
-                report.recovered_files
-            )));
-        }
+        Ok(DoctorOutcome::Repaired {
+            missing_files: report.fixed_missing_files,
+            recovered_files: report.recovered_files,
+        })
     }
-
-    Ok(result)
 }
 
 #[cfg(test)]
@@ -60,8 +62,13 @@ mod tests {
 
         let result = run(&mut store, Scope::Project).unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("No inconsistencies"));
+        assert_eq!(
+            result,
+            DoctorOutcome::Clean {
+                missing_files: 0,
+                recovered_files: 0
+            }
+        );
     }
 
     #[test]
@@ -77,14 +84,13 @@ mod tests {
         let mut store = bucketed_with_active(backend);
         let result = run(&mut store, Scope::Project).unwrap();
 
-        // Should report inconsistencies found
-        assert!(result.messages.len() >= 2);
-        assert!(result.messages[0].content.contains("Inconsistencies found"));
-        // Should report recovered files
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Recovered") && m.content.contains("1")));
+        assert_eq!(
+            result,
+            DoctorOutcome::Repaired {
+                missing_files: 0,
+                recovered_files: 1
+            }
+        );
     }
 
     #[test]
@@ -114,14 +120,13 @@ mod tests {
         let mut store = bucketed_with_active(backend);
         let result = run(&mut store, Scope::Project).unwrap();
 
-        // Should report inconsistencies found
-        assert!(result.messages.len() >= 2);
-        assert!(result.messages[0].content.contains("Inconsistencies found"));
-        // Should report removed entries
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Removed") && m.content.contains("1")));
+        assert_eq!(
+            result,
+            DoctorOutcome::Repaired {
+                missing_files: 1,
+                recovered_files: 0
+            }
+        );
     }
 
     #[test]
@@ -157,16 +162,12 @@ mod tests {
         let mut store = bucketed_with_active(backend);
         let result = run(&mut store, Scope::Project).unwrap();
 
-        // Should have warning + both issue types
-        assert!(result.messages.len() >= 3);
-        assert!(result.messages[0].content.contains("Inconsistencies found"));
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Removed")));
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Recovered")));
+        assert_eq!(
+            result,
+            DoctorOutcome::Repaired {
+                missing_files: 1,
+                recovered_files: 1
+            }
+        );
     }
 }

--- a/crates/padzapp/src/commands/helpers/mod.rs
+++ b/crates/padzapp/src/commands/helpers/mod.rs
@@ -8,7 +8,7 @@ mod tree_search;
 
 pub use indexing::{bucket_for_index, indexed_pads};
 pub use nesting::{collect_nested_pads, NestedPad};
-pub use pad_fetching::pads_by_selectors;
+pub use pad_fetching::{pads_by_selectors, pads_with_paths_by_selectors};
 pub use selector_resolve::{resolve_selectors, TitleBucket};
 pub use tree_search::{find_pad_by_uuid, get_descendant_ids};
 

--- a/crates/padzapp/src/commands/helpers/pad_fetching.rs
+++ b/crates/padzapp/src/commands/helpers/pad_fetching.rs
@@ -6,6 +6,44 @@ use crate::store::DataStore;
 use super::indexing::bucket_for_index;
 use super::selector_resolve::{resolve_selectors, TitleBucket};
 
+/// Resolves selectors and returns their complete display paths with flat pads.
+///
+/// The path preserves the canonical hierarchical identity selected by the user,
+/// while each [`DisplayPad`] keeps the operation-friendly local index and has
+/// `children: Vec::new()`.
+pub fn pads_with_paths_by_selectors<S: DataStore>(
+    store: &S,
+    scope: Scope,
+    selectors: &[PadSelector],
+    check_delete_protection: bool,
+    title_bucket: TitleBucket,
+) -> Result<Vec<(Vec<DisplayIndex>, DisplayPad)>> {
+    let resolved = resolve_selectors(
+        store,
+        scope,
+        selectors,
+        check_delete_protection,
+        title_bucket,
+    )?;
+    let mut pads = Vec::with_capacity(resolved.len());
+    for (path, id) in resolved {
+        let local_index = path.last().cloned().unwrap_or(DisplayIndex::Regular(0));
+        let bucket = bucket_for_index(&local_index);
+        let pad = store.get_pad(&id, scope, bucket)?;
+
+        pads.push((
+            path,
+            DisplayPad {
+                pad,
+                index: local_index,
+                matches: None,
+                children: Vec::new(),
+            },
+        ));
+    }
+    Ok(pads)
+}
+
 /// Resolves selectors and returns a flat list of DisplayPads.
 ///
 /// **Important**: This returns a *flattened* view—each pad has `children: Vec::new()`.
@@ -20,25 +58,14 @@ pub fn pads_by_selectors<S: DataStore>(
     check_delete_protection: bool,
     title_bucket: TitleBucket,
 ) -> Result<Vec<DisplayPad>> {
-    let resolved = resolve_selectors(
+    Ok(pads_with_paths_by_selectors(
         store,
         scope,
         selectors,
         check_delete_protection,
         title_bucket,
-    )?;
-    let mut pads = Vec::with_capacity(resolved.len());
-    for (path, id) in resolved {
-        let local_index = path.last().cloned().unwrap_or(DisplayIndex::Regular(0));
-        let bucket = bucket_for_index(&local_index);
-        let pad = store.get_pad(&id, scope, bucket)?;
-
-        pads.push(DisplayPad {
-            pad,
-            index: local_index,
-            matches: None,
-            children: Vec::new(),
-        });
-    }
-    Ok(pads)
+    )?
+    .into_iter()
+    .map(|(_, pad)| pad)
+    .collect())
 }

--- a/crates/padzapp/src/commands/init.rs
+++ b/crates/padzapp/src/commands/init.rs
@@ -1,34 +1,30 @@
-use crate::commands::{CmdMessage, CmdResult, PadzPaths};
+use crate::commands::PadzPaths;
 use crate::error::{PadzError, Result};
 use crate::init::create_bucket_layout;
 use crate::model::Scope;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
+/// Semantic result of explicit store initialization or link maintenance.
+///
+/// The reusable application layer reports only what happened. Shell-completion
+/// guidance, success wording, styles, and blank-line layout belong to clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitializationOutcome {
+    Initialized { scope: Scope, store_path: PathBuf },
+    Linked { target: PathBuf },
+    Unlinked,
+}
+
+pub fn run(paths: &PadzPaths, scope: Scope) -> Result<InitializationOutcome> {
     let dir = paths.scope_dir(scope)?;
 
     create_bucket_layout(&dir)?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!(
-        "Initialized padz store at {}",
-        dir.display()
-    )));
-
-    // Add shell completion hint
-    result.add_message(CmdMessage::info(String::new())); // blank line
-    result.add_message(CmdMessage::info(
-        "Tip: Enable shell completions for padz:".to_string(),
-    ));
-    result.add_message(CmdMessage::info(
-        "  eval \"$(padz completions bash)\"  # add to ~/.bashrc".to_string(),
-    ));
-    result.add_message(CmdMessage::info(
-        "  eval \"$(padz completions zsh)\"   # add to ~/.zshrc".to_string(),
-    ));
-
-    Ok(result)
+    Ok(InitializationOutcome::Initialized {
+        scope,
+        store_path: dir,
+    })
 }
 
 /// Create a persistent link from the current project's `.padz/` to another project's data.
@@ -38,7 +34,7 @@ pub fn run(paths: &PadzPaths, scope: Scope) -> Result<CmdResult> {
 ///
 /// `local_padz` is the **pre-resolution** `.padz/` directory (i.e., the CWD-based one,
 /// before any existing link is followed).
-pub fn link(local_padz: &Path, target: &Path) -> Result<CmdResult> {
+pub fn link(local_padz: &Path, target: &Path) -> Result<InitializationOutcome> {
     // Canonicalize target
     let target = target.canonicalize().map_err(|_| {
         PadzError::Store(format!(
@@ -90,18 +86,15 @@ pub fn link(local_padz: &Path, target: &Path) -> Result<CmdResult> {
         target_root.to_string_lossy().as_bytes(),
     )?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!(
-        "Linked to {}",
-        target_padz.display()
-    )));
-    Ok(result)
+    Ok(InitializationOutcome::Linked {
+        target: target_padz,
+    })
 }
 
 /// Remove an existing link file.
 ///
 /// `local_padz` is the **pre-resolution** `.padz/` directory.
-pub fn unlink(local_padz: &Path) -> Result<CmdResult> {
+pub fn unlink(local_padz: &Path) -> Result<InitializationOutcome> {
     let link_file = local_padz.join("link");
 
     if !link_file.exists() {
@@ -112,9 +105,7 @@ pub fn unlink(local_padz: &Path) -> Result<CmdResult> {
 
     fs::remove_file(&link_file)?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success("Unlinked.".to_string()));
-    Ok(result)
+    Ok(InitializationOutcome::Unlinked)
 }
 
 #[cfg(test)]
@@ -127,6 +118,28 @@ mod tests {
         fs::create_dir_all(dir.join("active")).unwrap();
         fs::create_dir_all(dir.join("archived")).unwrap();
         fs::create_dir_all(dir.join("deleted")).unwrap();
+    }
+
+    #[test]
+    fn initialization_returns_scope_and_store_path() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project").join(".padz");
+        let paths = PadzPaths {
+            project: Some(project.clone()),
+            global: temp.path().join("global"),
+            home: None,
+        };
+
+        let outcome = run(&paths, Scope::Project).unwrap();
+
+        assert_eq!(
+            outcome,
+            InitializationOutcome::Initialized {
+                scope: Scope::Project,
+                store_path: project.clone(),
+            }
+        );
+        assert!(project.join("active").is_dir());
     }
 
     #[test]
@@ -150,7 +163,12 @@ mod tests {
             PathBuf::from(link_content.trim()),
             target.canonicalize().unwrap()
         );
-        assert!(result.messages[0].content.contains("Linked to"));
+        assert_eq!(
+            result,
+            InitializationOutcome::Linked {
+                target: target.join(".padz").canonicalize().unwrap()
+            }
+        );
     }
 
     #[test]
@@ -234,7 +252,7 @@ mod tests {
         let result = unlink(&padz_dir).unwrap();
 
         assert!(!padz_dir.join("link").exists());
-        assert!(result.messages[0].content.contains("Unlinked"));
+        assert_eq!(result, InitializationOutcome::Unlinked);
     }
 
     #[test]

--- a/crates/padzapp/src/commands/io/import.rs
+++ b/crates/padzapp/src/commands/io/import.rs
@@ -1,14 +1,22 @@
+//! Semantic import pipeline for plain files, directories, inline metadata,
+//! and full-fidelity JSON archives.
+//!
+//! Every requested source produces one typed report. Recoverable source and
+//! archive-entry failures remain local so independent inputs continue, while
+//! metadata and tag-registry effects stay observable without authored prose.
+
 use crate::commands::inline_metadata::{parse_lex_metadata, parse_md_frontmatter};
 use crate::commands::metadata_apply::{
-    apply_metadata_defensively, parse_bucket_or_active, ParentPolicy,
+    apply_metadata_defensively, parse_bucket_or_active, MetadataApplicationWarning,
+    MetadataWarningSeverity, ParentPolicy,
 };
 use crate::commands::metadata_schema::{Archive, PadEntry};
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::model::{parse_pad_content, Pad, Scope};
 use crate::store::{Bucket, DataStore};
 use crate::tags::TagEntry;
 use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
@@ -16,94 +24,357 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportStatus {
+    FullSuccess,
+    PartialSuccess,
+    NoImports,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceKind {
+    File,
+    Directory,
+    JsonArchive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceStatus {
+    Imported,
+    Skipped,
+    Missing,
+    Unreadable,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArchiveEntrySkipReason {
+    MissingFile,
+    InvalidEncoding,
+    EmptyContent,
+    StoreFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectoryEntrySkipReason {
+    ReadEntry,
+    InspectEntry,
+    ImportFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagRegistryMergeStatus {
+    Merged,
+    Failed,
+}
+
+/// Ordered, source-local facts emitted while importing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportDiagnostic {
+    InlineMetadataApplied {
+        source_label: String,
+        bucket: Bucket,
+        warning_count: usize,
+    },
+    ArchiveMetadataSummary {
+        pad_id: Uuid,
+        warning_count: usize,
+    },
+    MetadataWarning {
+        warning: MetadataApplicationWarning,
+    },
+    ArchiveEntrySkipped {
+        entry: String,
+        reason: ArchiveEntrySkipReason,
+        detail: String,
+    },
+    DirectoryEntrySkipped {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        entry: Option<PathBuf>,
+        reason: DirectoryEntrySkipReason,
+        detail: String,
+    },
+    TagRegistryMerge {
+        status: TagRegistryMergeStatus,
+        /// Number of registry entries successfully persisted by this merge.
+        /// Failed merges always report zero.
+        added: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+/// Report for one path explicitly requested by the caller.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportSourceReport {
+    pub source: PathBuf,
+    pub source_kind: ImportSourceKind,
+    pub status: ImportSourceStatus,
+    pub imported: usize,
+    /// Plain files successfully read from this source, even when empty content
+    /// caused the file to be skipped rather than imported.
+    pub processed_files: Vec<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub diagnostics: Vec<ImportDiagnostic>,
+}
+
+/// Complete semantic import report, independent of any presentation client.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportReport {
+    pub status: ImportStatus,
+    pub total_imported: usize,
+    pub sources: Vec<ImportSourceReport>,
+}
+
+/// Import every requested path and return one presentation-free report.
+///
+/// Recoverable directory-entry inspection and file-import failures are
+/// retained as diagnostics so a partly imported directory cannot appear fully
+/// successful.
 pub fn run<S: DataStore>(
     store: &mut S,
     scope: Scope,
     paths: Vec<PathBuf>,
     import_exts: &[String],
-) -> Result<CmdResult> {
-    let mut result = CmdResult::default();
-    let mut imported_count = 0;
+) -> Result<ImportReport> {
+    let mut sources = Vec::with_capacity(paths.len());
 
     for path in paths {
         if is_json_archive(&path) {
-            match import_json_archive(store, scope, &path) {
-                Ok((count, messages)) => {
-                    imported_count += count;
-                    result.add_message(CmdMessage::info(format!(
-                        "Imported {} pads from {}",
-                        count,
-                        path.display()
-                    )));
-                    for m in messages {
-                        result.add_message(m);
-                    }
-                }
-                Err(e) => {
-                    result.add_message(CmdMessage::warning(format!(
-                        "Failed to import JSON archive {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            }
+            sources.push(match import_json_archive(store, scope, &path) {
+                Ok(archive) => ImportSourceReport {
+                    source: path,
+                    source_kind: ImportSourceKind::JsonArchive,
+                    status: if archive.imported > 0 {
+                        ImportSourceStatus::Imported
+                    } else {
+                        ImportSourceStatus::Skipped
+                    },
+                    imported: archive.imported,
+                    processed_files: Vec::new(),
+                    detail: None,
+                    diagnostics: archive.diagnostics,
+                },
+                Err(error) => ImportSourceReport {
+                    source: path,
+                    source_kind: ImportSourceKind::JsonArchive,
+                    status: source_error_status(&error),
+                    imported: 0,
+                    processed_files: Vec::new(),
+                    detail: Some(error.to_string()),
+                    diagnostics: Vec::new(),
+                },
+            });
             continue;
         }
 
         if path.is_dir() {
-            // Import directory of plain files
-            let entries = fs::read_dir(&path).map_err(PadzError::Io)?;
-            for entry in entries {
-                let entry = entry.map_err(PadzError::Io)?;
-                let sub_path = entry.path();
-                if sub_path.is_file() {
-                    if let Some(ext) = sub_path.extension() {
-                        let ext_str = format!(".{}", ext.to_string_lossy());
-                        if import_exts.contains(&ext_str) {
-                            if let Ok(res) = import_file(store, scope, &sub_path) {
-                                imported_count += res.imported;
-                                result.add_message(CmdMessage::info(format!(
-                                    "Imported: {}",
-                                    sub_path.display()
-                                )));
-                                for w in res.warnings {
-                                    result.add_message(w);
-                                }
-                            }
-                        }
-                    }
+            let entries = match fs::read_dir(&path) {
+                Ok(entries) => entries,
+                Err(error) => {
+                    sources.push(unreadable_directory_report(path, error));
+                    continue;
                 }
-            }
+            };
+            let directory = import_directory_entries(
+                store,
+                scope,
+                entries.map(|entry| entry.map(|entry| entry.path())),
+                import_exts,
+            );
+            sources.push(ImportSourceReport {
+                source: path,
+                source_kind: ImportSourceKind::Directory,
+                status: if directory.imported > 0 {
+                    ImportSourceStatus::Imported
+                } else {
+                    ImportSourceStatus::Skipped
+                },
+                imported: directory.imported,
+                processed_files: directory.processed_files,
+                detail: None,
+                diagnostics: directory.diagnostics,
+            });
         } else if path.is_file() {
-            // Import file directly (try as text)
-            match import_file(store, scope, &path) {
+            sources.push(match import_file(store, scope, &path) {
                 Ok(res) => {
-                    imported_count += res.imported;
-                    result.add_message(CmdMessage::info(format!("Imported: {}", path.display())));
-                    for w in res.warnings {
-                        result.add_message(w);
+                    let status = if res.imported > 0 {
+                        ImportSourceStatus::Imported
+                    } else {
+                        ImportSourceStatus::Skipped
+                    };
+                    ImportSourceReport {
+                        source: path.clone(),
+                        source_kind: ImportSourceKind::File,
+                        status,
+                        imported: res.imported,
+                        processed_files: vec![path],
+                        detail: None,
+                        diagnostics: res.diagnostics(),
                     }
                 }
-                Err(_) => {
-                    result.add_message(CmdMessage::warning(format!(
-                        "Failed to import: {}",
-                        path.display()
-                    )));
-                }
-            }
+                Err(error) => ImportSourceReport {
+                    source: path,
+                    source_kind: ImportSourceKind::File,
+                    status: source_error_status(&error),
+                    imported: 0,
+                    processed_files: Vec::new(),
+                    detail: Some(error.to_string()),
+                    diagnostics: Vec::new(),
+                },
+            });
         } else {
-            result.add_message(CmdMessage::warning(format!(
-                "Path not found: {}",
-                path.display()
-            )));
+            sources.push(ImportSourceReport {
+                source: path,
+                source_kind: ImportSourceKind::File,
+                status: ImportSourceStatus::Missing,
+                imported: 0,
+                processed_files: Vec::new(),
+                detail: None,
+                diagnostics: Vec::new(),
+            });
         }
     }
 
-    result.add_message(CmdMessage::success(format!(
-        "Total imported: {}",
-        imported_count
-    )));
-    Ok(result)
+    let total_imported = sources.iter().map(|source| source.imported).sum();
+    let status = if total_imported == 0 {
+        ImportStatus::NoImports
+    } else if sources.iter().any(source_is_partial) {
+        ImportStatus::PartialSuccess
+    } else {
+        ImportStatus::FullSuccess
+    };
+    Ok(ImportReport {
+        status,
+        total_imported,
+        sources,
+    })
+}
+
+fn unreadable_directory_report(path: PathBuf, error: std::io::Error) -> ImportSourceReport {
+    let detail = error.to_string();
+    let status = source_error_status(&PadzError::Io(error));
+    ImportSourceReport {
+        source: path,
+        source_kind: ImportSourceKind::Directory,
+        status,
+        imported: 0,
+        processed_files: Vec::new(),
+        detail: Some(detail),
+        diagnostics: Vec::new(),
+    }
+}
+
+struct DirectoryImportResult {
+    imported: usize,
+    processed_files: Vec<PathBuf>,
+    diagnostics: Vec<ImportDiagnostic>,
+}
+
+/// Import matching directory entries while retaining every recoverable entry
+/// failure as an ordered diagnostic.
+fn import_directory_entries<S, I>(
+    store: &mut S,
+    scope: Scope,
+    entries: I,
+    import_exts: &[String],
+) -> DirectoryImportResult
+where
+    S: DataStore,
+    I: IntoIterator<Item = std::io::Result<PathBuf>>,
+{
+    let mut imported = 0;
+    let mut processed_files = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for entry in entries {
+        let sub_path = match entry {
+            Ok(path) => path,
+            Err(error) => {
+                diagnostics.push(ImportDiagnostic::DirectoryEntrySkipped {
+                    entry: None,
+                    reason: DirectoryEntrySkipReason::ReadEntry,
+                    detail: error.to_string(),
+                });
+                continue;
+            }
+        };
+        let Some(ext) = sub_path.extension() else {
+            continue;
+        };
+        let ext = format!(".{}", ext.to_string_lossy());
+        if !import_exts.contains(&ext) {
+            continue;
+        }
+        match fs::metadata(&sub_path) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => continue,
+            Err(error) => {
+                diagnostics.push(ImportDiagnostic::DirectoryEntrySkipped {
+                    entry: Some(sub_path),
+                    reason: DirectoryEntrySkipReason::InspectEntry,
+                    detail: error.to_string(),
+                });
+                continue;
+            }
+        }
+        match import_file(store, scope, &sub_path) {
+            Ok(result) => {
+                imported += result.imported;
+                processed_files.push(sub_path);
+                diagnostics.extend(result.diagnostics());
+            }
+            Err(error) => diagnostics.push(ImportDiagnostic::DirectoryEntrySkipped {
+                entry: Some(sub_path),
+                reason: DirectoryEntrySkipReason::ImportFile,
+                detail: error.to_string(),
+            }),
+        }
+    }
+
+    DirectoryImportResult {
+        imported,
+        processed_files,
+        diagnostics,
+    }
+}
+
+fn source_error_status(error: &PadzError) -> ImportSourceStatus {
+    match error {
+        PadzError::Io(error) if error.kind() != std::io::ErrorKind::InvalidData => {
+            ImportSourceStatus::Unreadable
+        }
+        _ => ImportSourceStatus::Invalid,
+    }
+}
+
+fn source_is_partial(source: &ImportSourceReport) -> bool {
+    if source.status != ImportSourceStatus::Imported {
+        return true;
+    }
+    source
+        .diagnostics
+        .iter()
+        .any(|diagnostic| match diagnostic {
+            ImportDiagnostic::MetadataWarning { warning } => {
+                warning.severity == MetadataWarningSeverity::Warning
+            }
+            ImportDiagnostic::ArchiveEntrySkipped { .. }
+            | ImportDiagnostic::DirectoryEntrySkipped { .. } => true,
+            ImportDiagnostic::TagRegistryMerge { status, .. } => {
+                *status == TagRegistryMergeStatus::Failed
+            }
+            ImportDiagnostic::InlineMetadataApplied { .. }
+            | ImportDiagnostic::ArchiveMetadataSummary { .. } => false,
+        })
 }
 
 /// Heuristic: `.tar.gz` / `.tgz` files are candidates for JSON archive import.
@@ -123,7 +394,27 @@ fn is_json_archive(path: &Path) -> bool {
 /// Result of importing a single file: pads created + any per-field warnings.
 struct FileImportResult {
     imported: usize,
-    warnings: Vec<CmdMessage>,
+    warnings: Vec<MetadataApplicationWarning>,
+    inline_metadata: Option<(String, Bucket)>,
+}
+
+impl FileImportResult {
+    fn diagnostics(self) -> Vec<ImportDiagnostic> {
+        let mut diagnostics = Vec::new();
+        if let Some((source_label, bucket)) = self.inline_metadata {
+            diagnostics.push(ImportDiagnostic::InlineMetadataApplied {
+                source_label,
+                bucket,
+                warning_count: self.warnings.len(),
+            });
+        }
+        diagnostics.extend(
+            self.warnings
+                .into_iter()
+                .map(|warning| ImportDiagnostic::MetadataWarning { warning }),
+        );
+        diagnostics
+    }
 }
 
 fn import_file<S: DataStore>(store: &mut S, scope: Scope, path: &Path) -> Result<FileImportResult> {
@@ -157,11 +448,12 @@ fn import_content<S: DataStore>(
             return Ok(FileImportResult {
                 imported: 0,
                 warnings: Vec::new(),
+                inline_metadata: None,
             });
         };
 
         let mut pad = Pad::new(title.clone(), strip_title_from_body(&normalized, &title));
-        let mut warnings = apply_metadata_defensively(
+        let warnings = apply_metadata_defensively(
             &mut pad,
             &metadata_value,
             ParentPolicy::Trust,
@@ -181,16 +473,10 @@ fn import_content<S: DataStore>(
 
         store.save_pad(&pad, scope, bucket)?;
 
-        if !warnings.is_empty() {
-            warnings.insert(
-                0,
-                CmdMessage::info(format!("{}: applied inline metadata", source_label)),
-            );
-        }
-
         return Ok(FileImportResult {
             imported: 1,
             warnings,
+            inline_metadata: Some((source_label.to_string(), bucket)),
         });
     }
 
@@ -200,26 +486,26 @@ fn import_content<S: DataStore>(
         Ok(FileImportResult {
             imported: 1,
             warnings: Vec::new(),
+            inline_metadata: None,
         })
     } else {
         Ok(FileImportResult {
             imported: 0,
             warnings: Vec::new(),
+            inline_metadata: None,
         })
     }
 }
 
 /// Import a `.tar.gz` JSON archive.
 ///
-/// Returns `(imported_count, metadata_warnings)`. The function is optimistic:
-/// as long as the archive is readable, every pad file lands in the store.
-/// Metadata that fails to parse becomes a per-field warning; the pad itself
-/// always imports with at least a title and content.
+/// Returns imported counts and ordered semantic diagnostics. The function is
+/// optimistic: one bad entry does not prevent independent entries from landing.
 fn import_json_archive<S: DataStore>(
     store: &mut S,
     scope: Scope,
     archive_path: &Path,
-) -> Result<(usize, Vec<CmdMessage>)> {
+) -> Result<ArchiveImportResult> {
     let file = fs::File::open(archive_path).map_err(PadzError::Io)?;
     let decoder = GzDecoder::new(file);
     let mut tar = tar::Archive::new(decoder);
@@ -230,15 +516,21 @@ fn import_json_archive<S: DataStore>(
     // without meaningful savings. Keep everything keyed by archive-relative
     // path so we can cross-reference `db.json` against the pad files.
     let mut files: HashMap<String, Vec<u8>> = HashMap::new();
-    for entry in tar.entries().map_err(PadzError::Io)? {
-        let mut entry = entry.map_err(PadzError::Io)?;
+    for entry in tar
+        .entries()
+        .map_err(|error| PadzError::Api(format!("Invalid archive: {error}")))?
+    {
+        let mut entry =
+            entry.map_err(|error| PadzError::Api(format!("Invalid archive: {error}")))?;
         let archive_path = entry
             .path()
-            .map_err(PadzError::Io)?
+            .map_err(|error| PadzError::Api(format!("Invalid archive path: {error}")))?
             .to_string_lossy()
             .to_string();
         let mut buf = Vec::new();
-        entry.read_to_end(&mut buf).map_err(PadzError::Io)?;
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|error| PadzError::Api(format!("Invalid archive entry: {error}")))?;
         files.insert(archive_path, buf);
     }
 
@@ -251,7 +543,7 @@ fn import_json_archive<S: DataStore>(
     let archive: Archive = serde_json::from_slice(db_bytes)
         .map_err(|e| PadzError::Api(format!("Invalid db.json: {}", e)))?;
 
-    let mut warnings: Vec<CmdMessage> = Vec::new();
+    let mut diagnostics = Vec::new();
     let mut imported = 0usize;
 
     // 3. Index of UUIDs present in this archive, for parent_id orphaning.
@@ -260,33 +552,50 @@ fn import_json_archive<S: DataStore>(
     // 4. Import each pad entry.
     for entry in &archive.pads {
         match import_pad_entry(store, scope, entry, &files, &archive_ids) {
-            Ok((id, mut entry_warnings)) => {
+            Ok((id, entry_warnings)) => {
                 imported += 1;
                 if !entry_warnings.is_empty() {
-                    warnings.push(CmdMessage::info(format!(
-                        "Pad {} imported; {} metadata warning(s)",
-                        id,
-                        entry_warnings.len()
-                    )));
-                    warnings.append(&mut entry_warnings);
+                    diagnostics.push(ImportDiagnostic::ArchiveMetadataSummary {
+                        pad_id: id,
+                        warning_count: entry_warnings.len(),
+                    });
+                    diagnostics.extend(
+                        entry_warnings
+                            .into_iter()
+                            .map(|warning| ImportDiagnostic::MetadataWarning { warning }),
+                    );
                 }
             }
             Err(e) => {
-                warnings.push(CmdMessage::warning(format!(
-                    "Skipping pad entry {}: {}",
-                    entry.file, e
-                )));
+                diagnostics.push(ImportDiagnostic::ArchiveEntrySkipped {
+                    entry: entry.file.clone(),
+                    reason: e.reason(),
+                    detail: e.to_string(),
+                });
             }
         }
     }
 
     // 5. Merge referenced tag registry entries (don't overwrite existing).
-    let existing_tags: HashMap<String, TagEntry> = store
-        .load_tags(scope)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|t| (t.name.clone(), t))
-        .collect();
+    let existing_tags: HashMap<String, TagEntry> = match store.load_tags(scope) {
+        Ok(tags) => tags
+            .into_iter()
+            .map(|tag| (tag.name.clone(), tag))
+            .collect(),
+        Err(error) => {
+            if !archive.tags.is_empty() {
+                diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+                    status: TagRegistryMergeStatus::Failed,
+                    added: 0,
+                    detail: Some(error.to_string()),
+                });
+            }
+            return Ok(ArchiveImportResult {
+                imported,
+                diagnostics,
+            });
+        }
+    };
     let mut new_tags: Vec<TagEntry> = existing_tags.values().cloned().collect();
     let mut added_tags = 0usize;
     for t in &archive.tags {
@@ -300,19 +609,35 @@ fn import_json_archive<S: DataStore>(
     }
     if added_tags > 0 {
         if let Err(e) = store.save_tags(scope, &new_tags) {
-            warnings.push(CmdMessage::warning(format!(
-                "Failed to merge tag registry: {}",
-                e
-            )));
+            diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+                status: TagRegistryMergeStatus::Failed,
+                added: 0,
+                detail: Some(e.to_string()),
+            });
         } else {
-            warnings.push(CmdMessage::info(format!(
-                "Merged {} tag registry entry/entries",
-                added_tags
-            )));
+            diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+                status: TagRegistryMergeStatus::Merged,
+                added: added_tags,
+                detail: None,
+            });
         }
+    } else if !archive.tags.is_empty() {
+        diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+            status: TagRegistryMergeStatus::Merged,
+            added: 0,
+            detail: None,
+        });
     }
 
-    Ok((imported, warnings))
+    Ok(ArchiveImportResult {
+        imported,
+        diagnostics,
+    })
+}
+
+struct ArchiveImportResult {
+    imported: usize,
+    diagnostics: Vec<ImportDiagnostic>,
 }
 
 fn pad_id_from_entry(entry: &PadEntry) -> Option<Uuid> {
@@ -332,18 +657,17 @@ fn import_pad_entry<S: DataStore>(
     entry: &PadEntry,
     files: &HashMap<String, Vec<u8>>,
     archive_ids: &HashSet<Uuid>,
-) -> Result<(Uuid, Vec<CmdMessage>)> {
+) -> std::result::Result<(Uuid, Vec<MetadataApplicationWarning>), ArchiveEntryError> {
     // Resolve file: db.json uses relative paths ("pads/pad-<uuid>.lex"); tar
     // entries include the "padz/" prefix.
     let content_bytes = files
         .get(&format!("padz/{}", entry.file))
         .or_else(|| files.get(&entry.file))
-        .ok_or_else(|| PadzError::Api(format!("Missing file: {}", entry.file)))?;
+        .ok_or_else(|| ArchiveEntryError::MissingFile(entry.file.clone()))?;
 
     let raw = std::str::from_utf8(content_bytes)
-        .map_err(|e| PadzError::Api(format!("Non-UTF-8 content: {}", e)))?;
-    let (title, content) =
-        parse_pad_content(raw).ok_or_else(|| PadzError::Api("Empty pad content".to_string()))?;
+        .map_err(|error| ArchiveEntryError::InvalidEncoding(error.to_string()))?;
+    let (title, content) = parse_pad_content(raw).ok_or(ArchiveEntryError::EmptyContent)?;
 
     // Start from a fresh Pad so we have a valid baseline, then overlay fields.
     let mut pad = Pad::new(title.clone(), strip_title_from_body(&content, &title));
@@ -362,9 +686,34 @@ fn import_pad_entry<S: DataStore>(
     }
 
     let bucket = parse_bucket_or_active(&entry.bucket);
-    store.save_pad(&pad, scope, bucket)?;
+    store
+        .save_pad(&pad, scope, bucket)
+        .map_err(|error| ArchiveEntryError::StoreFailure(error.to_string()))?;
 
     Ok((pad.metadata.id, warnings))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ArchiveEntryError {
+    #[error("Missing file: {0}")]
+    MissingFile(String),
+    #[error("Non-UTF-8 content: {0}")]
+    InvalidEncoding(String),
+    #[error("Empty pad content")]
+    EmptyContent,
+    #[error("{0}")]
+    StoreFailure(String),
+}
+
+impl ArchiveEntryError {
+    fn reason(&self) -> ArchiveEntrySkipReason {
+        match self {
+            Self::MissingFile(_) => ArchiveEntrySkipReason::MissingFile,
+            Self::InvalidEncoding(_) => ArchiveEntrySkipReason::InvalidEncoding,
+            Self::EmptyContent => ArchiveEntrySkipReason::EmptyContent,
+            Self::StoreFailure(_) => ArchiveEntrySkipReason::StoreFailure,
+        }
+    }
 }
 
 /// `parse_pad_content` returns `(title, "title\n\nbody")`. `Pad::new` expects
@@ -447,17 +796,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            res.messages
-                .iter()
-                .filter(|m| m.content.contains("Imported:"))
-                .count(),
-            2
-        );
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 2")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 2);
+        assert_eq!(res.sources[0].source_kind, ImportSourceKind::Directory);
+        assert_eq!(res.sources[0].processed_files.len(), 2);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -465,6 +807,82 @@ mod tests {
         assert_eq!(pads.len(), 2);
         assert!(pads.iter().any(|p| p.metadata.title == "# Note 1"));
         assert!(pads.iter().any(|p| p.metadata.title == "Note 2"));
+    }
+
+    #[test]
+    fn unreadable_directory_report_retains_io_error_detail() {
+        let report = unreadable_directory_report(
+            PathBuf::from("locked"),
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "permission denied while listing",
+            ),
+        );
+
+        assert_eq!(report.status, ImportSourceStatus::Unreadable);
+        assert_eq!(
+            report.detail.as_deref(),
+            Some("permission denied while listing")
+        );
+    }
+
+    #[test]
+    fn directory_entry_failures_are_typed_and_make_import_partial() {
+        let mut store = new_store();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let imported_path = temp_dir.path().join("imported.md");
+        let invalid_path = temp_dir.path().join("invalid.md");
+        let vanished_path = temp_dir.path().join("vanished.md");
+        std::fs::write(&imported_path, "Imported\n\nBody").unwrap();
+        std::fs::write(&invalid_path, [0xff, 0xfe]).unwrap();
+
+        let directory = import_directory_entries(
+            &mut store,
+            Scope::Project,
+            vec![
+                Ok(imported_path.clone()),
+                Ok(invalid_path.clone()),
+                Ok(vanished_path.clone()),
+                Err(std::io::Error::other("entry vanished while listing")),
+            ],
+            &[".md".to_string()],
+        );
+
+        assert_eq!(directory.imported, 1);
+        assert_eq!(directory.processed_files, vec![imported_path]);
+        assert!(directory.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry: Some(entry),
+                reason: DirectoryEntrySkipReason::ImportFile,
+                ..
+            } if entry == &invalid_path
+        )));
+        assert!(directory.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry: Some(entry),
+                reason: DirectoryEntrySkipReason::InspectEntry,
+                ..
+            } if entry == &vanished_path
+        )));
+        assert!(directory.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry: None,
+                reason: DirectoryEntrySkipReason::ReadEntry,
+                ..
+            }
+        )));
+        assert!(source_is_partial(&ImportSourceReport {
+            source: temp_dir.path().to_path_buf(),
+            source_kind: ImportSourceKind::Directory,
+            status: ImportSourceStatus::Imported,
+            imported: directory.imported,
+            processed_files: directory.processed_files,
+            detail: None,
+            diagnostics: directory.diagnostics,
+        }));
     }
 
     #[test]
@@ -482,11 +900,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages[0].content.contains("Imported:"));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Imported);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -509,7 +925,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages[0].content.contains("Path not found"));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Missing);
     }
 
     #[test]
@@ -540,11 +957,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages[0].content.contains("Failed to import"));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 0")));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Invalid);
     }
 
     #[test]
@@ -563,10 +977,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 0")));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Skipped);
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
             .unwrap();
@@ -579,10 +991,8 @@ mod tests {
 
         let res = run(&mut store, Scope::Project, vec![], &[".md".to_string()]).unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 0")));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert!(res.sources.is_empty());
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
             .unwrap();
@@ -607,15 +1017,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Path not found")));
-        assert!(res.messages.iter().any(|m| m.content.contains("Imported:")));
+        assert_eq!(res.status, ImportStatus::PartialSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Imported);
+        assert_eq!(res.sources[1].status, ImportSourceStatus::Missing);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -642,10 +1047,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -671,10 +1073,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -710,10 +1109,11 @@ mod tests {
         std::fs::write(&path, body).unwrap();
 
         let res = run(&mut store, Scope::Project, vec![path], &[".md".into()]).unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
+        assert!(matches!(
+            res.sources[0].diagnostics[0],
+            ImportDiagnostic::InlineMetadataApplied { .. }
+        ));
 
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -746,10 +1146,11 @@ mod tests {
         std::fs::write(&path, body).unwrap();
 
         let res = run(&mut store, Scope::Project, vec![path], &[".lex".into()]).unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
+        assert!(matches!(
+            res.sources[0].diagnostics[0],
+            ImportDiagnostic::InlineMetadataApplied { .. }
+        ));
 
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -808,10 +1209,12 @@ mod tests {
 
         let res = run(&mut store, Scope::Project, vec![path], &[".md".into()]).unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("invalid status")));
+        assert_eq!(res.status, ImportStatus::PartialSuccess);
+        assert!(res.sources[0].diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::MetadataWarning { warning }
+                if warning.field.as_deref() == Some("status")
+        )));
 
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -855,6 +1258,112 @@ mod tests {
         path
     }
 
+    fn handcrafted_archive(db: serde_json::Value, files: &[(&str, &[u8])]) -> std::path::PathBuf {
+        let temp = tempfile::NamedTempFile::with_suffix(".tar.gz").unwrap();
+        let (file, path) = temp.keep().unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        for (path, content) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append_data(&mut header, format!("padz/{path}"), *content)
+                .unwrap();
+        }
+        let db = serde_json::to_vec(&db).unwrap();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(db.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, "padz/db.json", db.as_slice())
+            .unwrap();
+        tar.into_inner().unwrap().finish().unwrap();
+        path
+    }
+
+    #[test]
+    fn archive_entry_skip_is_typed_and_other_entries_continue() {
+        let good_id = Uuid::new_v4();
+        let missing_id = Uuid::new_v4();
+        let good_file = format!("pads/pad-{good_id}.txt");
+        let missing_file = format!("pads/pad-{missing_id}.txt");
+        let db = serde_json::json!({
+            "schema_version": 1,
+            "exported_at": "2026-04-22T00:00:00Z",
+            "padz_version": "1.9.0",
+            "pads": [
+                {"file": good_file.clone(), "metadata": {"id": good_id.to_string()}},
+                {"file": missing_file.clone(), "metadata": {"id": missing_id.to_string()}}
+            ],
+            "tags": []
+        });
+        let archive = handcrafted_archive(db, &[(good_file.as_str(), b"Good\n\nBody")]);
+        let mut store = new_store();
+
+        let report = run(
+            &mut store,
+            Scope::Project,
+            vec![archive.clone()],
+            &[".txt".into()],
+        )
+        .unwrap();
+
+        assert_eq!(report.status, ImportStatus::PartialSuccess);
+        assert_eq!(report.total_imported, 1);
+        assert!(report.sources[0]
+            .diagnostics
+            .iter()
+            .any(|diagnostic| matches!(
+                diagnostic,
+                ImportDiagnostic::ArchiveEntrySkipped {
+                    entry,
+                    reason: ArchiveEntrySkipReason::MissingFile,
+                    ..
+                } if entry == &missing_file
+            )));
+        std::fs::remove_file(archive).ok();
+    }
+
+    #[test]
+    fn tag_registry_merge_failure_is_typed_partial_success() {
+        let id = Uuid::new_v4();
+        let file = format!("pads/pad-{id}.txt");
+        let db = serde_json::json!({
+            "schema_version": 1,
+            "exported_at": "2026-04-22T00:00:00Z",
+            "padz_version": "1.9.0",
+            "pads": [{"file": file.clone(), "metadata": {"id": id.to_string(), "tags": ["work"]}}],
+            "tags": [{"name": "work", "created_at": "2026-04-22T00:00:00Z"}]
+        });
+        let archive = handcrafted_archive(db, &[(file.as_str(), b"Tagged\n\nBody")]);
+        let mut store = new_store();
+        store.tag_backend.set_simulate_write_error(true);
+
+        let report = run(
+            &mut store,
+            Scope::Project,
+            vec![archive.clone()],
+            &[".txt".into()],
+        )
+        .unwrap();
+
+        assert_eq!(report.status, ImportStatus::PartialSuccess);
+        assert_eq!(report.total_imported, 1);
+        assert!(report.sources[0]
+            .diagnostics
+            .iter()
+            .any(|diagnostic| matches!(
+                diagnostic,
+                ImportDiagnostic::TagRegistryMerge {
+                    status: TagRegistryMergeStatus::Failed,
+                    added: 0,
+                    ..
+                }
+            )));
+        std::fs::remove_file(archive).ok();
+    }
+
     #[test]
     fn test_json_roundtrip_preserves_metadata() {
         let mut src = new_store();
@@ -896,10 +1405,16 @@ mod tests {
             &[".md".into(), ".txt".into(), ".lex".into()],
         )
         .unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert!(res.sources[0].diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::TagRegistryMerge {
+                status: TagRegistryMergeStatus::Merged,
+                added: 1,
+                ..
+            }
+        )));
 
         let pads = dst.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -1081,14 +1596,13 @@ mod tests {
             &[".md".into()],
         )
         .unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
-        assert!(
-            res.messages.iter().any(|m| m.content.contains("status")),
-            "expected a warning mentioning the bad status field"
-        );
+        assert_eq!(res.status, ImportStatus::PartialSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert!(res.sources[0].diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::MetadataWarning { warning }
+                if warning.field.as_deref() == Some("status")
+        )));
 
         let pads = dst.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -1166,11 +1680,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Imported:")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert_eq!(res.sources[0].processed_files.len(), 1);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)

--- a/crates/padzapp/src/commands/metadata_apply.rs
+++ b/crates/padzapp/src/commands/metadata_apply.rs
@@ -1,44 +1,119 @@
-//! Thin CLI-layer adapter over [`crate::model::Metadata::apply_json_patch`].
+//! Thin import-boundary adapter over [`crate::model::Metadata::apply_json_patch`].
 //!
-//! The defensive "apply every field, collect per-field warnings" logic lives
-//! on the `Metadata` model — see [`crate::model::Metadata::apply_json_patch`].
-//! This module's job is only:
-//!
-//! - convert model-level [`crate::model::MetadataPatchWarning`]s into
-//!   user-facing [`CmdMessage`]s, tagging each with the source (file name /
-//!   pad id)
-//! - parse bucket labels coming off the wire (a store concept, not a model one)
-//!
-//! The JSON-archive import and the md/lex inline-metadata import both go
-//! through this adapter so warning formatting stays consistent.
+//! The defensive "apply every field, collect per-field outcomes" logic lives
+//! on the [`crate::model::Metadata`] model. This module adds the source label
+//! and stable semantic categories needed by import clients. It deliberately
+//! returns no authored prose: a CLI can render compatible diagnostics while a
+//! structured client branches on category, reason, field, count, and severity.
 
-use crate::commands::CmdMessage;
 use crate::model::{MetadataPatchWarning, Pad};
 use crate::store::Bucket;
+use serde::{Deserialize, Serialize};
 
 pub use crate::model::ParentPolicy;
 
-/// Apply `value` to `pad.metadata` defensively and return user-facing
-/// messages prefixed with `source_label` (e.g. a file path or pad id).
+/// Severity of a recoverable metadata-application outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningSeverity {
+    Info,
+    Warning,
+}
+
+/// Stable area of metadata affected by a warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningCategory {
+    Metadata,
+    Field,
+    Tags,
+    Parent,
+}
+
+/// Stable reason a metadata value was not applied as requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningReason {
+    NotAnObject,
+    InvalidValue,
+    NonStringEntries,
+    OutsideImportSet,
+}
+
+/// One typed, source-labelled metadata application warning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetadataApplicationWarning {
+    pub source_label: String,
+    pub category: MetadataWarningCategory,
+    pub reason: MetadataWarningReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    pub severity: MetadataWarningSeverity,
+}
+
+/// Apply `value` to `pad.metadata` defensively and return stable warning facts.
 pub fn apply_metadata_defensively(
     pad: &mut Pad,
     value: &serde_json::Value,
     parent_policy: ParentPolicy<'_>,
     source_label: &str,
-) -> Vec<CmdMessage> {
+) -> Vec<MetadataApplicationWarning> {
     pad.metadata
         .apply_json_patch(value, &parent_policy)
         .into_iter()
-        .map(|w| warning_to_message(w, source_label))
+        .map(|warning| warning_fact(warning, source_label))
         .collect()
 }
 
-fn warning_to_message(w: MetadataPatchWarning, source_label: &str) -> CmdMessage {
-    let text = format!("{}: {}", source_label, w);
-    if w.is_info() {
-        CmdMessage::info(text)
-    } else {
-        CmdMessage::warning(text)
+fn warning_fact(warning: MetadataPatchWarning, source_label: &str) -> MetadataApplicationWarning {
+    use MetadataPatchWarning as Warning;
+
+    let (category, reason, field, count) = match warning {
+        Warning::NotAnObject => (
+            MetadataWarningCategory::Metadata,
+            MetadataWarningReason::NotAnObject,
+            None,
+            None,
+        ),
+        Warning::InvalidId => (
+            MetadataWarningCategory::Field,
+            MetadataWarningReason::InvalidValue,
+            Some("id".to_string()),
+            None,
+        ),
+        Warning::InvalidField(field) => (
+            MetadataWarningCategory::Field,
+            MetadataWarningReason::InvalidValue,
+            Some(field.to_string()),
+            None,
+        ),
+        Warning::NonStringTags(count) => (
+            MetadataWarningCategory::Tags,
+            MetadataWarningReason::NonStringEntries,
+            Some("tags".to_string()),
+            Some(count),
+        ),
+        Warning::ParentOrphaned => (
+            MetadataWarningCategory::Parent,
+            MetadataWarningReason::OutsideImportSet,
+            Some("parent_id".to_string()),
+            None,
+        ),
+    };
+
+    MetadataApplicationWarning {
+        source_label: source_label.to_string(),
+        category,
+        reason,
+        field,
+        count,
+        severity: if warning.is_info() {
+            MetadataWarningSeverity::Info
+        } else {
+            MetadataWarningSeverity::Warning
+        },
     }
 }
 
@@ -50,5 +125,39 @@ pub fn parse_bucket_or_active(s: &str) -> Bucket {
         "Archived" => Bucket::Archived,
         "Deleted" => Bucket::Deleted,
         _ => Bucket::Active,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Pad;
+
+    #[test]
+    fn warning_facts_keep_source_category_reason_field_count_and_severity() {
+        let mut pad = Pad::new("Title".into(), "Body".into());
+        let warnings = apply_metadata_defensively(
+            &mut pad,
+            &serde_json::json!({"status": "broken", "tags": ["ok", 7]}),
+            ParentPolicy::Trust,
+            "entry.lex",
+        );
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().all(|warning| {
+            warning.source_label == "entry.lex"
+                && warning.severity == MetadataWarningSeverity::Warning
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.category == MetadataWarningCategory::Field
+                && warning.reason == MetadataWarningReason::InvalidValue
+                && warning.field.as_deref() == Some("status")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.category == MetadataWarningCategory::Tags
+                && warning.reason == MetadataWarningReason::NonStringEntries
+                && warning.field.as_deref() == Some("tags")
+                && warning.count == Some(1)
+        }));
     }
 }

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -32,8 +32,10 @@
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
 //! Initialization, doctor, purge, and artifact-producing commands use dedicated
-//! outcome types where a generic result would obscure the operation's facts. The
-//! UI layer (CLI, web, etc.) decides how to render every result.
+//! outcome types where a generic result would obscure the operation's facts. Pad
+//! mutations that still use [`CmdResult`] attach presentation-free [`CmdOutcome`]
+//! and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides how to render
+//! every result.
 //!
 //! ## Testing Strategy
 //!
@@ -94,6 +96,49 @@ pub enum CmdNotice {
     },
     AlreadyUnpinned {
         path: Vec<crate::index::DisplayIndex>,
+    },
+    /// A move request found the pad under the requested parent already.
+    AlreadyAtDestination {
+        path: Vec<crate::index::DisplayIndex>,
+    },
+    /// A status request found the pad in the requested state already.
+    AlreadyInStatus {
+        path: Vec<crate::index::DisplayIndex>,
+        status: crate::model::TodoStatus,
+    },
+    /// A completed-pad deletion request found no completed pads.
+    NoCompletedPads,
+}
+
+/// How a pad's content reached the update command.
+///
+/// The distinction preserves the compatible human result while structured
+/// clients can identify the operation without parsing its sentence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateKind {
+    /// A typed [`PadUpdate`] changed explicit pad fields.
+    Structured,
+    /// Raw content was parsed and applied to one or more pads.
+    Content,
+    /// The store refreshed a pad after its backing file changed externally.
+    Refresh,
+}
+
+/// A semantic, presentation-free fact about a completed pad mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CmdOutcome {
+    /// A pad's title/content/status fields were updated.
+    Updated {
+        path: Vec<crate::index::DisplayIndex>,
+        title: String,
+        update_kind: UpdateKind,
+    },
+    /// A pad changed to the requested todo status.
+    StatusChanged {
+        path: Vec<crate::index::DisplayIndex>,
+        status: crate::model::TodoStatus,
     },
 }
 
@@ -207,6 +252,8 @@ pub struct CmdResult {
     pub messages: Vec<CmdMessage>,
     /// Semantic notices that clients render or inspect without parsing English.
     pub notices: Vec<CmdNotice>,
+    /// Semantic successful outcomes that clients inspect without parsing English.
+    pub outcomes: Vec<CmdOutcome>,
     /// The nesting mode used to produce listed_pads.
     pub nesting: NestingMode,
 }

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -32,9 +32,9 @@
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
 //! Initialization, doctor, purge, import, cross-store transfer, tag
-//! catalog/mutation, and artifact-producing commands use dedicated outcome
-//! types where a generic result would obscure the operation's facts. Pad
-//! mutations that still use [`CmdResult`] attach presentation-free
+//! catalog/mutation, UUID selection, and artifact-producing commands return
+//! direct values or dedicated outcome types where a generic result would obscure
+//! the operation's facts. Pad mutations that still use [`CmdResult`] attach presentation-free
 //! [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides
 //! how to render every result.
 //!
@@ -61,6 +61,7 @@
 //! - [`export`]: Export pads to archive
 //! - [`import`]: Import pads from files
 //! - [`paths`]: Get filesystem paths to pads
+//! - [`uuid`]: Resolve selected pads to durable UUID values
 //! - [`init`]: Initialize scope directories
 //! - [`doctor`]: Verify and fix data consistency
 //! - [`tags`]: List and mutate the tag registry

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -31,9 +31,9 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! Initialization, doctor, purge, tag catalog/mutation, and artifact-producing
-//! commands use dedicated outcome types where a generic result would obscure the
-//! operation's facts. Pad mutations that still use [`CmdResult`] attach
+//! Initialization, doctor, purge, import, tag catalog/mutation, and
+//! artifact-producing commands use dedicated outcome types where a generic
+//! result would obscure the operation's facts. Pad mutations that still use [`CmdResult`] attach
 //! presentation-free [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI,
 //! web, etc.) decides how to render every result.
 //!

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -31,11 +31,11 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! Initialization, doctor, purge, and artifact-producing commands use dedicated
-//! outcome types where a generic result would obscure the operation's facts. Pad
-//! mutations that still use [`CmdResult`] attach presentation-free [`CmdOutcome`]
-//! and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides how to render
-//! every result.
+//! Initialization, doctor, purge, tag catalog/mutation, and artifact-producing
+//! commands use dedicated outcome types where a generic result would obscure the
+//! operation's facts. Pad mutations that still use [`CmdResult`] attach
+//! presentation-free [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI,
+//! web, etc.) decides how to render every result.
 //!
 //! ## Testing Strategy
 //!
@@ -62,6 +62,8 @@
 //! - [`paths`]: Get filesystem paths to pads
 //! - [`init`]: Initialize scope directories
 //! - [`doctor`]: Verify and fix data consistency
+//! - [`tags`]: List and mutate the tag registry
+//! - [`tagging`]: Assign and remove tags on selected pads
 //! - [`helpers`]: Shared utilities (index resolution, etc.)
 
 use crate::error::{PadzError, Result};

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -8,7 +8,7 @@
 //! Commands are where the real work happens:
 //! - Implement the actual logic for each operation
 //! - Operate on `Pad`, `Metadata`, and other domain types
-//! - Return structured `CmdResult` with affected pads and messages
+//! - Return structured `CmdResult` values or operation-specific semantic outcomes
 //! - Are completely UI-agnostic
 //!
 //! ## What Commands Do NOT Do
@@ -21,7 +21,7 @@
 //!
 //! ## Structured Returns
 //!
-//! Commands return [`CmdResult`], not strings. This struct carries:
+//! Most commands return [`CmdResult`], not strings. This struct carries:
 //! - `affected_pads`: Pads that were modified (as `DisplayPad` with post-operation index)
 //! - `listed_pads`: Pads to display (as `DisplayPad` with current index)
 //! - `messages`: Structured messages with levels (info, success, warning, error)
@@ -31,7 +31,9 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! The UI layer (CLI, web, etc.) then decides how to render this data.
+//! Initialization, doctor, purge, and artifact-producing commands use dedicated
+//! outcome types where a generic result would obscure the operation's facts. The
+//! UI layer (CLI, web, etc.) decides how to render every result.
 //!
 //! ## Testing Strategy
 //!

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -31,11 +31,12 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! Initialization, doctor, purge, import, tag catalog/mutation, and
-//! artifact-producing commands use dedicated outcome types where a generic
-//! result would obscure the operation's facts. Pad mutations that still use [`CmdResult`] attach
-//! presentation-free [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI,
-//! web, etc.) decides how to render every result.
+//! Initialization, doctor, purge, import, cross-store transfer, tag
+//! catalog/mutation, and artifact-producing commands use dedicated outcome
+//! types where a generic result would obscure the operation's facts. Pad
+//! mutations that still use [`CmdResult`] attach presentation-free
+//! [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides
+//! how to render every result.
 //!
 //! ## Testing Strategy
 //!

--- a/crates/padzapp/src/commands/move_pads.rs
+++ b/crates/padzapp/src/commands/move_pads.rs
@@ -1,4 +1,6 @@
-use crate::commands::{CmdMessage, CmdResult, DisplayPad};
+//! Hierarchy-preserving pad moves with semantic no-op reporting.
+
+use crate::commands::{CmdNotice, CmdResult, DisplayPad};
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayIndex, PadSelector};
 use crate::model::Scope;
@@ -87,10 +89,9 @@ pub fn run<S: DataStore>(
 
         // Skip if already there
         if pad.metadata.parent_id == dest_uuid {
-            result.add_message(CmdMessage::info(format!(
-                "Pad '{}' is already at destination",
-                fmt_path(&display_index)
-            )));
+            result.notices.push(CmdNotice::AlreadyAtDestination {
+                path: display_index,
+            });
             continue;
         }
 
@@ -287,5 +288,26 @@ mod tests {
         // Depending on exact impl, fetching "1.1" might fail if it uses get_pad_at_path and relies on index which might shift?
         // But here the structure exists.
         assert!(res.unwrap_err().to_string().contains("descendant"));
+    }
+
+    #[test]
+    fn moving_a_nested_pad_to_its_current_parent_is_a_semantic_no_op() {
+        let (mut store, _root_id, _child_id) = setup_store();
+        let path = vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)];
+
+        let result = run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(path.clone())],
+            Some(&PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        assert!(result.affected_pads.is_empty());
+        assert!(result.messages.is_empty());
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyAtDestination { path }]
+        );
     }
 }

--- a/crates/padzapp/src/commands/purge.rs
+++ b/crates/padzapp/src/commands/purge.rs
@@ -6,15 +6,33 @@ use crate::store::DataStore;
 use std::collections::HashSet;
 use uuid::Uuid;
 
-use super::helpers::{indexed_pads, pads_by_selectors, TitleBucket};
+use super::helpers::{indexed_pads, pads_with_paths_by_selectors, TitleBucket};
+
+/// One explicitly selected pad with its complete canonical display path.
+#[derive(Debug, Clone)]
+pub struct PurgeSelection {
+    pub path: Vec<DisplayIndex>,
+    pub pad: DisplayPad,
+}
+
+impl PurgeSelection {
+    /// Return the complete canonical display selector for this selection.
+    pub fn selector(&self) -> String {
+        self.path
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+}
 
 /// Semantic result of a permanent-deletion request.
 #[derive(Debug, Clone)]
 pub enum PurgeOutcome {
     Empty,
     Purged {
-        /// Explicitly selected pads, de-duplicated by UUID in display order.
-        selected_pads: Vec<DisplayPad>,
+        /// Explicit selections, de-duplicated by UUID in display order.
+        selected_pads: Vec<PurgeSelection>,
         /// Total number of unique pads permanently deleted.
         total_purged: usize,
         /// Unique deleted descendants that were not explicitly selected.
@@ -44,7 +62,7 @@ pub fn run<S: DataStore>(
     include_done: bool,
 ) -> Result<PurgeOutcome> {
     // 1. Resolve targets
-    let mut pads_to_purge = if selectors.is_empty() {
+    let mut pads_to_purge: Vec<PurgeSelection> = if selectors.is_empty() {
         let all_pads = indexed_pads(store, scope)?;
         all_pads
             .into_iter()
@@ -52,22 +70,32 @@ pub fn run<S: DataStore>(
                 matches!(dp.index, DisplayIndex::Deleted(_))
                     || (include_done && dp.pad.metadata.status == TodoStatus::Done)
             })
+            .map(|pad| PurgeSelection {
+                path: vec![pad.index.clone()],
+                pad,
+            })
             .collect()
     } else {
-        pads_by_selectors(store, scope, selectors, true, TitleBucket::Deleted)?
+        pads_with_paths_by_selectors(store, scope, selectors, true, TitleBucket::Deleted)?
+            .into_iter()
+            .map(|(path, pad)| PurgeSelection { path, pad })
+            .collect()
     };
 
     // Pinned active pads appear under both pinned and regular display indexes.
     // Preserve the first display identity while keeping semantic selections unique.
     let mut seen_targets = HashSet::new();
-    pads_to_purge.retain(|dp| seen_targets.insert(dp.pad.metadata.id));
+    pads_to_purge.retain(|selection| seen_targets.insert(selection.pad.pad.metadata.id));
 
     if pads_to_purge.is_empty() {
         return Ok(PurgeOutcome::Empty);
     }
 
     // 2. Find descendants
-    let target_ids: Vec<Uuid> = pads_to_purge.iter().map(|dp| dp.pad.metadata.id).collect();
+    let target_ids: Vec<Uuid> = pads_to_purge
+        .iter()
+        .map(|selection| selection.pad.pad.metadata.id)
+        .collect();
     let descendants = super::helpers::get_descendant_ids(store, scope, &target_ids)?;
 
     // 3. Safety valve: require --recursive if there are children
@@ -76,8 +104,8 @@ pub fn run<S: DataStore>(
             "Cannot purge: {} pad(s) have children. Use --recursive (-r) to purge entire subtrees.",
             pads_to_purge
                 .iter()
-                .filter(|dp| {
-                    let id = dp.pad.metadata.id;
+                .filter(|selection| {
+                    let id = selection.pad.pad.metadata.id;
                     super::helpers::get_descendant_ids(store, scope, &[id])
                         .map(|d| !d.is_empty())
                         .unwrap_or(false)
@@ -147,7 +175,13 @@ mod tests {
         };
         let actual_selected: Vec<String> = selected_pads
             .iter()
-            .map(|pad| format!("{} {}", pad.index, pad.pad.metadata.title))
+            .map(|selection| {
+                format!(
+                    "{} {}",
+                    selection.selector(),
+                    selection.pad.pad.metadata.title
+                )
+            })
             .collect();
         assert_eq!(actual_selected, selected);
         assert_eq!(actual_total, total_purged);
@@ -397,7 +431,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_purged(res, &["1 Parent", "1 Child"], 2, 0);
+        assert_purged(res, &["1 Parent", "1.1 Child"], 2, 0);
     }
 
     #[test]

--- a/crates/padzapp/src/commands/purge.rs
+++ b/crates/padzapp/src/commands/purge.rs
@@ -1,12 +1,26 @@
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
-use crate::index::{DisplayIndex, PadSelector};
+use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
 use crate::store::Bucket;
 use crate::store::DataStore;
+use std::collections::HashSet;
 use uuid::Uuid;
 
 use super::helpers::{indexed_pads, pads_by_selectors, TitleBucket};
+
+/// Semantic result of a permanent-deletion request.
+#[derive(Debug, Clone)]
+pub enum PurgeOutcome {
+    Empty,
+    Purged {
+        /// Explicitly selected pads, de-duplicated by UUID in display order.
+        selected_pads: Vec<DisplayPad>,
+        /// Total number of unique pads permanently deleted.
+        total_purged: usize,
+        /// Unique deleted descendants that were not explicitly selected.
+        descendant_count: usize,
+    },
+}
 
 /// Permanently removes pads from the store.
 ///
@@ -20,6 +34,7 @@ use super::helpers::{indexed_pads, pads_by_selectors, TitleBucket};
 /// - If `recursive` is false and any target has children, returns an error
 /// - If `confirmed` is false, returns an error (no pads are deleted)
 /// - `include_done`: when true and no selectors given, also purges pads with Done status
+/// - Duplicate display indexes and selected/descendant overlap count each UUID once
 pub fn run<S: DataStore>(
     store: &mut S,
     scope: Scope,
@@ -27,9 +42,9 @@ pub fn run<S: DataStore>(
     recursive: bool,
     confirmed: bool,
     include_done: bool,
-) -> Result<CmdResult> {
+) -> Result<PurgeOutcome> {
     // 1. Resolve targets
-    let pads_to_purge = if selectors.is_empty() {
+    let mut pads_to_purge = if selectors.is_empty() {
         let all_pads = indexed_pads(store, scope)?;
         all_pads
             .into_iter()
@@ -42,10 +57,13 @@ pub fn run<S: DataStore>(
         pads_by_selectors(store, scope, selectors, true, TitleBucket::Deleted)?
     };
 
+    // Pinned active pads appear under both pinned and regular display indexes.
+    // Preserve the first display identity while keeping semantic selections unique.
+    let mut seen_targets = HashSet::new();
+    pads_to_purge.retain(|dp| seen_targets.insert(dp.pad.metadata.id));
+
     if pads_to_purge.is_empty() {
-        let mut res = CmdResult::default();
-        res.add_message(CmdMessage::info("No pads to purge."));
-        return Ok(res);
+        return Ok(PurgeOutcome::Empty);
     }
 
     // 2. Find descendants
@@ -68,8 +86,15 @@ pub fn run<S: DataStore>(
         )));
     }
 
-    // 4. Calculate total count for message
-    let total_count = pads_to_purge.len() + descendants.len();
+    // 4. Build the unique deletion set. A selected child can also be returned as
+    // a descendant of another selected pad, but remains an explicit selection.
+    let mut all_ids = target_ids;
+    all_ids.extend(descendants);
+    all_ids.sort();
+    all_ids.dedup();
+
+    let total_count = all_ids.len();
+    let descendant_count = total_count - pads_to_purge.len();
 
     // 5. Confirmation check - must come after we know the count
     if !confirmed {
@@ -80,19 +105,6 @@ pub fn run<S: DataStore>(
     }
 
     // 6. Execute the purge
-    let mut all_ids = target_ids;
-    all_ids.extend(descendants.clone());
-    all_ids.sort();
-    all_ids.dedup();
-
-    let mut result = CmdResult::default();
-
-    // Add the "Purging X padz..." message first
-    result.add_message(CmdMessage::info(format!(
-        "Purging {} pad(s)...",
-        total_count
-    )));
-
     for id in all_ids {
         // Try each bucket (deleted first, then active for Done pads, then archived)
         for &bucket in &[Bucket::Deleted, Bucket::Active, Bucket::Archived] {
@@ -103,30 +115,44 @@ pub fn run<S: DataStore>(
         }
     }
 
-    for dp in pads_to_purge {
-        result.add_message(CmdMessage::success(format!(
-            "Purged: {} {}",
-            dp.index, dp.pad.metadata.title
-        )));
-    }
-    if !descendants.is_empty() {
-        result.add_message(CmdMessage::success(format!(
-            "And purged {} descendant(s)",
-            descendants.len()
-        )));
-    }
-
-    Ok(result)
+    Ok(PurgeOutcome::Purged {
+        selected_pads: pads_to_purge,
+        total_purged: total_count,
+        descendant_count,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::{create, delete, get};
+    use crate::commands::{create, delete, get, pinning};
     use crate::index::DisplayIndex;
     use crate::model::Scope;
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
+
+    fn assert_purged(
+        outcome: PurgeOutcome,
+        selected: &[&str],
+        total_purged: usize,
+        descendant_count: usize,
+    ) {
+        let PurgeOutcome::Purged {
+            selected_pads,
+            total_purged: actual_total,
+            descendant_count: actual_descendants,
+        } = outcome
+        else {
+            panic!("expected PurgeOutcome::Purged");
+        };
+        let actual_selected: Vec<String> = selected_pads
+            .iter()
+            .map(|pad| format!("{} {}", pad.index, pad.pad.metadata.title))
+            .collect();
+        assert_eq!(actual_selected, selected);
+        assert_eq!(actual_total, total_purged);
+        assert_eq!(actual_descendants, descendant_count);
+    }
 
     #[test]
     fn purges_deleted_pads_when_confirmed() {
@@ -170,12 +196,7 @@ mod tests {
         )
         .unwrap();
 
-        // Should have "Purging 1 pad(s)..." and "Purged: d1 A"
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 1")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Purged: d1 A")));
+        assert_purged(res, &["d1 A"], 1, 0);
 
         // Verify empty
         let deleted_after = get::run(
@@ -260,10 +281,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Purged: 1 A")));
+        assert_purged(res, &["1 A"], 1, 0);
 
         // Verify gone
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -283,8 +301,7 @@ mod tests {
         // Purge deleted (none) - even with confirmed=true, should just say "No pads"
         let res = run(&mut store, Scope::Project, &[], false, true, false).unwrap();
 
-        assert_eq!(res.messages.len(), 1);
-        assert!(res.messages[0].content.contains("No pads to purge"));
+        assert!(matches!(res, PurgeOutcome::Empty));
 
         // A still exists
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -330,15 +347,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 2"))); // parent + child
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Purged: d1 Parent")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("And purged 1 descendant")));
+        assert_purged(res, &["d1 Parent"], 2, 1);
 
         // Verify Store is empty (both Active and Deleted)
         assert_eq!(
@@ -355,6 +364,40 @@ mod tests {
                 .len(),
             0
         );
+    }
+
+    #[test]
+    fn selected_child_is_not_counted_again_as_a_descendant() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let res = run(
+            &mut store,
+            Scope::Project,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)]),
+            ],
+            true,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_purged(res, &["1 Parent", "1 Child"], 2, 0);
     }
 
     #[test]
@@ -430,7 +473,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 1")));
+        assert_purged(res, &["d1 B"], 1, 0);
 
         let remaining = store.list_pads(Scope::Project, Bucket::Deleted).unwrap();
         assert_eq!(remaining.len(), 1); // One remains in Deleted bucket
@@ -446,7 +489,7 @@ mod tests {
         );
         // Empty store - even with confirmed=true
         let res = run(&mut store, Scope::Project, &[], false, true, false).unwrap();
-        assert!(res.messages[0].content.contains("No pads to purge"));
+        assert!(matches!(res, PurgeOutcome::Empty));
     }
 
     #[test]
@@ -516,13 +559,46 @@ mod tests {
         // Purge with include_done=true (no selectors)
         let res = run(&mut store, Scope::Project, &[], false, true, true).unwrap();
 
-        // Should purge the Done pad
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 1")));
+        assert_purged(res, &["1 Complete Me"], 1, 0);
 
         // "Keep Me" (Planned) should still exist
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
         assert_eq!(listed.listed_pads.len(), 1);
         assert_eq!(listed.listed_pads[0].pad.metadata.title, "Keep Me");
+    }
+
+    #[test]
+    fn purge_include_done_reports_a_pinned_pad_once() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Complete Me".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        crate::commands::status::complete(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+        pinning::pin(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+        )
+        .unwrap();
+
+        let res = run(&mut store, Scope::Project, &[], false, true, true).unwrap();
+
+        assert_purged(res, &["p1 Complete Me"], 1, 0);
     }
 
     #[test]
@@ -546,8 +622,7 @@ mod tests {
         // Purge with include_done=false (default / notes mode)
         let res = run(&mut store, Scope::Project, &[], false, true, false).unwrap();
 
-        // No pads to purge (Done but not Deleted, and include_done is false)
-        assert!(res.messages[0].content.contains("No pads to purge"));
+        assert!(matches!(res, PurgeOutcome::Empty));
 
         // A still exists
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();
@@ -609,7 +684,7 @@ mod tests {
         // Purge with include_done=true - should get both Done and Deleted
         let res = run(&mut store, Scope::Project, &[], false, true, true).unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Purging 2")));
+        assert_purged(res, &["2 Done Pad", "d1 Deleted Pad"], 2, 0);
 
         // Only "Active Pad" should remain
         let listed = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();

--- a/crates/padzapp/src/commands/status.rs
+++ b/crates/padzapp/src/commands/status.rs
@@ -4,7 +4,7 @@
 //! - [`complete`]: Marks pads as Done
 //! - [`reopen`]: Reopens pads (sets them back to Planned)
 
-use crate::commands::{CmdMessage, CmdResult};
+use crate::commands::{CmdNotice, CmdOutcome, CmdResult};
 use crate::error::Result;
 use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
@@ -46,18 +46,15 @@ fn set_status<S: DataStore>(
         let old_status = pad.metadata.status;
 
         if old_status == new_status {
-            // Already in desired state - add info message
-            let status_name = match new_status {
-                TodoStatus::Done => "done",
-                TodoStatus::Planned => "planned",
-                TodoStatus::InProgress => "in progress",
-            };
-            result.add_message(CmdMessage::info(format!(
-                "Pad {} is already {}",
-                super::helpers::fmt_path(&display_index),
-                status_name
-            )));
+            result.notices.push(CmdNotice::AlreadyInStatus {
+                path: display_index,
+                status: new_status,
+            });
         } else {
+            result.outcomes.push(CmdOutcome::StatusChanged {
+                path: display_index.clone(),
+                status: new_status,
+            });
             pad.metadata.status = new_status;
             pad.metadata.updated_at = chrono::Utc::now();
 
@@ -165,11 +162,14 @@ mod tests {
         // Complete again
         let result = complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        assert!(matches!(
-            result.messages[0].level,
-            crate::commands::MessageLevel::Info
-        ));
-        assert!(result.messages[0].content.contains("already done"));
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyInStatus {
+                path: vec![DisplayIndex::Regular(1)],
+                status: TodoStatus::Done,
+            }]
+        );
+        assert!(result.messages.is_empty());
     }
 
     #[test]
@@ -187,11 +187,62 @@ mod tests {
         // Reopen an already planned pad
         let result = reopen(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        assert!(matches!(
-            result.messages[0].level,
-            crate::commands::MessageLevel::Info
-        ));
-        assert!(result.messages[0].content.contains("already planned"));
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyInStatus {
+                path: vec![DisplayIndex::Regular(1)],
+                status: TodoStatus::Planned,
+            }]
+        );
+        assert!(result.messages.is_empty());
+    }
+
+    #[test]
+    fn complete_mixed_request_distinguishes_changed_and_no_op_pads() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Changed".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        create::run(&mut store, Scope::Project, "No op".into(), "".into(), None).unwrap();
+        let first = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        complete(&mut store, Scope::Project, slice::from_ref(&first)).unwrap();
+
+        let result = complete(
+            &mut store,
+            Scope::Project,
+            &[first, PadSelector::Path(vec![DisplayIndex::Regular(2)])],
+        )
+        .unwrap();
+
+        assert_eq!(result.affected_pads.len(), 2);
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyInStatus {
+                path: vec![DisplayIndex::Regular(1)],
+                status: TodoStatus::Done,
+            }]
+        );
+        assert!(result
+            .affected_pads
+            .iter()
+            .all(|pad| pad.pad.metadata.status == TodoStatus::Done));
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::StatusChanged {
+                path: vec![DisplayIndex::Regular(2)],
+                status: TodoStatus::Done,
+            }]
+        );
     }
 
     #[test]

--- a/crates/padzapp/src/commands/tagging.rs
+++ b/crates/padzapp/src/commands/tagging.rs
@@ -1,63 +1,83 @@
-//! Pad tagging commands.
+//! Semantic per-pad tag assignment and removal.
 //!
-//! This module provides operations for managing tags on pads:
-//! - `add_tags`: Add tags to pads (auto-creates tags if needed)
-//! - `remove_tags`: Remove specific tags from pads
+//! Requested tag order, changed-pad counts, and no-op distinctions are domain
+//! facts. Human sentences, brackets, pluralization, and styles belong to clients.
 
 use crate::attributes::AttrValue;
 use crate::commands::helpers::{indexed_pads, resolve_selectors, TitleBucket};
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::Scope;
-use crate::store::Bucket;
-use crate::store::DataStore;
+use crate::store::{Bucket, DataStore};
 
-/// Add tags to selected pads.
+/// The semantic result of applying or removing requested tags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaggingOutcome {
+    Assigned {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+    AllAlreadyPresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+    Removed {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+    NonePresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+}
+
+/// Selected pads after a tag mutation, paired with its semantic outcome.
+#[derive(Debug, Clone)]
+pub struct TaggingResult {
+    pub affected_pads: Vec<DisplayPad>,
+    pub outcome: TaggingOutcome,
+}
+
+/// Add tags to selected pads, auto-creating missing registry entries.
 ///
-/// Tags are auto-created in the registry if they don't already exist.
-/// Adding a tag that a pad already has is a no-op (idempotent).
+/// Adding tags that every selected pad already carries is an explicit no-op.
 pub fn add_tags<S: DataStore>(
     store: &mut S,
     scope: Scope,
     selectors: &[PadSelector],
     tags: &[String],
-) -> Result<CmdResult> {
+) -> Result<TaggingResult> {
     if tags.is_empty() {
         return Err(PadzError::Api("No tags specified".to_string()));
     }
 
-    // Auto-create tags that don't exist in the registry
     let mut registry = store.load_tags(scope)?;
-    let mut created_tags = Vec::new();
+    let mut registry_changed = false;
     for tag in tags {
-        if !registry.iter().any(|t| t.name == *tag) {
+        if !registry.iter().any(|entry| entry.name == *tag) {
             use crate::tags::{validate_tag_name, TagEntry};
             validate_tag_name(tag).map_err(|e| PadzError::Api(e.to_string()))?;
             registry.push(TagEntry::new(tag.clone()));
-            created_tags.push(tag.clone());
+            registry_changed = true;
         }
     }
-    if !created_tags.is_empty() {
+    if registry_changed {
         store.save_tags(scope, &registry)?;
     }
 
     let resolved = resolve_selectors(store, scope, selectors, false, TitleBucket::Active)?;
-    let mut result = CmdResult::default();
-    let mut modified_count = 0;
+    let mut affected_pads = Vec::with_capacity(resolved.len());
+    let mut modified_pads = 0;
 
     for (display_index, uuid) in resolved {
         let mut pad = store.get_pad(&uuid, scope, Bucket::Active)?;
-
-        // Get current tags via attribute API
         let current_tags = pad
             .metadata
             .get_attr("tags")
-            .and_then(|v| v.as_list().map(|l| l.to_vec()))
+            .and_then(|value| value.as_list().map(<[String]>::to_vec))
             .unwrap_or_default();
         let original_count = current_tags.len();
 
-        // Add tags that aren't already present
         let mut new_tags = current_tags;
         for tag in tags {
             if !new_tags.contains(tag) {
@@ -65,19 +85,16 @@ pub fn add_tags<S: DataStore>(
             }
         }
 
-        // Sort and save if changed
         if new_tags.len() > original_count {
             new_tags.sort();
             pad.metadata.set_attr("tags", AttrValue::List(new_tags));
             store.save_pad(&pad, scope, Bucket::Active)?;
-            modified_count += 1;
+            modified_pads += 1;
         }
 
-        // Re-index to get updated pad with correct index
-        let indexed = indexed_pads(store, scope)?;
-        if let Some(dp) = find_pad_by_uuid_any(&indexed, uuid) {
-            result.affected_pads.push(DisplayPad {
-                pad: dp.pad.clone(),
+        if let Some(display_pad) = find_pad_by_uuid_any(&indexed_pads(store, scope)?, uuid) {
+            affected_pads.push(DisplayPad {
+                pad: display_pad.pad.clone(),
                 index: display_index
                     .last()
                     .cloned()
@@ -88,72 +105,65 @@ pub fn add_tags<S: DataStore>(
         }
     }
 
-    let tag_list = tags.join(", ");
-    if modified_count > 0 {
-        result.add_message(CmdMessage::success(format!(
-            "Added tag{} [{}] to {} pad{}",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list,
-            modified_count,
-            if modified_count == 1 { "" } else { "s" }
-        )));
+    let requested_tags = tags.to_vec();
+    let outcome = if modified_pads == 0 {
+        TaggingOutcome::AllAlreadyPresent {
+            requested_tags,
+            modified_pads,
+        }
     } else {
-        result.add_message(CmdMessage::info(format!(
-            "All pads already have tag{} [{}]",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list
-        )));
-    }
+        TaggingOutcome::Assigned {
+            requested_tags,
+            modified_pads,
+        }
+    };
 
-    Ok(result)
+    Ok(TaggingResult {
+        affected_pads,
+        outcome,
+    })
 }
 
-/// Remove specific tags from selected pads.
+/// Remove requested tags from selected pads.
 ///
-/// Removing a tag that a pad doesn't have is a no-op (idempotent).
+/// A request where none of the selected pads carries any requested tag is an
+/// explicit no-op. Registry entries are not removed.
 pub fn remove_tags<S: DataStore>(
     store: &mut S,
     scope: Scope,
     selectors: &[PadSelector],
     tags: &[String],
-) -> Result<CmdResult> {
+) -> Result<TaggingResult> {
     if tags.is_empty() {
         return Err(PadzError::Api("No tags specified".to_string()));
     }
 
     let resolved = resolve_selectors(store, scope, selectors, false, TitleBucket::Active)?;
-    let mut result = CmdResult::default();
-    let mut modified_count = 0;
+    let mut affected_pads = Vec::with_capacity(resolved.len());
+    let mut modified_pads = 0;
 
     for (display_index, uuid) in resolved {
         let mut pad = store.get_pad(&uuid, scope, Bucket::Active)?;
-
-        // Get current tags via attribute API
         let current_tags = pad
             .metadata
             .get_attr("tags")
-            .and_then(|v| v.as_list().map(|l| l.to_vec()))
+            .and_then(|value| value.as_list().map(<[String]>::to_vec))
             .unwrap_or_default();
         let original_count = current_tags.len();
-
-        // Remove specified tags
-        let new_tags: Vec<String> = current_tags
+        let new_tags = current_tags
             .into_iter()
-            .filter(|t| !tags.contains(t))
-            .collect();
+            .filter(|tag| !tags.contains(tag))
+            .collect::<Vec<_>>();
 
-        // Save if changed
         if new_tags.len() < original_count {
             pad.metadata.set_attr("tags", AttrValue::List(new_tags));
             store.save_pad(&pad, scope, Bucket::Active)?;
-            modified_count += 1;
+            modified_pads += 1;
         }
 
-        // Re-index to get updated pad with correct index
-        let indexed = indexed_pads(store, scope)?;
-        if let Some(dp) = find_pad_by_uuid_any(&indexed, uuid) {
-            result.affected_pads.push(DisplayPad {
-                pad: dp.pad.clone(),
+        if let Some(display_pad) = find_pad_by_uuid_any(&indexed_pads(store, scope)?, uuid) {
+            affected_pads.push(DisplayPad {
+                pad: display_pad.pad.clone(),
                 index: display_index
                     .last()
                     .cloned()
@@ -164,33 +174,31 @@ pub fn remove_tags<S: DataStore>(
         }
     }
 
-    let tag_list = tags.join(", ");
-    if modified_count > 0 {
-        result.add_message(CmdMessage::success(format!(
-            "Removed tag{} [{}] from {} pad{}",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list,
-            modified_count,
-            if modified_count == 1 { "" } else { "s" }
-        )));
+    let requested_tags = tags.to_vec();
+    let outcome = if modified_pads == 0 {
+        TaggingOutcome::NonePresent {
+            requested_tags,
+            modified_pads,
+        }
     } else {
-        result.add_message(CmdMessage::info(format!(
-            "No pads had tag{} [{}]",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list
-        )));
-    }
+        TaggingOutcome::Removed {
+            requested_tags,
+            modified_pads,
+        }
+    };
 
-    Ok(result)
+    Ok(TaggingResult {
+        affected_pads,
+        outcome,
+    })
 }
 
-/// Find a pad by UUID in the indexed tree (any index type).
 fn find_pad_by_uuid_any(pads: &[DisplayPad], uuid: uuid::Uuid) -> Option<&DisplayPad> {
-    for dp in pads {
-        if dp.pad.metadata.id == uuid {
-            return Some(dp);
+    for pad in pads {
+        if pad.pad.metadata.id == uuid {
+            return Some(pad);
         }
-        if let Some(found) = find_pad_by_uuid_any(&dp.children, uuid) {
+        if let Some(found) = find_pad_by_uuid_any(&pad.children, uuid) {
             return Some(found);
         }
     }
@@ -204,168 +212,163 @@ mod tests {
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
 
-    fn setup_store_with_tag() -> BucketedStore<MemBackend> {
-        let mut store = BucketedStore::new(
+    fn store() -> BucketedStore<MemBackend> {
+        BucketedStore::new(
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
+        )
+    }
+
+    fn selectors(count: usize) -> Vec<PadSelector> {
+        (1..=count)
+            .map(|index| PadSelector::Path(vec![DisplayIndex::Regular(index)]))
+            .collect()
+    }
+
+    #[test]
+    fn assigning_one_tag_returns_requested_tags_and_modified_pad_count() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+
+        let result = add_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
+
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Assigned {
+                requested_tags: vec!["work".into()],
+                modified_pads: 1,
+            }
         );
-        tags::create_tag(&mut store, Scope::Project, "work").unwrap();
-        tags::create_tag(&mut store, Scope::Project, "rust").unwrap();
-        store
+        assert_eq!(result.affected_pads[0].pad.metadata.tags, vec!["work"]);
+        assert!(store
+            .load_tags(Scope::Project)
+            .unwrap()
+            .iter()
+            .any(|tag| tag.name == "work"));
     }
 
     #[test]
-    fn test_add_tags_single_pad() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(
+    fn assigning_multiple_tags_counts_pads_not_tag_applications() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "One".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Two".into(), "".into(), None).unwrap();
+        add_tags(
             &mut store,
             Scope::Project,
-            &selectors,
-            &["work".to_string()],
+            &selectors(1),
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
-        assert!(result.messages[0].content.contains("Added tag"));
+        let result = add_tags(
+            &mut store,
+            Scope::Project,
+            &selectors(2),
+            &["work".into(), "rust".into()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Assigned {
+                requested_tags: vec!["work".into(), "rust".into()],
+                modified_pads: 1,
+            }
+        );
+        assert_eq!(result.affected_pads.len(), 2);
+    }
+
+    #[test]
+    fn repeated_assignment_is_a_distinct_all_already_present_no_op() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        add_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
+
+        let result = add_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
+
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::AllAlreadyPresent {
+                requested_tags: vec!["work".into()],
+                modified_pads: 0,
+            }
+        );
         assert_eq!(result.affected_pads.len(), 1);
-        assert!(result.affected_pads[0]
-            .pad
-            .metadata
-            .tags
-            .contains(&"work".to_string()));
     }
 
     #[test]
-    fn test_add_tags_multiple_tags() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string(), "rust".to_string()],
-        )
-        .unwrap();
-
-        assert!(result.messages[0].content.contains("Added tags"));
-        let tags = &result.affected_pads[0].pad.metadata.tags;
-        assert!(tags.contains(&"work".to_string()));
-        assert!(tags.contains(&"rust".to_string()));
-    }
-
-    #[test]
-    fn test_add_tags_auto_creates_tag() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["newbie".to_string()],
-        )
-        .unwrap();
-
-        assert!(result.messages[0].content.contains("Added tag"));
-        assert!(result.affected_pads[0]
-            .pad
-            .metadata
-            .tags
-            .contains(&"newbie".to_string()));
-
-        // Verify the tag was auto-created in the registry
-        let registry = store.load_tags(Scope::Project).unwrap();
-        assert!(registry.iter().any(|t| t.name == "newbie"));
-    }
-
-    #[test]
-    fn test_add_tags_idempotent() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
+    fn removing_tags_returns_requested_tags_and_modified_pad_count() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
         add_tags(
             &mut store,
             Scope::Project,
-            &selectors,
-            &["work".to_string()],
-        )
-        .unwrap();
-
-        // Adding same tag again
-        let result = add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string()],
-        )
-        .unwrap();
-
-        assert!(result.messages[0].content.contains("already have"));
-    }
-
-    #[test]
-    fn test_remove_tags() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string()],
+            &selectors(1),
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
         let result = remove_tags(
             &mut store,
             Scope::Project,
-            &selectors,
-            &["work".to_string()],
+            &selectors(1),
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
-        assert!(result.messages[0].content.contains("Removed tag"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Removed {
+                requested_tags: vec!["work".into(), "rust".into()],
+                modified_pads: 1,
+            }
+        );
         assert!(result.affected_pads[0].pad.metadata.tags.is_empty());
     }
 
     #[test]
-    fn test_remove_tags_not_present() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
+    fn removing_absent_tags_is_a_distinct_none_present_no_op() {
+        let mut store = store();
+        tags::create_tag(&mut store, Scope::Project, "work").unwrap();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
 
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = remove_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string()],
-        )
-        .unwrap();
+        let result =
+            remove_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
 
-        assert!(result.messages[0].content.contains("No pads had"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::NonePresent {
+                requested_tags: vec!["work".into()],
+                modified_pads: 0,
+            }
+        );
+        assert_eq!(result.affected_pads.len(), 1);
     }
 
     #[test]
-    fn test_add_tags_no_tags_error() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
+    fn empty_tag_requests_preserve_validation_error() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        let error = add_tags(&mut store, Scope::Project, &selectors(1), &[]).unwrap_err();
+        assert!(error.to_string().contains("No tags specified"));
+    }
 
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(&mut store, Scope::Project, &selectors, &[]);
+    #[test]
+    fn invalid_auto_created_tag_preserves_validation_error_without_registry_write() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("No tags specified"));
+        let error = add_tags(
+            &mut store,
+            Scope::Project,
+            &selectors(1),
+            &["-invalid".into()],
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must start"));
+        assert!(store.load_tags(Scope::Project).unwrap().is_empty());
     }
 }

--- a/crates/padzapp/src/commands/tags.rs
+++ b/crates/padzapp/src/commands/tags.rs
@@ -1,43 +1,68 @@
-//! Tag management commands.
+//! Semantic tag-registry operations.
 //!
-//! This module provides CRUD operations for the tag registry:
-//! - `list_tags`: List all tags in a scope
-//! - `create_tag`: Create a new tag
-//! - `delete_tag`: Delete a tag (cascades to pads)
-//! - `rename_tag`: Rename a tag (updates all pads)
+//! Registry order and affected-pad counts are application facts. Human prose,
+//! pluralization, line layout, and styling belong to clients.
 
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::model::Scope;
-use crate::store::Bucket;
-use crate::store::DataStore;
+use crate::store::{Bucket, DataStore};
 use crate::tags::{validate_tag_name, TagEntry};
 
-/// List all tags in the registry.
-pub fn list_tags<S: DataStore>(store: &S, scope: Scope) -> Result<CmdResult> {
-    let tags = store.load_tags(scope)?;
-    let mut result = CmdResult::default();
-
-    if tags.is_empty() {
-        result.add_message(CmdMessage::info("No tags defined"));
-    } else {
-        for tag in &tags {
-            result.add_message(CmdMessage::info(tag.name.clone()));
-        }
-    }
-
-    Ok(result)
+/// An ordered catalog of tag names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TagCatalogOutcome {
+    /// No tags are defined for the requested registry or pad selection.
+    Empty,
+    /// Tags in the order the command contract exposes them.
+    Listed { tags: Vec<String> },
 }
 
-/// List tags for specific pads.
+impl TagCatalogOutcome {
+    fn from_names(tags: Vec<String>) -> Self {
+        if tags.is_empty() {
+            Self::Empty
+        } else {
+            Self::Listed { tags }
+        }
+    }
+}
+
+/// A completed tag-registry mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TagRegistryOutcome {
+    Created {
+        name: String,
+        affected_pads: usize,
+    },
+    Deleted {
+        name: String,
+        affected_pads: usize,
+    },
+    Renamed {
+        old_name: String,
+        new_name: String,
+        affected_pads: usize,
+    },
+}
+
+/// List all tags in registry order.
+pub fn list_tags<S: DataStore>(store: &S, scope: Scope) -> Result<TagCatalogOutcome> {
+    let tags = store
+        .load_tags(scope)?
+        .into_iter()
+        .map(|tag| tag.name)
+        .collect();
+    Ok(TagCatalogOutcome::from_names(tags))
+}
+
+/// List the unique tags on selected pads in lexical order.
 ///
-/// Collects all unique tags from the resolved pads and outputs them
-/// in the same format as `list_tags` (one tag name per line).
+/// The lexical ordering preserves the established `tag list <id>...` contract.
 pub fn list_pad_tags<S: DataStore>(
     store: &S,
     scope: Scope,
     selectors: &[crate::index::PadSelector],
-) -> Result<CmdResult> {
+) -> Result<TagCatalogOutcome> {
     use crate::commands::helpers::{resolve_selectors, TitleBucket};
     use std::collections::BTreeSet;
 
@@ -46,446 +71,283 @@ pub fn list_pad_tags<S: DataStore>(
 
     for (_display_index, uuid) in resolved {
         let pad = store.get_pad(&uuid, scope, Bucket::Active)?;
-        for tag in &pad.metadata.tags {
-            all_tags.insert(tag.clone());
-        }
+        all_tags.extend(pad.metadata.tags);
     }
 
-    let mut result = CmdResult::default();
-    if all_tags.is_empty() {
-        result.add_message(CmdMessage::info("No tags defined"));
-    } else {
-        for tag in &all_tags {
-            result.add_message(CmdMessage::info(tag.clone()));
-        }
-    }
-
-    Ok(result)
+    Ok(TagCatalogOutcome::from_names(
+        all_tags.into_iter().collect(),
+    ))
 }
 
 /// Create a new tag in the registry.
 ///
-/// Returns an error if the tag name is invalid or already exists.
-pub fn create_tag<S: DataStore>(store: &mut S, scope: Scope, name: &str) -> Result<CmdResult> {
-    // Validate tag name
+/// Returns an error if the tag name is invalid or already exists. Creation does
+/// not modify any pads, so the semantic affected count is always zero.
+pub fn create_tag<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    name: &str,
+) -> Result<TagRegistryOutcome> {
     validate_tag_name(name).map_err(|e| PadzError::Api(e.to_string()))?;
 
-    // Check if tag already exists
     let mut tags = store.load_tags(scope)?;
-    if tags.iter().any(|t| t.name == name) {
+    if tags.iter().any(|tag| tag.name == name) {
         return Err(PadzError::Api(format!("Tag '{}' already exists", name)));
     }
 
-    // Create and save the tag
-    let tag = TagEntry::new(name.to_string());
-    tags.push(tag);
+    tags.push(TagEntry::new(name.to_string()));
     store.save_tags(scope, &tags)?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!("Created tag '{}'", name)));
-    Ok(result)
+    Ok(TagRegistryOutcome::Created {
+        name: name.to_string(),
+        affected_pads: 0,
+    })
 }
 
-/// Delete a tag from the registry.
-///
-/// This cascades to all pads that have the tag - the tag is removed from their metadata.
-pub fn delete_tag<S: DataStore>(store: &mut S, scope: Scope, name: &str) -> Result<CmdResult> {
+/// Delete a registry tag and remove it from every active pad that carries it.
+pub fn delete_tag<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    name: &str,
+) -> Result<TagRegistryOutcome> {
     let mut tags = store.load_tags(scope)?;
-
-    // Find and remove the tag
     let original_len = tags.len();
-    tags.retain(|t| t.name != name);
+    tags.retain(|tag| tag.name != name);
 
     if tags.len() == original_len {
         return Err(PadzError::Api(format!("Tag '{}' not found", name)));
     }
 
-    // Save updated tag registry
     store.save_tags(scope, &tags)?;
 
-    // Cascade: remove tag from all pads
-    let pads = store.list_pads(scope, Bucket::Active)?;
-    let mut affected_count = 0;
-    for mut pad in pads {
-        if pad.metadata.tags.contains(&name.to_string()) {
-            pad.metadata.tags.retain(|t| t != name);
+    let mut affected_pads = 0;
+    for mut pad in store.list_pads(scope, Bucket::Active)? {
+        if pad.metadata.tags.iter().any(|tag| tag == name) {
+            pad.metadata.tags.retain(|tag| tag != name);
             store.save_pad(&pad, scope, Bucket::Active)?;
-            affected_count += 1;
+            affected_pads += 1;
         }
     }
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!("Deleted tag '{}'", name)));
-    if affected_count > 0 {
-        result.add_message(CmdMessage::info(format!(
-            "Removed from {} pad{}",
-            affected_count,
-            if affected_count == 1 { "" } else { "s" }
-        )));
-    }
-    Ok(result)
+    Ok(TagRegistryOutcome::Deleted {
+        name: name.to_string(),
+        affected_pads,
+    })
 }
 
-/// Rename a tag in the registry.
-///
-/// This updates all pads that have the old tag name to use the new name.
+/// Rename a registry tag and update every active pad that carries it.
 pub fn rename_tag<S: DataStore>(
     store: &mut S,
     scope: Scope,
     old_name: &str,
     new_name: &str,
-) -> Result<CmdResult> {
-    // Validate new tag name
+) -> Result<TagRegistryOutcome> {
     validate_tag_name(new_name).map_err(|e| PadzError::Api(e.to_string()))?;
 
     let mut tags = store.load_tags(scope)?;
-
-    // Check if old tag exists
     let tag_idx = tags
         .iter()
-        .position(|t| t.name == old_name)
+        .position(|tag| tag.name == old_name)
         .ok_or_else(|| PadzError::Api(format!("Tag '{}' not found", old_name)))?;
 
-    // Check if new name already exists
-    if tags.iter().any(|t| t.name == new_name) {
+    if tags.iter().any(|tag| tag.name == new_name) {
         return Err(PadzError::Api(format!("Tag '{}' already exists", new_name)));
     }
 
-    // Update the tag name in the registry
     tags[tag_idx].name = new_name.to_string();
     store.save_tags(scope, &tags)?;
 
-    // Update all pads that have this tag
-    let pads = store.list_pads(scope, Bucket::Active)?;
-    let mut affected_count = 0;
-    for mut pad in pads {
-        if let Some(pos) = pad.metadata.tags.iter().position(|t| t == old_name) {
+    let mut affected_pads = 0;
+    for mut pad in store.list_pads(scope, Bucket::Active)? {
+        if let Some(pos) = pad.metadata.tags.iter().position(|tag| tag == old_name) {
             pad.metadata.tags[pos] = new_name.to_string();
             store.save_pad(&pad, scope, Bucket::Active)?;
-            affected_count += 1;
+            affected_pads += 1;
         }
     }
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!(
-        "Renamed tag '{}' to '{}'",
-        old_name, new_name
-    )));
-    if affected_count > 0 {
-        result.add_message(CmdMessage::info(format!(
-            "Updated {} pad{}",
-            affected_count,
-            if affected_count == 1 { "" } else { "s" }
-        )));
-    }
-    Ok(result)
+    Ok(TagRegistryOutcome::Renamed {
+        old_name: old_name.to_string(),
+        new_name: new_name.to_string(),
+        affected_pads,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::create;
+    use crate::commands::{create, tagging};
+    use crate::index::{DisplayIndex, PadSelector};
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
 
-    #[test]
-    fn test_list_tags_empty() {
-        let store = BucketedStore::new(
+    fn store() -> BucketedStore<MemBackend> {
+        BucketedStore::new(
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
-        );
-        let result = list_tags(&store, Scope::Project).unwrap();
-        assert!(result.messages[0].content.contains("No tags defined"));
+        )
     }
 
     #[test]
-    fn test_list_tags_no_preamble() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
+    fn empty_registry_is_an_explicit_catalog_state() {
+        assert_eq!(
+            list_tags(&store(), Scope::Project).unwrap(),
+            TagCatalogOutcome::Empty
         );
+    }
+
+    #[test]
+    fn registry_catalog_preserves_creation_order() {
+        let mut store = store();
         create_tag(&mut store, Scope::Project, "work").unwrap();
         create_tag(&mut store, Scope::Project, "rust").unwrap();
 
-        let result = list_tags(&store, Scope::Project).unwrap();
-        // Should just be the tag names, no "X tags defined" preamble
-        assert_eq!(result.messages.len(), 2);
-        assert_eq!(result.messages[0].content, "work");
-        assert_eq!(result.messages[1].content, "rust");
+        assert_eq!(
+            list_tags(&store, Scope::Project).unwrap(),
+            TagCatalogOutcome::Listed {
+                tags: vec!["work".into(), "rust".into()]
+            }
+        );
     }
 
     #[test]
-    fn test_create_tag() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = create_tag(&mut store, Scope::Project, "work").unwrap();
-        assert!(result.messages[0].content.contains("Created tag 'work'"));
+    fn create_returns_the_name_and_zero_affected_pads() {
+        let mut store = store();
 
-        // Verify tag exists
-        let tags = store.load_tags(Scope::Project).unwrap();
-        assert_eq!(tags.len(), 1);
-        assert_eq!(tags[0].name, "work");
+        assert_eq!(
+            create_tag(&mut store, Scope::Project, "work").unwrap(),
+            TagRegistryOutcome::Created {
+                name: "work".into(),
+                affected_pads: 0,
+            }
+        );
+        assert_eq!(store.load_tags(Scope::Project).unwrap()[0].name, "work");
     }
 
     #[test]
-    fn test_create_tag_invalid_name() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = create_tag(&mut store, Scope::Project, "-invalid");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_create_tag_duplicate() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
+    fn create_preserves_invalid_and_duplicate_errors() {
+        let mut store = store();
+        assert!(create_tag(&mut store, Scope::Project, "-invalid").is_err());
         create_tag(&mut store, Scope::Project, "work").unwrap();
-        let result = create_tag(&mut store, Scope::Project, "work");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already exists"));
+        let error = create_tag(&mut store, Scope::Project, "work").unwrap_err();
+        assert!(error.to_string().contains("already exists"));
     }
 
     #[test]
-    fn test_delete_tag() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
+    fn delete_returns_its_name_and_cascade_count() {
+        let mut store = store();
         create_tag(&mut store, Scope::Project, "work").unwrap();
-
-        let result = delete_tag(&mut store, Scope::Project, "work").unwrap();
-        assert!(result.messages[0].content.contains("Deleted tag 'work'"));
-
-        // Verify tag is gone
-        let tags = store.load_tags(Scope::Project).unwrap();
-        assert!(tags.is_empty());
-    }
-
-    #[test]
-    fn test_delete_tag_not_found() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = delete_tag(&mut store, Scope::Project, "nonexistent");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[test]
-    fn test_delete_tag_cascades_to_pads() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-
-        // Create a tag and a pad with that tag
-        create_tag(&mut store, Scope::Project, "work").unwrap();
-        create::run(
+        create::run(&mut store, Scope::Project, "One".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Two".into(), "".into(), None).unwrap();
+        tagging::add_tags(
             &mut store,
             Scope::Project,
-            "Test Pad".into(),
-            "".into(),
-            None,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+            ],
+            &["work".into()],
         )
         .unwrap();
 
-        // Manually add tag to pad
-        let mut pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        pads[0].metadata.tags.push("work".to_string());
-        store
-            .save_pad(&pads[0], Scope::Project, Bucket::Active)
-            .unwrap();
-
-        // Delete the tag
-        let result = delete_tag(&mut store, Scope::Project, "work").unwrap();
-        assert!(result.messages[1].content.contains("Removed from 1 pad"));
-
-        // Verify tag is removed from pad
-        let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        assert!(pads[0].metadata.tags.is_empty());
+        assert_eq!(
+            delete_tag(&mut store, Scope::Project, "work").unwrap(),
+            TagRegistryOutcome::Deleted {
+                name: "work".into(),
+                affected_pads: 2,
+            }
+        );
+        assert!(store
+            .list_pads(Scope::Project, Bucket::Active)
+            .unwrap()
+            .iter()
+            .all(|pad| pad.metadata.tags.is_empty()));
     }
 
     #[test]
-    fn test_rename_tag() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "old-name").unwrap();
-
-        let result = rename_tag(&mut store, Scope::Project, "old-name", "new-name").unwrap();
-        assert!(result.messages[0]
-            .content
-            .contains("Renamed tag 'old-name' to 'new-name'"));
-
-        // Verify old tag is gone, new tag exists
-        let tags = store.load_tags(Scope::Project).unwrap();
-        assert_eq!(tags.len(), 1);
-        assert_eq!(tags[0].name, "new-name");
+    fn delete_preserves_not_found_error() {
+        let error = delete_tag(&mut store(), Scope::Project, "missing").unwrap_err();
+        assert!(error.to_string().contains("not found"));
     }
 
     #[test]
-    fn test_rename_tag_not_found() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = rename_tag(&mut store, Scope::Project, "nonexistent", "new-name");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_rename_tag_to_existing() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "tag-a").unwrap();
-        create_tag(&mut store, Scope::Project, "tag-b").unwrap();
-
-        let result = rename_tag(&mut store, Scope::Project, "tag-a", "tag-b");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already exists"));
-    }
-
-    #[test]
-    fn test_rename_tag_invalid_new_name() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "valid").unwrap();
-
-        let result = rename_tag(&mut store, Scope::Project, "valid", "-invalid");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_rename_tag_updates_pads() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-
-        // Create a tag and a pad with that tag
-        create_tag(&mut store, Scope::Project, "old-tag").unwrap();
-        create::run(
+    fn rename_returns_both_names_and_update_count() {
+        let mut store = store();
+        create_tag(&mut store, Scope::Project, "old").unwrap();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        tagging::add_tags(
             &mut store,
             Scope::Project,
-            "Test Pad".into(),
-            "".into(),
-            None,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            &["old".into()],
         )
         .unwrap();
 
-        // Manually add tag to pad
-        let mut pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        pads[0].metadata.tags.push("old-tag".to_string());
-        store
-            .save_pad(&pads[0], Scope::Project, Bucket::Active)
-            .unwrap();
-
-        // Rename the tag
-        let result = rename_tag(&mut store, Scope::Project, "old-tag", "new-tag").unwrap();
-        assert!(result.messages[1].content.contains("Updated 1 pad"));
-
-        // Verify tag is updated in pad
-        let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        assert_eq!(pads[0].metadata.tags, vec!["new-tag"]);
+        assert_eq!(
+            rename_tag(&mut store, Scope::Project, "old", "new").unwrap(),
+            TagRegistryOutcome::Renamed {
+                old_name: "old".into(),
+                new_name: "new".into(),
+                affected_pads: 1,
+            }
+        );
+        assert_eq!(
+            store.list_pads(Scope::Project, Bucket::Active).unwrap()[0]
+                .metadata
+                .tags,
+            vec!["new"]
+        );
     }
 
     #[test]
-    fn test_list_pad_tags() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "work").unwrap();
-        create_tag(&mut store, Scope::Project, "rust").unwrap();
-        create::run(
-            &mut store,
-            Scope::Project,
-            "Test Pad".into(),
-            "".into(),
-            None,
-        )
-        .unwrap();
+    fn rename_preserves_validation_duplicate_and_not_found_errors() {
+        let mut store = store();
+        create_tag(&mut store, Scope::Project, "one").unwrap();
+        create_tag(&mut store, Scope::Project, "two").unwrap();
 
-        // Add tags to the pad
-        use crate::commands::tagging::add_tags;
-        use crate::index::{DisplayIndex, PadSelector};
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        add_tags(
+        assert!(rename_tag(&mut store, Scope::Project, "one", "-invalid").is_err());
+        assert!(rename_tag(&mut store, Scope::Project, "one", "two")
+            .unwrap_err()
+            .to_string()
+            .contains("already exists"));
+        assert!(rename_tag(&mut store, Scope::Project, "missing", "three")
+            .unwrap_err()
+            .to_string()
+            .contains("not found"));
+    }
+
+    #[test]
+    fn pad_catalog_is_unique_and_lexically_ordered() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        let selectors = [PadSelector::Path(vec![DisplayIndex::Regular(1)])];
+        tagging::add_tags(
             &mut store,
             Scope::Project,
             &selectors,
-            &["work".to_string(), "rust".to_string()],
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
-        let result = list_pad_tags(&store, Scope::Project, &selectors).unwrap();
-        // Output is just tag names, one per message, sorted
-        assert_eq!(result.messages.len(), 2);
-        assert_eq!(result.messages[0].content, "rust");
-        assert_eq!(result.messages[1].content, "work");
+        assert_eq!(
+            list_pad_tags(&store, Scope::Project, &selectors).unwrap(),
+            TagCatalogOutcome::Listed {
+                tags: vec!["rust".into(), "work".into()]
+            }
+        );
     }
 
     #[test]
-    fn test_list_pad_tags_no_tags() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create::run(
-            &mut store,
-            Scope::Project,
-            "Empty Pad".into(),
-            "".into(),
-            None,
-        )
-        .unwrap();
+    fn untagged_pad_has_an_explicit_empty_catalog() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        let selectors = [PadSelector::Path(vec![DisplayIndex::Regular(1)])];
 
-        use crate::index::{DisplayIndex, PadSelector};
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = list_pad_tags(&store, Scope::Project, &selectors).unwrap();
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].content, "No tags defined");
+        assert_eq!(
+            list_pad_tags(&store, Scope::Project, &selectors).unwrap(),
+            TagCatalogOutcome::Empty
+        );
     }
 }

--- a/crates/padzapp/src/commands/transfer.rs
+++ b/crates/padzapp/src/commands/transfer.rs
@@ -4,16 +4,17 @@
 //! 1. Resolve selectors against the source store to UUIDs.
 //! 2. Open a destination [`FileStore`] at the target path (smart-resolved to
 //!    `.padz/` via [`resolve_target_dir`]).
-//! 3. For each pad, read from source, apply metadata defensively to a fresh
-//!    `Pad` on the destination side, save. `parent_id`s that point outside
-//!    the move set are orphaned.
+//! 3. For each pad, read from source and save the same live [`Pad`] on the
+//!    destination side. `parent_id`s that point outside the move set are
+//!    orphaned.
 //! 4. Merge referenced tag registry entries into the destination (no
 //!    overwriting existing entries).
 //! 5. For migrate: delete each successfully copied pad from the source.
 //!
-//! The "content copy" is treated as the critical path: if it fails, we
-//! report the pad as failed and skip it. Metadata field failures are
-//! per-pad warnings — the file still lands.
+//! The report is presentation-free and retains every partial-success fact in
+//! pipeline order. Copy failures distinguish source reads from destination
+//! writes; destination enumeration, parent orphaning, tag-registry merging,
+//! and migrate cleanup remain independently observable.
 //!
 //! ## Path resolution
 //!
@@ -27,7 +28,6 @@
 //! This means `padz clone --to /tmp/work` works whether the user points at
 //! `/tmp/work`, `/tmp/work/.padz`, or a subdirectory of the project.
 
-use crate::commands::{CmdMessage, CmdResult};
 use crate::config::PadzConfig;
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayIndex, PadSelector};
@@ -37,6 +37,7 @@ use crate::store::fs::FileStore;
 use crate::store::{Bucket, DataStore};
 use crate::tags::TagEntry;
 use clapfig::{Clapfig, SearchMode, SearchPath};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -44,7 +45,8 @@ use uuid::Uuid;
 use super::helpers::{indexed_pads, resolve_selectors, TitleBucket};
 
 /// Whether the source keeps or loses the pads after a transfer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TransferMode {
     /// Clone: copy to destination, keep in source.
     Clone,
@@ -52,13 +54,86 @@ pub enum TransferMode {
     Migrate,
 }
 
-impl TransferMode {
-    fn verb(self) -> &'static str {
-        match self {
-            TransferMode::Clone => "Cloned",
-            TransferMode::Migrate => "Migrated",
-        }
-    }
+/// Whether the external peer is receiving pads or providing them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirection {
+    To,
+    From,
+}
+
+/// The selector request resolved against the source store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferSelection {
+    AllNonDeleted,
+    Explicit { selectors: Vec<String> },
+}
+
+/// Invocation facts that are independent of the two participating stores.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferRequest {
+    pub operation: TransferMode,
+    pub direction: TransferDirection,
+    pub peer_store: PathBuf,
+    pub requested_selection: TransferSelection,
+}
+
+/// Overall semantic state of a cross-store transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferStatus {
+    Empty,
+    FullSuccess,
+    PartialSuccess,
+    NoCopies,
+}
+
+/// The phase that prevented one requested pad from reaching the destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopyFailureCategory {
+    SourceRead,
+    DestinationWrite,
+}
+
+/// Ordered warning/failure facts produced by the transfer pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferDiagnostic {
+    DestinationBucketEnumerationFailed {
+        bucket: Bucket,
+        detail: String,
+    },
+    ParentOrphaned {
+        pad_id: Uuid,
+        parent_id: Uuid,
+    },
+    CopyFailed {
+        pad_id: Uuid,
+        category: CopyFailureCategory,
+        detail: String,
+    },
+    TagRegistryMergeFailed {
+        detail: String,
+    },
+    SourceDeleteFailed {
+        pad_id: Uuid,
+        detail: String,
+    },
+}
+
+/// Complete presentation-free result of clone/migrate across two stores.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferReport {
+    pub status: TransferStatus,
+    pub operation: TransferMode,
+    pub direction: TransferDirection,
+    pub peer_store: PathBuf,
+    pub requested_selection: TransferSelection,
+    pub copied_pad_ids: Vec<Uuid>,
+    pub copied_count: usize,
+    pub diagnostics: Vec<TransferDiagnostic>,
 }
 
 /// Resolve a user-supplied path into the `.padz/` directory at or above it.
@@ -159,19 +234,22 @@ pub fn open_target_store(padz_dir: &Path) -> Result<FileStore> {
 /// - `dest`: the store we write pads to
 /// - `dest_scope`: Project or Global on the dest side
 /// - `selectors`: pad selectors, resolved against the source
-/// - `summary_path`: human-readable destination location (used in the
-///   trailing success message; usually a path, can be anything)
-/// - `mode`: Clone (keep source) or Migrate (delete source on success)
+/// - `request`: operation, direction, resolved peer, and requested selection
 pub fn run<Src: DataStore, Dst: DataStore>(
     source: &mut Src,
     source_scope: Scope,
     dest: &mut Dst,
     dest_scope: Scope,
     selectors: &[PadSelector],
-    summary_path: &Path,
-    mode: TransferMode,
-) -> Result<CmdResult> {
-    let mut result = CmdResult::default();
+    request: TransferRequest,
+) -> Result<TransferReport> {
+    let TransferRequest {
+        operation,
+        direction,
+        peer_store,
+        requested_selection,
+    } = request;
+    let mut diagnostics = Vec::new();
 
     // 1. Resolve selectors on the source. Empty selectors mean "all non-
     //    deleted pads" (active + archived), matching `padz export`'s default
@@ -182,8 +260,16 @@ pub fn run<Src: DataStore, Dst: DataStore>(
         resolve_selectors(source, source_scope, selectors, false, TitleBucket::Any)?
     };
     if resolved.is_empty() {
-        result.add_message(CmdMessage::info("No pads to transfer."));
-        return Ok(result);
+        return Ok(TransferReport {
+            status: TransferStatus::Empty,
+            operation,
+            direction,
+            peer_store,
+            requested_selection,
+            copied_pad_ids: Vec::new(),
+            copied_count: 0,
+            diagnostics,
+        });
     }
 
     // 2. Build the move set. Pads whose parent lives outside the move set
@@ -192,11 +278,7 @@ pub fn run<Src: DataStore, Dst: DataStore>(
     //    silently swallowed — an incomplete `dest_ids` set can incorrectly
     //    orphan parent relationships.
     let move_set: HashSet<Uuid> = resolved.iter().map(|(_, uuid)| *uuid).collect();
-    let mut dest_ids_warnings = Vec::new();
-    let dest_ids = collect_all_ids(dest, dest_scope, &mut dest_ids_warnings);
-    for w in dest_ids_warnings {
-        result.add_message(w);
-    }
+    let dest_ids = collect_all_ids(dest, dest_scope, &mut diagnostics);
     let known_ids: HashSet<Uuid> = move_set.union(&dest_ids).copied().collect();
 
     // 3. Transfer pad-by-pad. `copy_one_pad` returns the source pad's tags so
@@ -206,23 +288,27 @@ pub fn run<Src: DataStore, Dst: DataStore>(
 
     for (_, id) in &resolved {
         match copy_one_pad(source, source_scope, dest, dest_scope, *id, &known_ids) {
-            Ok(CopyOutcome { mut warnings, tags }) => {
+            Ok(CopyOutcome {
+                orphaned_parent,
+                tags,
+            }) => {
                 copied.push(*id);
                 for t in tags {
                     referenced_tags.insert(t);
                 }
-                result.messages.append(&mut warnings);
+                if let Some(parent_id) = orphaned_parent {
+                    diagnostics.push(TransferDiagnostic::ParentOrphaned {
+                        pad_id: *id,
+                        parent_id,
+                    });
+                }
             }
-            Err(e) => {
-                result.add_message(CmdMessage::warning(format!(
-                    "Failed to {} pad {}: {}",
-                    match mode {
-                        TransferMode::Clone => "clone",
-                        TransferMode::Migrate => "migrate",
-                    },
-                    id,
-                    e
-                )));
+            Err(failure) => {
+                diagnostics.push(TransferDiagnostic::CopyFailed {
+                    pad_id: *id,
+                    category: failure.category,
+                    detail: failure.detail,
+                });
             }
         }
     }
@@ -231,46 +317,48 @@ pub fn run<Src: DataStore, Dst: DataStore>(
     if !copied.is_empty() {
         if let Err(e) = merge_tag_registry(source, source_scope, dest, dest_scope, &referenced_tags)
         {
-            result.add_message(CmdMessage::warning(format!(
-                "Tag registry merge failed: {}",
-                e
-            )));
+            diagnostics.push(TransferDiagnostic::TagRegistryMergeFailed {
+                detail: e.to_string(),
+            });
         }
     }
 
     // 5. For migrate: delete copies from source.
-    if mode == TransferMode::Migrate {
+    if operation == TransferMode::Migrate {
         for id in &copied {
             if let Err(e) = delete_from_source(source, source_scope, *id) {
-                result.add_message(CmdMessage::warning(format!(
-                    "Copied but failed to remove from source, pad {}: {}",
-                    id, e
-                )));
+                diagnostics.push(TransferDiagnostic::SourceDeleteFailed {
+                    pad_id: *id,
+                    detail: e.to_string(),
+                });
             }
         }
     }
 
-    if copied.is_empty() {
-        result.add_message(CmdMessage::warning(format!(
-            "No pads were {} to {}",
-            mode.verb().to_lowercase(),
-            summary_path.display()
-        )));
+    let status = if copied.is_empty() {
+        TransferStatus::NoCopies
+    } else if diagnostics.is_empty() {
+        TransferStatus::FullSuccess
     } else {
-        result.add_message(CmdMessage::success(format!(
-            "{} {} pad(s) to {}",
-            mode.verb(),
-            copied.len(),
-            summary_path.display()
-        )));
-    }
-    Ok(result)
+        TransferStatus::PartialSuccess
+    };
+    let copied_count = copied.len();
+    Ok(TransferReport {
+        status,
+        operation,
+        direction,
+        peer_store,
+        requested_selection,
+        copied_pad_ids: copied,
+        copied_count,
+        diagnostics,
+    })
 }
 
 fn collect_all_ids<S: DataStore>(
     store: &S,
     scope: Scope,
-    warnings: &mut Vec<CmdMessage>,
+    diagnostics: &mut Vec<TransferDiagnostic>,
 ) -> HashSet<Uuid> {
     let mut ids = HashSet::new();
     for bucket in [Bucket::Active, Bucket::Archived, Bucket::Deleted] {
@@ -281,11 +369,10 @@ fn collect_all_ids<S: DataStore>(
                 }
             }
             Err(e) => {
-                warnings.push(CmdMessage::warning(format!(
-                    "Could not enumerate destination bucket {:?}: {}. \
-Parent relationships that cross this bucket may be orphaned.",
-                    bucket, e
-                )));
+                diagnostics.push(TransferDiagnostic::DestinationBucketEnumerationFailed {
+                    bucket,
+                    detail: e.to_string(),
+                });
             }
         }
     }
@@ -313,12 +400,16 @@ fn default_non_deleted_ids<S: DataStore>(
     Ok(out)
 }
 
-/// Result of a successful per-pad copy: carries warnings from defensive
-/// metadata application plus the source pad's tags (so the caller can
-/// merge the tag registry without another source read).
+/// Result of a successful per-pad copy, retaining any removed parent plus the
+/// source pad's tags so the caller can merge the registry without another read.
 struct CopyOutcome {
-    warnings: Vec<CmdMessage>,
+    orphaned_parent: Option<Uuid>,
     tags: Vec<String>,
+}
+
+struct CopyFailure {
+    category: CopyFailureCategory,
+    detail: String,
 }
 
 /// Read a pad from whichever bucket it lives in on the source side. Returns
@@ -328,10 +419,18 @@ fn read_source_pad_any_bucket<S: DataStore>(
     scope: Scope,
     id: Uuid,
 ) -> Result<(Pad, Bucket)> {
+    let mut storage_failure = None;
     for bucket in [Bucket::Active, Bucket::Archived, Bucket::Deleted] {
-        if let Ok(pad) = source.get_pad(&id, scope, bucket) {
-            return Ok((pad, bucket));
+        match source.get_pad(&id, scope, bucket) {
+            Ok(pad) => return Ok((pad, bucket)),
+            Err(PadzError::PadNotFound(_)) => {}
+            Err(error) => {
+                storage_failure.get_or_insert(error);
+            }
         }
+    }
+    if let Some(error) = storage_failure {
+        return Err(error);
     }
     Err(PadzError::Api(format!(
         "Pad {} not found in any bucket",
@@ -361,25 +460,32 @@ fn copy_one_pad<Src: DataStore, Dst: DataStore>(
     dest_scope: Scope,
     id: Uuid,
     known_ids: &HashSet<Uuid>,
-) -> Result<CopyOutcome> {
-    let (mut pad, bucket) = read_source_pad_any_bucket(source, source_scope, id)?;
+) -> std::result::Result<CopyOutcome, CopyFailure> {
+    let (mut pad, bucket) =
+        read_source_pad_any_bucket(source, source_scope, id).map_err(|error| CopyFailure {
+            category: CopyFailureCategory::SourceRead,
+            detail: error.to_string(),
+        })?;
     let tags = pad.metadata.tags.clone();
 
-    let mut warnings = Vec::new();
+    let mut orphaned_parent = None;
     if let Some(pid) = pad.metadata.parent_id {
         if !known_ids.contains(&pid) {
             pad.metadata.parent_id = None;
-            warnings.push(CmdMessage::info(format!(
-                "Pad {}: parent not in move set, orphaned to root",
-                id
-            )));
+            orphaned_parent = Some(pid);
         }
     }
 
     dest.save_pad(&pad, dest_scope, bucket)
-        .map_err(|e| PadzError::Api(format!("Writing pad {} to destination failed: {}", id, e)))?;
+        .map_err(|error| CopyFailure {
+            category: CopyFailureCategory::DestinationWrite,
+            detail: format!("Writing pad {} to destination failed: {}", id, error),
+        })?;
 
-    Ok(CopyOutcome { warnings, tags })
+    Ok(CopyOutcome {
+        orphaned_parent,
+        tags,
+    })
 }
 
 fn delete_from_source<S: DataStore>(source: &mut S, scope: Scope, id: Uuid) -> Result<()> {
@@ -408,10 +514,9 @@ fn merge_tag_registry<Src: DataStore, Dst: DataStore>(
     if referenced.is_empty() {
         return Ok(());
     }
-    let source_tags = source.load_tags(source_scope).unwrap_or_default();
+    let source_tags = source.load_tags(source_scope)?;
     let existing: HashMap<String, TagEntry> = dest
-        .load_tags(dest_scope)
-        .unwrap_or_default()
+        .load_tags(dest_scope)?
         .into_iter()
         .map(|t| (t.name.clone(), t))
         .collect();
@@ -433,7 +538,7 @@ fn merge_tag_registry<Src: DataStore, Dst: DataStore>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::{create, MessageLevel};
+    use crate::commands::create;
     use crate::index::{DisplayIndex, PadSelector};
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
@@ -447,6 +552,125 @@ mod tests {
         )
     }
 
+    struct FaultStore {
+        inner: BucketedStore<MemBackend>,
+        fail_get: bool,
+        fail_list: Option<Bucket>,
+        fail_delete: bool,
+        fail_save_tags: bool,
+    }
+
+    impl FaultStore {
+        fn new() -> Self {
+            Self {
+                inner: store(),
+                fail_get: false,
+                fail_list: None,
+                fail_delete: false,
+                fail_save_tags: false,
+            }
+        }
+
+        fn fault(label: &str) -> PadzError {
+            PadzError::Store(format!("simulated {label} failure"))
+        }
+    }
+
+    impl DataStore for FaultStore {
+        fn save_pad(&mut self, pad: &Pad, scope: Scope, bucket: Bucket) -> Result<()> {
+            self.inner.save_pad(pad, scope, bucket)
+        }
+
+        fn get_pad(&self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<Pad> {
+            if self.fail_get {
+                Err(Self::fault("source read"))
+            } else {
+                self.inner.get_pad(id, scope, bucket)
+            }
+        }
+
+        fn list_pads(&self, scope: Scope, bucket: Bucket) -> Result<Vec<Pad>> {
+            if self.fail_list == Some(bucket) {
+                Err(Self::fault("bucket enumeration"))
+            } else {
+                self.inner.list_pads(scope, bucket)
+            }
+        }
+
+        fn delete_pad(&mut self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<()> {
+            if self.fail_delete {
+                Err(Self::fault("source delete"))
+            } else {
+                self.inner.delete_pad(id, scope, bucket)
+            }
+        }
+
+        fn move_pad(&mut self, id: &Uuid, scope: Scope, from: Bucket, to: Bucket) -> Result<Pad> {
+            self.inner.move_pad(id, scope, from, to)
+        }
+
+        fn move_pads(
+            &mut self,
+            ids: &[Uuid],
+            scope: Scope,
+            from: Bucket,
+            to: Bucket,
+        ) -> Result<Vec<Pad>> {
+            self.inner.move_pads(ids, scope, from, to)
+        }
+
+        fn get_pad_path(&self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<PathBuf> {
+            self.inner.get_pad_path(id, scope, bucket)
+        }
+
+        fn doctor(&mut self, scope: Scope) -> Result<crate::store::DoctorReport> {
+            self.inner.doctor(scope)
+        }
+
+        fn load_tags(&self, scope: Scope) -> Result<Vec<TagEntry>> {
+            self.inner.load_tags(scope)
+        }
+
+        fn save_tags(&mut self, scope: Scope, tags: &[TagEntry]) -> Result<()> {
+            if self.fail_save_tags {
+                Err(Self::fault("tag registry merge"))
+            } else {
+                self.inner.save_tags(scope, tags)
+            }
+        }
+    }
+
+    fn run_test<Src: DataStore, Dst: DataStore>(
+        source: &mut Src,
+        source_scope: Scope,
+        dest: &mut Dst,
+        dest_scope: Scope,
+        selectors: &[PadSelector],
+        peer_store: &Path,
+        mode: TransferMode,
+    ) -> Result<TransferReport> {
+        let requested_selection = if selectors.is_empty() {
+            TransferSelection::AllNonDeleted
+        } else {
+            TransferSelection::Explicit {
+                selectors: selectors.iter().map(ToString::to_string).collect(),
+            }
+        };
+        super::run(
+            source,
+            source_scope,
+            dest,
+            dest_scope,
+            selectors,
+            TransferRequest {
+                operation: mode,
+                direction: TransferDirection::To,
+                peer_store: peer_store.to_path_buf(),
+                requested_selection,
+            },
+        )
+    }
+
     /// For unit tests we need a destination store that is `&mut dyn DataStore`.
     /// The production `run` takes a `FileStore` directly, so test the inner
     /// pipeline (copy_one_pad + delete_from_source) using two in-memory stores.
@@ -457,7 +681,8 @@ mod tests {
         id: Uuid,
         known: &HashSet<Uuid>,
     ) -> Result<()> {
-        copy_one_pad(src, scope, dst, Scope::Project, id, known)?;
+        copy_one_pad(src, scope, dst, Scope::Project, id, known)
+            .map_err(|failure| PadzError::Api(failure.detail))?;
         Ok(())
     }
 
@@ -604,21 +829,14 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_mode_verb() {
-        // Direct check on the only entry point that uses verb().
-        assert_eq!(TransferMode::Clone.verb(), "Cloned");
-        assert_eq!(TransferMode::Migrate.verb(), "Migrated");
-    }
-
-    #[test]
-    fn test_run_no_pads_returns_info_message() {
+    fn test_run_no_pads_returns_explicit_empty_report() {
         // Empty source + explicit selectors that can't resolve to anything.
         let mut src = store();
         let mut dst = store();
         // An empty source with empty selectors triggers the "no pads" branch
         // through `default_non_deleted_ids` (which returns an empty Vec).
         let summary = std::path::PathBuf::from("/tmp/nowhere");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -629,14 +847,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("No pads to transfer")),
-            "expected info message about no pads; got {:?}",
-            result.messages
-        );
+        assert_eq!(result.status, TransferStatus::Empty);
+        assert_eq!(result.operation, TransferMode::Clone);
+        assert_eq!(result.direction, TransferDirection::To);
+        assert_eq!(result.peer_store, summary);
+        assert_eq!(result.requested_selection, TransferSelection::AllNonDeleted);
+        assert!(result.copied_pad_ids.is_empty());
+        assert_eq!(result.copied_count, 0);
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -647,7 +865,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -658,13 +876,10 @@ mod tests {
         )
         .unwrap();
 
-        let success_message = result
-            .messages
-            .iter()
-            .find(|m| matches!(m.level, MessageLevel::Success))
-            .expect("clone should emit a success message");
-        assert!(success_message.content.contains("Cloned 2 pad(s)"));
-        assert!(success_message.content.contains("/tmp/dest"));
+        assert_eq!(result.status, TransferStatus::FullSuccess);
+        assert_eq!(result.copied_count, 2);
+        assert_eq!(result.copied_pad_ids.len(), 2);
+        assert!(result.diagnostics.is_empty());
 
         // Both pads on destination, both still on source.
         assert_eq!(
@@ -684,7 +899,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -695,14 +910,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("Migrated 1 pad(s)")),
-            "expected Migrated success message; got {:?}",
-            result.messages
-        );
+        assert_eq!(result.status, TransferStatus::FullSuccess);
+        assert_eq!(result.operation, TransferMode::Migrate);
+        assert_eq!(result.copied_count, 1);
 
         // Migrate clears the source.
         assert!(src
@@ -747,7 +957,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        run(
+        run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -784,7 +994,7 @@ mod tests {
         // The newest pad gets index 1 (which is "Second"). Asking for "1"
         // should clone exactly one pad: the most recently created.
         let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -795,10 +1005,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Cloned 1 pad(s)")));
+        assert_eq!(result.status, TransferStatus::FullSuccess);
+        assert_eq!(
+            result.requested_selection,
+            TransferSelection::Explicit {
+                selectors: vec!["1".to_string()]
+            }
+        );
+        assert_eq!(result.copied_count, 1);
         let dst_pads = dst.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(dst_pads.len(), 1);
         assert_eq!(dst_pads[0].metadata.title, "Second");
@@ -824,7 +1038,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        run(
+        run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -870,7 +1084,7 @@ mod tests {
         let mut dst = BucketedStore::new(dst_active, dst_archived, dst_deleted, dst_tags);
 
         let summary = std::path::PathBuf::from("/tmp/dest");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -881,25 +1095,214 @@ mod tests {
         )
         .unwrap();
 
-        // Per-pad warning naming the failed action.
-        assert!(
-            result.messages.iter().any(|m| {
-                matches!(m.level, MessageLevel::Warning)
-                    && m.content.contains("Failed to clone pad")
-            }),
-            "expected per-pad clone failure warning; got {:?}",
-            result.messages
-        );
+        assert_eq!(result.status, TransferStatus::NoCopies);
+        assert!(result.copied_pad_ids.is_empty());
+        assert!(matches!(
+            result.diagnostics.as_slice(),
+            [TransferDiagnostic::CopyFailed {
+                category: CopyFailureCategory::DestinationWrite,
+                detail,
+                ..
+            }] if detail.contains("Writing pad") && detail.contains("Simulated write error")
+        ));
+    }
 
-        // And the trailing "no pads were cloned" message.
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("No pads were cloned")),
-            "expected 'No pads were cloned' trailer; got {:?}",
-            result.messages
+    #[test]
+    fn test_run_reports_source_read_failure_category() {
+        let mut src = FaultStore::new();
+        create::run(
+            &mut src,
+            Scope::Project,
+            "Unreadable".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        src.fail_get = true;
+        let mut dst = store();
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::NoCopies);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::CopyFailed {
+                category: CopyFailureCategory::SourceRead,
+                detail,
+                ..
+            }] if detail.contains("simulated source read failure")
+        ));
+    }
+
+    #[test]
+    fn test_run_reports_parent_orphaning_as_partial_success() {
+        let mut src = store();
+        create::run(&mut src, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut src,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        let pads = src.list_pads(Scope::Project, Bucket::Active).unwrap();
+        let parent = pads
+            .iter()
+            .find(|pad| pad.metadata.title == "Parent")
+            .unwrap();
+        let child = pads
+            .iter()
+            .find(|pad| pad.metadata.title == "Child")
+            .unwrap();
+        let parent_id = parent.metadata.id;
+        let child_id = child.metadata.id;
+        let selectors = vec![PadSelector::Path(vec![
+            DisplayIndex::Regular(1),
+            DisplayIndex::Regular(1),
+        ])];
+        let mut dst = store();
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &selectors,
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_pad_ids, vec![child_id]);
+        assert_eq!(
+            report.diagnostics,
+            vec![TransferDiagnostic::ParentOrphaned {
+                pad_id: child_id,
+                parent_id,
+            }]
         );
+        assert_eq!(
+            dst.get_pad(&child_id, Scope::Project, Bucket::Active)
+                .unwrap()
+                .metadata
+                .parent_id,
+            None
+        );
+    }
+
+    #[test]
+    fn test_run_reports_destination_bucket_enumeration_failure() {
+        let mut src = store();
+        create::run(&mut src, Scope::Project, "Alpha".into(), "".into(), None).unwrap();
+        let mut dst = FaultStore::new();
+        dst.fail_list = Some(Bucket::Archived);
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_count, 1);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::DestinationBucketEnumerationFailed {
+                bucket: Bucket::Archived,
+                detail,
+            }] if detail.contains("simulated bucket enumeration failure")
+        ));
+    }
+
+    #[test]
+    fn test_run_reports_tag_registry_merge_failure_without_losing_copy() {
+        let mut src = store();
+        create::run(&mut src, Scope::Project, "Tagged".into(), "".into(), None).unwrap();
+        let mut pad = src
+            .list_pads(Scope::Project, Bucket::Active)
+            .unwrap()
+            .remove(0);
+        pad.metadata.tags = vec!["work".into()];
+        src.save_pad(&pad, Scope::Project, Bucket::Active).unwrap();
+        src.save_tags(Scope::Project, &[TagEntry::new("work".into())])
+            .unwrap();
+        let mut dst = FaultStore::new();
+        dst.fail_save_tags = true;
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_pad_ids, vec![pad.metadata.id]);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::TagRegistryMergeFailed { detail }]
+                if detail.contains("simulated tag registry merge failure")
+        ));
+        assert!(dst
+            .get_pad(&pad.metadata.id, Scope::Project, Bucket::Active)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_migrate_delete_failure_is_partial_and_keeps_both_copies() {
+        let mut src = FaultStore::new();
+        create::run(&mut src, Scope::Project, "Stuck".into(), "".into(), None).unwrap();
+        let id = src.list_pads(Scope::Project, Bucket::Active).unwrap()[0]
+            .metadata
+            .id;
+        src.fail_delete = true;
+        let mut dst = store();
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Migrate,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_pad_ids, vec![id]);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::SourceDeleteFailed { pad_id, detail }]
+                if *pad_id == id && detail.contains("simulated source delete failure")
+        ));
+        assert!(src.get_pad(&id, Scope::Project, Bucket::Active).is_ok());
+        assert!(dst.get_pad(&id, Scope::Project, Bucket::Active).is_ok());
     }
 
     #[test]
@@ -928,7 +1331,7 @@ mod tests {
         dst.save_tags(Scope::Project, &[dst_tag.clone()]).unwrap();
 
         let summary = std::path::PathBuf::from("/tmp/dest");
-        run(
+        run_test(
             &mut src,
             Scope::Project,
             &mut dst,

--- a/crates/padzapp/src/commands/update.rs
+++ b/crates/padzapp/src/commands/update.rs
@@ -1,4 +1,10 @@
-use crate::commands::{CmdMessage, CmdResult, PadUpdate};
+//! Semantic pad updates.
+//!
+//! Both typed-field and raw-content updates return the affected pads plus an
+//! [`CmdOutcome`](crate::commands::CmdOutcome) for each update. Human wording is
+//! deliberately left to clients.
+
+use crate::commands::{CmdOutcome, CmdResult, PadUpdate, UpdateKind};
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayPad, PadSelector};
 use crate::model::{parse_pad_content, Scope};
@@ -50,12 +56,11 @@ pub fn run<S: DataStore>(store: &mut S, scope: Scope, updates: &[PadUpdate]) -> 
         // edit still surfaces the parent under `ordering = updated_at`.
         crate::todos::propagate_status_change(store, scope, parent_id)?;
 
-        // Fix: Use display_index directly as it's already formatted for display
-        result.add_message(CmdMessage::success(format!(
-            "Pad updated ({}): {}",
-            super::helpers::fmt_path(&display_index),
-            pad.metadata.title
-        )));
+        result.outcomes.push(CmdOutcome::Updated {
+            path: display_index.clone(),
+            title: pad.metadata.title.clone(),
+            update_kind: UpdateKind::Structured,
+        });
         // Index doesn't change after update (use the last segment of the path)
         let local_index = display_index
             .last()
@@ -110,11 +115,11 @@ pub fn run_from_content<S: DataStore>(
         // edit still surfaces the parent under `ordering = updated_at`.
         crate::todos::propagate_status_change(store, scope, parent_id)?;
 
-        result.add_message(CmdMessage::success(format!(
-            "Updated ({}): {}",
-            super::helpers::fmt_path(&display_index),
-            pad.metadata.title
-        )));
+        result.outcomes.push(CmdOutcome::Updated {
+            path: display_index.clone(),
+            title: pad.metadata.title.clone(),
+            update_kind: UpdateKind::Content,
+        });
 
         let local_index = display_index
             .last()
@@ -245,10 +250,25 @@ mod tests {
 
         let res = run(&mut store, Scope::Project, &updates).unwrap();
 
-        // Check results
-        assert_eq!(res.messages.len(), 2);
-        assert!(res.messages.iter().any(|m| m.content.contains("A Updated")));
-        assert!(res.messages.iter().any(|m| m.content.contains("B Updated")));
+        // Check semantic results without parsing presentation prose.
+        assert!(res.messages.is_empty());
+        assert_eq!(res.outcomes.len(), 2);
+        assert!(res.outcomes.iter().any(|outcome| matches!(
+            outcome,
+            CmdOutcome::Updated {
+                title,
+                update_kind: UpdateKind::Structured,
+                ..
+            } if title == "A Updated"
+        )));
+        assert!(res.outcomes.iter().any(|outcome| matches!(
+            outcome,
+            CmdOutcome::Updated {
+                title,
+                update_kind: UpdateKind::Structured,
+                ..
+            } if title == "B Updated"
+        )));
 
         // Check store state
         let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[])
@@ -356,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn update_success_message_format() {
+    fn update_returns_semantic_kind_path_and_title() {
         let mut store = BucketedStore::new(
             MemBackend::new(),
             MemBackend::new(),
@@ -372,10 +392,15 @@ mod tests {
         );
         let result = run(&mut store, Scope::Project, &[update]).unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("Pad updated"));
-        assert!(result.messages[0].content.contains("1")); // index
-        assert!(result.messages[0].content.contains("Updated Title"));
+        assert!(result.messages.is_empty());
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::Updated {
+                path: vec![DisplayIndex::Regular(1)],
+                title: "Updated Title".to_string(),
+                update_kind: UpdateKind::Structured,
+            }]
+        );
     }
 
     #[test]
@@ -508,6 +533,51 @@ mod tests {
         assert_eq!(
             result.affected_pads[0].pad.content,
             "New Title From Pipe\n\nNew body content from piped input."
+        );
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::Updated {
+                path: vec![DisplayIndex::Regular(1)],
+                title: "New Title From Pipe".to_string(),
+                update_kind: UpdateKind::Content,
+            }]
+        );
+    }
+
+    #[test]
+    fn run_from_content_reports_a_nested_canonical_path() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let path = vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)];
+        let result = run_from_content(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(path.clone())],
+            "Edited child",
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::Updated {
+                path,
+                title: "Edited child".to_string(),
+                update_kind: UpdateKind::Content,
+            }]
         );
     }
 

--- a/crates/padzapp/src/commands/uuid.rs
+++ b/crates/padzapp/src/commands/uuid.rs
@@ -1,22 +1,21 @@
-use crate::commands::CmdResult;
+//! Resolve pad selectors to their durable UUIDs.
+//!
+//! Selector parsing and canonical display ordering remain application concerns;
+//! presentation clients decide how to render or serialize the resolved values.
+
 use crate::error::Result;
 use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
+use uuid::Uuid;
 
 use super::helpers::{resolve_selectors, TitleBucket};
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+/// Return the selected UUIDs in selector order, expanding ranges in canonical
+/// display order.
+pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<Vec<Uuid>> {
     let resolved = resolve_selectors(store, scope, selectors, false, TitleBucket::Active)?;
-    let mut result = CmdResult::default();
-
-    for (_, uuid) in resolved {
-        result
-            .messages
-            .push(super::CmdMessage::info(uuid.to_string()));
-    }
-
-    Ok(result)
+    Ok(resolved.into_iter().map(|(_, uuid)| uuid).collect())
 }
 
 #[cfg(test)]
@@ -47,8 +46,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].content, expected_uuid.to_string());
+        assert_eq!(result, vec![expected_uuid]);
     }
 
     #[test]
@@ -59,20 +57,30 @@ mod tests {
             MemBackend::new(),
             MemBackend::new(),
         );
-        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
-        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
+        let first = create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let second = create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
 
         let result = run(
             &store,
             Scope::Project,
             &[
-                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
                 PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
             ],
         )
         .unwrap();
 
-        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result, vec![first, second]);
     }
 
     #[test]
@@ -83,9 +91,24 @@ mod tests {
             MemBackend::new(),
             MemBackend::new(),
         );
-        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
-        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
-        create::run(&mut store, Scope::Project, "Pad C".into(), "".into(), None).unwrap();
+        let first = create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let second = create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let third = create::run(&mut store, Scope::Project, "Pad C".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
 
         let result = run(
             &store,
@@ -97,6 +120,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.messages.len(), 3);
+        assert_eq!(result, vec![third, second, first]);
     }
 }

--- a/crates/padzapp/src/lib.rs
+++ b/crates/padzapp/src/lib.rs
@@ -29,7 +29,7 @@
 //! │  API Layer (api.rs)                                         │
 //! │  - Thin facade over commands                                │
 //! │  - Normalizes inputs (indexes → UUIDs)                      │
-//! │  - Returns structured Result<CmdResult>                     │
+//! │  - Returns structured results and semantic outcomes         │
 //! └─────────────────────────────────────────────────────────────┘
 //!                              │
 //!                              ▼
@@ -52,7 +52,7 @@
 //!
 //! From `api.rs` inward, code:
 //! - Takes regular Rust function arguments
-//! - Returns regular Rust types (`Result<CmdResult>`)
+//! - Returns regular Rust types (`Result<CmdResult>` or dedicated outcomes)
 //! - **Never** writes to stdout/stderr
 //! - **Never** calls `std::process::exit`
 //! - **Never** assumes a terminal environment
@@ -70,8 +70,8 @@
 //! 1. **CLI**: `clap` parses `1`. `handle_delete` receives `vec!["1"]`.
 //! 2. **API**: `parse_selectors` maps `"1"` → `PadSelector::Index(Regular(1))`.
 //! 3. **Command**: Resolves to UUID, checks protection, marks as deleted.
-//! 4. **Return**: `CmdResult` with message "Deleted 1 pad".
-//! 5. **CLI**: Renders the message to terminal.
+//! 4. **Return**: A structured result containing the affected pad.
+//! 5. **CLI**: Renders compatible human feedback or serializes the facts.
 //!
 //! ## Testing Strategy
 //!


### PR DESCRIPTION
## Context

closes #208

STD02 now ships the coherent semantic-ownership increment approved during execution: every remaining command-family result in #213-#219 is typed at its owning layer, projected through CLI-owned DTOs, and rendered by MiniJinja without moving shell concerns into `padzapp`.

The Standout dependency baseline was verified before implementation and again during workstreams: Padz already pins the complete coherent family to the newest tagged release, `v7.9.0`, matching refreshed `arthur-debert/standout` `origin/main`; no empty dependency-only change was created.

## Integrated workstreams

- [x] STD02-WS01 / #213 — semantic initialization and maintenance outcomes (#224)
- [x] STD02-WS02 / #214 — semantic pad mutation outcomes (#226)
- [x] STD02-WS03 / #215 — semantic tag outcomes (#227)
- [x] STD02-WS04 / #216 — semantic import outcomes (#228)
- [x] STD02-WS05 / #217 — semantic cross-store transfer outcomes (#229)
- [x] STD02-WS06 / #218 — typed UUID selections (#230)
- [x] STD02-WS07 / #219 — semantic CLI copy and empty-input outcomes (#231)

Each workstream was implemented on the evolving epic baseline, tested, independently reviewed, shepherded to READY, and coordinator-merged into this branch.

## Intentional follow-up

The test-pyramid/audit tail is intentionally split into a separate incremental epic after this PR merges:

- #220 — direct format behavior at smaller seams
- #221 — structured-output breadth in TestHarness
- #222 — final presentation-prose audit
- #223 — final process-only smoke suite

This cut is coherent: #213-#219 complete the semantic-result migration; #220-#223 form the test-suite migration and closing audit. The follow-up epic code is `STD03` as assigned by the user, pending post-merge creation.

## Compatibility

Commands, aliases, arguments, input precedence, selectors, hierarchy, storage, export formats, clipboard payloads, and established human output are preserved. Intentional structured-schema migrations replace prose-only messages with documented, fixture-pinned facts. Recoverable warnings and partial-success diagnostics remain observable.

## Integration policy

This umbrella remains draft until integrated verification, review, and Shipit gates are complete. It will stop at READY for the required human merge.