### PR TITLE
STD02-WS02: Epic: Complete Remaining Standout Ownership Work - Workstream: Semantic Pad Mutation Outcomes

### DIFF
--- a/CHANGELOG/unreleased-semantic-pad-mutation-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-pad-mutation-outcomes.md
@@ -1,0 +1,9 @@
+- Pad updates now expose an `outcomes` array with an `updated` kind, canonical
+  display path, title, and `structured`/`content`/`refresh` update kind. Repeated
+  complete/reopen requests, same-parent moves, and empty `delete --completed`
+  requests now expose typed `notices` instead of prose-only `messages`; mixed
+  status requests expose `status_changed` outcomes alongside the paths and
+  requested statuses that were no-ops. This intentionally extends the structured
+  modification schema and removes the migrated English messages. Human wording,
+  status display, and semantic `info`/`success` styling remain unchanged and are
+  rendered by `modification_result.jinja`.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -18,7 +18,7 @@ use crate::cli::clipboard::{copy_to_clipboard, format_for_clipboard};
 use crate::cli::errors::to_anyhow;
 use crate::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
-use padzapp::commands::{CmdResult, NestingMode};
+use padzapp::commands::{CmdOutcome, CmdResult, NestingMode, UpdateKind};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
 use padzapp::model::{extract_title_and_body, Scope};
@@ -163,7 +163,8 @@ impl<'a> ScopedApi<'a> {
             action: action.to_string(),
             pads: result.affected_pads,
             messages: result.messages,
-            notices: result.notices,
+            notices: result.notices.into_iter().map(Into::into).collect(),
+            outcomes: result.outcomes.into_iter().map(Into::into).collect(),
             request: ModificationRequest {
                 status: self.state.wants_status(force_show_status),
             },
@@ -202,14 +203,7 @@ impl<'a> ScopedApi<'a> {
     }
 
     pub fn delete_completed_pads(&self) -> Result<Output<ModificationResult>, anyhow::Error> {
-        let mut result = self.call(|api, scope| api.delete_completed_pads(scope))?;
-
-        if result.affected_pads.is_empty() {
-            result
-                .messages
-                .push(CmdMessage::info("No completed pads to delete."));
-        }
-
+        let result = self.call(|api, scope| api.delete_completed_pads(scope))?;
         self.modification("Deleted", result, false)
     }
 
@@ -774,6 +768,7 @@ fn aborted_create() -> ModificationResult {
         pads: Vec::new(),
         messages: vec![CmdMessage::warning("Aborted: empty content")],
         notices: Vec::new(),
+        outcomes: Vec::new(),
         request: ModificationRequest::default(),
     }
 }
@@ -989,6 +984,10 @@ pub fn edit(
         .ok_or_else(|| anyhow::anyhow!("No pad found"))?;
     let pad_id = pad.pad.metadata.id;
     let display_index = pad.index.clone();
+    let display_path = state.with_api(|api| {
+        api.display_path_by_id(state.scope, pad_id)
+            .map_err(to_anyhow)
+    })?;
 
     let pad_path =
         state.with_api(|api| api.get_path_by_id(state.scope, pad_id).map_err(to_anyhow))?;
@@ -1000,6 +999,7 @@ pub fn edit(
     match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
         Some(pad) => {
             copy_content_to_clipboard(&pad.content);
+            let title = pad.metadata.title.clone();
 
             let display_pad = padzapp::index::DisplayPad {
                 pad,
@@ -1009,6 +1009,11 @@ pub fn edit(
             };
             let result = CmdResult {
                 affected_pads: vec![display_pad],
+                outcomes: vec![CmdOutcome::Updated {
+                    path: display_path,
+                    title,
+                    update_kind: UpdateKind::Refresh,
+                }],
                 ..Default::default()
             };
             Ok(Output::Render(
@@ -1631,15 +1636,18 @@ mod tests {
     }
 
     #[test]
-    fn delete_completed_with_nothing_to_delete_reports_a_message() {
+    fn delete_completed_with_nothing_to_delete_reports_a_semantic_no_op() {
         let app = TestApp::new(PadzMode::Todos);
         app.seed("Still open", "body");
 
         let result = rendered(delete(&app.ctx, vec![], true).unwrap());
 
         assert!(result.pads.is_empty());
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("No completed pads"));
+        assert!(result.messages.is_empty());
+        assert_eq!(
+            result.notices,
+            vec![super::super::result::ModificationNoticeResult::NoCompletedPads]
+        );
     }
 
     // --- path / uuid ----------------------------------------------------------

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -45,12 +45,14 @@
 //!
 //! Everything a template can decide, a template decides.
 
-use super::result::{ModificationResult, PadListResult};
+use super::result::{
+    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
+    PadListResult, UpdateKindResult,
+};
 use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
 use minijinja::Value;
 use padzapp::api::CmdMessage;
-use padzapp::commands::CmdNotice;
 use padzapp::index::{DisplayIndex, DisplayPad, SearchMatch};
 use padzapp::model::TodoStatus;
 use padzapp::peek::{format_as_peek, PeekResult};
@@ -218,6 +220,8 @@ pub struct ModificationView {
     pub messages: Vec<CmdMessage>,
     /// Presentation-ready projections of semantic core notices.
     pub notices: Vec<ModificationNoticeView>,
+    /// Presentation-ready projections of semantic successful outcomes.
+    pub outcomes: Vec<MutationOutcomeView>,
 }
 
 /// The small amount of display shaping a semantic modification notice needs.
@@ -225,6 +229,16 @@ pub struct ModificationView {
 pub struct ModificationNoticeView {
     pub kind: &'static str,
     pub index: String,
+    pub status: &'static str,
+}
+
+/// The small amount of display shaping a semantic update outcome needs.
+#[derive(Debug, Clone, Serialize)]
+pub struct MutationOutcomeView {
+    pub kind: &'static str,
+    pub index: String,
+    pub title: String,
+    pub update_kind: &'static str,
 }
 
 // =============================================================================
@@ -306,13 +320,37 @@ pub fn build_modification_view(result: &ModificationResult) -> ModificationView 
         show_status: result.request.status,
         messages: result.messages.clone(),
         notices: result.notices.iter().map(modification_notice).collect(),
+        outcomes: result
+            .outcomes
+            .iter()
+            .filter_map(mutation_outcome)
+            .collect(),
     }
 }
 
-fn modification_notice(notice: &CmdNotice) -> ModificationNoticeView {
-    let (kind, path) = match notice {
-        CmdNotice::AlreadyPinned { path } => ("already_pinned", path),
-        CmdNotice::AlreadyUnpinned { path } => ("already_unpinned", path),
+fn modification_notice(notice: &ModificationNoticeResult) -> ModificationNoticeView {
+    let (kind, path, status) = match notice {
+        ModificationNoticeResult::AlreadyPinned { path } => ("already_pinned", path, ""),
+        ModificationNoticeResult::AlreadyUnpinned { path } => ("already_unpinned", path, ""),
+        ModificationNoticeResult::AlreadyAtDestination { path } => {
+            ("already_at_destination", path, "")
+        }
+        ModificationNoticeResult::AlreadyInStatus { path, status } => (
+            "already_in_status",
+            path,
+            match status {
+                MutationStatusResult::Planned => "planned",
+                MutationStatusResult::InProgress => "in progress",
+                MutationStatusResult::Done => "done",
+            },
+        ),
+        ModificationNoticeResult::NoCompletedPads => {
+            return ModificationNoticeView {
+                kind: "no_completed_pads",
+                index: String::new(),
+                status: "",
+            };
+        }
     };
     ModificationNoticeView {
         kind,
@@ -321,6 +359,31 @@ fn modification_notice(notice: &CmdNotice) -> ModificationNoticeView {
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join("."),
+        status,
+    }
+}
+
+fn mutation_outcome(outcome: &MutationOutcomeResult) -> Option<MutationOutcomeView> {
+    match outcome {
+        MutationOutcomeResult::Updated {
+            path,
+            title,
+            update_kind,
+        } => Some(MutationOutcomeView {
+            kind: "updated",
+            index: path
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("."),
+            title: title.clone(),
+            update_kind: match update_kind {
+                UpdateKindResult::Structured => "structured",
+                UpdateKindResult::Content => "content",
+                UpdateKindResult::Refresh => "refresh",
+            },
+        }),
+        MutationOutcomeResult::StatusChanged { .. } => None,
     }
 }
 
@@ -617,6 +680,7 @@ mod tests {
             )],
             messages: vec![],
             notices: vec![],
+            outcomes: vec![],
             request: ModificationRequest { status: true },
         };
         let view = build_modification_view(&result);

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -27,8 +27,9 @@
 //! it is part of the result and visible in structured output.
 
 use padzapp::api::CmdMessage;
-use padzapp::commands::{CmdNotice, NestingMode};
-use padzapp::index::DisplayPad;
+use padzapp::commands::{CmdNotice, CmdOutcome, NestingMode, UpdateKind};
+use padzapp::index::{DisplayIndex, DisplayPad};
+use padzapp::model::TodoStatus;
 use serde::{Deserialize, Serialize};
 
 /// What the user asked a listing to show.
@@ -83,8 +84,122 @@ pub struct ModificationResult {
     pub messages: Vec<CmdMessage>,
     /// Machine-readable facts emitted by the core; templates own their prose.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub notices: Vec<CmdNotice>,
+    pub notices: Vec<ModificationNoticeResult>,
+    /// Machine-readable successful outcomes emitted by the core.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outcomes: Vec<MutationOutcomeResult>,
     pub request: ModificationRequest,
+}
+
+/// CLI projection of a semantic mutation no-op.
+///
+/// This keeps the shell's structured schema independent from the core enum while
+/// retaining the `kind` and canonical display-path shape established for pinning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModificationNoticeResult {
+    AlreadyPinned {
+        path: Vec<DisplayIndex>,
+    },
+    AlreadyUnpinned {
+        path: Vec<DisplayIndex>,
+    },
+    AlreadyAtDestination {
+        path: Vec<DisplayIndex>,
+    },
+    AlreadyInStatus {
+        path: Vec<DisplayIndex>,
+        status: MutationStatusResult,
+    },
+    NoCompletedPads,
+}
+
+impl From<CmdNotice> for ModificationNoticeResult {
+    fn from(notice: CmdNotice) -> Self {
+        match notice {
+            CmdNotice::AlreadyPinned { path } => Self::AlreadyPinned { path },
+            CmdNotice::AlreadyUnpinned { path } => Self::AlreadyUnpinned { path },
+            CmdNotice::AlreadyAtDestination { path } => Self::AlreadyAtDestination { path },
+            CmdNotice::AlreadyInStatus { path, status } => Self::AlreadyInStatus {
+                path,
+                status: status.into(),
+            },
+            CmdNotice::NoCompletedPads => Self::NoCompletedPads,
+        }
+    }
+}
+
+/// Requested status exposed by a semantic no-op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationStatusResult {
+    Planned,
+    InProgress,
+    Done,
+}
+
+impl From<TodoStatus> for MutationStatusResult {
+    fn from(status: TodoStatus) -> Self {
+        match status {
+            TodoStatus::Planned => Self::Planned,
+            TodoStatus::InProgress => Self::InProgress,
+            TodoStatus::Done => Self::Done,
+        }
+    }
+}
+
+/// CLI projection of a successful semantic pad mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MutationOutcomeResult {
+    Updated {
+        path: Vec<DisplayIndex>,
+        title: String,
+        update_kind: UpdateKindResult,
+    },
+    StatusChanged {
+        path: Vec<DisplayIndex>,
+        status: MutationStatusResult,
+    },
+}
+
+impl From<CmdOutcome> for MutationOutcomeResult {
+    fn from(outcome: CmdOutcome) -> Self {
+        match outcome {
+            CmdOutcome::Updated {
+                path,
+                title,
+                update_kind,
+            } => Self::Updated {
+                path,
+                title,
+                update_kind: update_kind.into(),
+            },
+            CmdOutcome::StatusChanged { path, status } => Self::StatusChanged {
+                path,
+                status: status.into(),
+            },
+        }
+    }
+}
+
+/// How an update reached the core, as part of the shell's public result schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateKindResult {
+    Structured,
+    Content,
+    Refresh,
+}
+
+impl From<UpdateKind> for UpdateKindResult {
+    fn from(kind: UpdateKind) -> Self {
+        match kind {
+            UpdateKind::Structured => Self::Structured,
+            UpdateKind::Content => Self::Content,
+            UpdateKind::Refresh => Self::Refresh,
+        }
+    }
 }
 
 /// A command whose whole result is user-facing messages.

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -19,11 +19,27 @@
 {{ msg.content | style_as(msg.level) }}{{ "" | nl }}
 {%- endfor -%}
 
+{#- Semantic successful outcomes: wording stays here; refresh updates deliberately -#}
+{#- add no extra line, preserving the interactive editor's established output. -#}
+{%- for outcome in view.outcomes -%}
+{%- if outcome.kind == "updated" and outcome.update_kind == "structured" -%}
+[success]Pad updated ({{ outcome.index }}): {{ outcome.title }}[/success]{{ "" | nl }}
+{%- elif outcome.kind == "updated" and outcome.update_kind == "content" -%}
+[success]Updated ({{ outcome.index }}): {{ outcome.title }}[/success]{{ "" | nl }}
+{%- endif -%}
+{%- endfor -%}
+
 {#- Semantic notices: wording stays here; structured modes receive kind + fields. -#}
 {%- for notice in view.notices -%}
 {%- if notice.kind == "already_pinned" -%}
 [info]Pad {{ notice.index }} is already pinned[/info]{{ "" | nl }}
 {%- elif notice.kind == "already_unpinned" -%}
 [info]Pad {{ notice.index }} is already unpinned[/info]{{ "" | nl }}
+{%- elif notice.kind == "already_at_destination" -%}
+[info]Pad '{{ notice.index }}' is already at destination[/info]{{ "" | nl }}
+{%- elif notice.kind == "already_in_status" -%}
+[info]Pad {{ notice.index }} is already {{ notice.status }}[/info]{{ "" | nl }}
+{%- elif notice.kind == "no_completed_pads" -%}
+[info]No completed pads to delete.[/info]{{ "" | nl }}
 {%- endif -%}
 {%- endfor -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/complete-mixed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/complete-mixed.json
@@ -1,0 +1,16 @@
+{
+  "notices": [
+    {
+      "kind": "already_in_status",
+      "path": [{ "type": "Regular", "value": 1 }],
+      "status": "done"
+    }
+  ],
+  "outcomes": [
+    {
+      "kind": "status_changed",
+      "path": [{ "type": "Regular", "value": 2 }],
+      "status": "done"
+    }
+  ]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/delete-completed-empty.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/delete-completed-empty.json
@@ -1,0 +1,1 @@
+[{ "kind": "no_completed_pads" }]

--- a/crates/padz/tests/fixtures/semantic_outcomes/edit-content.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/edit-content.json
@@ -1,0 +1,11 @@
+[
+  {
+    "kind": "updated",
+    "path": [
+      { "type": "Regular", "value": 1 },
+      { "type": "Regular", "value": 1 }
+    ],
+    "title": "Edited child",
+    "update_kind": "content"
+  }
+]

--- a/crates/padz/tests/fixtures/semantic_outcomes/move-no-op.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/move-no-op.json
@@ -1,0 +1,9 @@
+[
+  {
+    "kind": "already_at_destination",
+    "path": [
+      { "type": "Regular", "value": 1 },
+      { "type": "Regular", "value": 1 }
+    ]
+  }
+]

--- a/crates/padz/tests/fixtures/semantic_outcomes/reopen-no-op.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/reopen-no-op.json
@@ -1,0 +1,7 @@
+[
+  {
+    "kind": "already_in_status",
+    "path": [{ "type": "Regular", "value": 1 }],
+    "status": "planned"
+  }
+]

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -27,9 +27,10 @@ use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
     DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
-    ModificationResult, PadContentResult, PadListResult, PathResult, PurgeResult, UuidResult,
+    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
+    PadContentResult, PadListResult, PathResult, PurgeResult, UpdateKindResult, UuidResult,
 };
-use padzapp::commands::{CmdNotice, NestingMode};
+use padzapp::commands::NestingMode;
 use standout::cli::Output;
 use support::Fixture;
 
@@ -373,7 +374,7 @@ fn repeated_pin_maps_the_core_notice_without_parsing_prose() {
 
     assert_eq!(
         result.notices,
-        vec![CmdNotice::AlreadyPinned {
+        vec![ModificationNoticeResult::AlreadyPinned {
             path: vec![padzapp::index::DisplayIndex::Pinned(1)]
         }]
     );
@@ -444,6 +445,81 @@ fn move_to_root_needs_only_the_sources() {
     assert!(
         result.pads[0].pad.metadata.parent_id.is_none(),
         "--root detaches the pad from its parent"
+    );
+}
+
+#[test]
+fn same_parent_move_maps_the_nested_no_op_path() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::move_pads(
+        &ctx,
+        vec!["1.1".to_string(), "1".to_string()],
+        false,
+    ));
+
+    assert!(result.pads.is_empty());
+    assert_eq!(
+        result.notices,
+        vec![ModificationNoticeResult::AlreadyAtDestination {
+            path: vec![
+                padzapp::index::DisplayIndex::Regular(1),
+                padzapp::index::DisplayIndex::Regular(1),
+            ],
+        }]
+    );
+    assert!(result.outcomes.is_empty());
+}
+
+#[test]
+fn mixed_complete_maps_changed_pads_and_requested_status_no_ops() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "changed", "");
+    fx.seed_pad(&state, "no op", "");
+    let ctx = support::ctx_with_state(state);
+    rendered(handlers::complete(&ctx, vec!["1".to_string()]));
+
+    let result = rendered(handlers::complete(
+        &ctx,
+        vec!["1".to_string(), "2".to_string()],
+    ));
+
+    assert_eq!(result.pads.len(), 2);
+    assert_eq!(
+        result.notices,
+        vec![ModificationNoticeResult::AlreadyInStatus {
+            path: vec![padzapp::index::DisplayIndex::Regular(1)],
+            status: MutationStatusResult::Done,
+        }]
+    );
+    assert_eq!(
+        result.outcomes,
+        vec![MutationOutcomeResult::StatusChanged {
+            path: vec![padzapp::index::DisplayIndex::Regular(2)],
+            status: MutationStatusResult::Done,
+        }]
+    );
+}
+
+#[test]
+fn empty_delete_completed_maps_the_core_no_op() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "still open", "");
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::delete(&ctx, vec![], true));
+
+    assert!(result.pads.is_empty());
+    assert!(result.messages.is_empty());
+    assert_eq!(
+        result.notices,
+        vec![ModificationNoticeResult::NoCompletedPads]
     );
 }
 
@@ -749,4 +825,39 @@ fn edit_with_direct_content_replaces_the_selected_pads_text() {
 
     assert_eq!(result.pads[0].pad.metadata.title, "after");
     assert!(result.pads[0].pad.content.contains("new body"));
+    assert_eq!(
+        result.outcomes,
+        vec![MutationOutcomeResult::Updated {
+            path: vec![padzapp::index::DisplayIndex::Regular(1)],
+            title: "after".to_string(),
+            update_kind: UpdateKindResult::Content,
+        }]
+    );
+}
+
+#[test]
+fn edit_maps_a_nested_canonical_path_without_parsing_prose() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    let ctx = support::ctx_with_input(
+        state,
+        EDIT_CONTENT,
+        RequestContent::Direct("edited child".to_string()),
+    );
+
+    let result = rendered(handlers::edit(&ctx, vec!["1.1".to_string()]));
+
+    assert_eq!(
+        result.outcomes,
+        vec![MutationOutcomeResult::Updated {
+            path: vec![
+                padzapp::index::DisplayIndex::Regular(1),
+                padzapp::index::DisplayIndex::Regular(1),
+            ],
+            title: "edited child".to_string(),
+            update_kind: UpdateKindResult::Content,
+        }]
+    );
 }

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -401,6 +401,200 @@ fn empty_purge_is_distinct_in_text_and_structured_output() {
     );
 }
 
+// =============================================================================
+// Semantic pad mutation outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn nested_edit_preserves_text_and_exposes_update_facts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    drop(state);
+    let (app, cmd) = fx.app(&["list"]);
+
+    let text = TestHarness::new()
+        .no_color()
+        .piped_stdin("Edited child")
+        .run(
+            &app,
+            cmd.clone(),
+            fx.argv(&["edit", "1.1", "--output", "text"]),
+        );
+    text.assert_success();
+    text.assert_stdout_contains("Updated 1 pad...");
+    text.assert_stdout_contains("Updated (1.1): Edited child");
+    drop(text);
+
+    let json = TestHarness::new().piped_stdin("Edited child").run(
+        &app,
+        cmd,
+        fx.argv(&["edit", "1.1", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/edit-content.json")).unwrap();
+    assert_eq!(value["outcomes"], fixture);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
+#[test]
+#[serial]
+fn same_parent_move_preserves_text_and_exposes_the_nested_no_op() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "");
+    fx.seed_child(&state, "1", "child", "");
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["move", "1.1", "1", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "Pad '1.1' is already at destination\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["move", "1.1", "1", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/move-no-op.json")).unwrap();
+    assert_eq!(value["notices"], fixture);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
+#[test]
+#[serial]
+fn mixed_complete_distinguishes_changed_pads_from_no_ops() {
+    let fx = Fixture::new();
+    fx.todos_mode();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "changed", "");
+    fx.seed_pad(&state, "no op", "");
+    state
+        .with_api(|api| api.complete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["complete", "1", "2", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/complete-mixed.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "notices": value["notices"].clone(),
+            "outcomes": value["outcomes"].clone(),
+        }),
+        fixture
+    );
+    assert_eq!(value["pads"].as_array().map(Vec::len), Some(2));
+    assert!(value["pads"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|pad| pad["pad"]["metadata"]["status"] == "Done"));
+}
+
+#[test]
+#[serial]
+fn repeated_complete_and_reopen_keep_compatible_text_and_typed_statuses() {
+    let complete_fx = Fixture::new();
+    complete_fx.todos_mode();
+    let state = complete_fx.app_state();
+    complete_fx.seed_pad(&state, "done", "");
+    state
+        .with_api(|api| api.complete_pads(state.scope, &["1"]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = complete_fx.read_app();
+    let complete = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        complete_fx.argv(&["complete", "1", "--output", "text"]),
+    );
+    complete.assert_success();
+    complete.assert_stdout_contains("Pad 1 is already done");
+    drop(complete);
+
+    let reopen_fx = Fixture::new();
+    reopen_fx.todos_mode();
+    let state = reopen_fx.app_state();
+    reopen_fx.seed_pad(&state, "planned", "");
+    drop(state);
+    let (app, cmd) = reopen_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        reopen_fx.argv(&["reopen", "1", "--output", "text"]),
+    );
+    text.assert_success();
+    text.assert_stdout_contains("Pad 1 is already planned");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        reopen_fx.argv(&["reopen", "1", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/reopen-no-op.json")).unwrap();
+    assert_eq!(value["notices"], fixture);
+}
+
+#[test]
+#[serial]
+fn empty_delete_completed_preserves_text_and_exposes_a_typed_no_op() {
+    let fx = Fixture::new();
+    fx.todos_mode();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "still open", "");
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["delete", "--completed", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "No completed pads to delete.\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["delete", "--completed", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/delete-completed-empty.json"
+    ))
+    .unwrap();
+    assert_eq!(value["notices"], fixture);
+    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+}
+
 #[test]
 #[serial]
 fn uuid_flag_reaches_the_view_handler() {
@@ -1112,6 +1306,26 @@ fn status_glyphs_appear_only_when_the_listing_asks_for_them() {
 // =============================================================================
 // Styles — asserted semantically via term-debug, never by scraping ANSI
 // =============================================================================
+
+#[test]
+#[serial]
+fn mutation_outcomes_keep_the_established_info_and_success_styles() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "before", "");
+    drop(state);
+
+    let (app, cmd) = fx.app(&["list"]);
+    let result = TestHarness::new().piped_stdin("after").run(
+        &app,
+        cmd,
+        fx.argv(&["edit", "1", "--output", "term-debug"]),
+    );
+
+    result.assert_success();
+    result.assert_stdout_contains("[info]Updated 1 pad...[/info]");
+    result.assert_stdout_contains("[success]Updated (1): after[/success]");
+}
 
 #[test]
 #[serial]

--- a/crates/padzapp/src/api/crud.rs
+++ b/crates/padzapp/src/api/crud.rs
@@ -62,10 +62,13 @@ impl<S: DataStore> PadzApi<S> {
     }
 
     /// Soft-deletes all active pads marked as Done (completed).
+    ///
+    /// Returns a semantic `NoCompletedPads` notice when there are no matches.
     pub fn delete_completed_pads(&mut self, scope: Scope) -> Result<commands::CmdResult> {
         commands::delete::run_completed(&mut self.store, scope)
     }
 
+    /// Applies typed updates and returns affected pads plus semantic update facts.
     pub fn update_pads(
         &mut self,
         scope: Scope,
@@ -74,7 +77,8 @@ impl<S: DataStore> PadzApi<S> {
         commands::update::run(&mut self.store, scope, updates)
     }
 
-    /// Updates pads with raw content (e.g., from piped stdin).
+    /// Updates pads with raw content (e.g., from piped stdin), returning affected
+    /// pads plus semantic content-update facts.
     pub fn update_pads_from_content<I: AsRef<str>>(
         &mut self,
         scope: Scope,

--- a/crates/padzapp/src/api/status.rs
+++ b/crates/padzapp/src/api/status.rs
@@ -28,7 +28,7 @@ impl<S: DataStore> PadzApi<S> {
         commands::pinning::unpin(&mut self.store, scope, &selectors)
     }
 
-    /// Marks pads as Done (completed).
+    /// Marks pads as Done, reporting already-done selectors as semantic no-ops.
     pub fn complete_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
@@ -38,7 +38,7 @@ impl<S: DataStore> PadzApi<S> {
         commands::status::complete(&mut self.store, scope, &selectors)
     }
 
-    /// Reopens pads (sets them back to Planned).
+    /// Reopens pads, reporting already-planned selectors as semantic no-ops.
     pub fn reopen_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
@@ -48,6 +48,8 @@ impl<S: DataStore> PadzApi<S> {
         commands::status::reopen(&mut self.store, scope, &selectors)
     }
 
+    /// Moves pads under a parent (or root), reporting same-parent moves as
+    /// semantic no-ops with their canonical display paths.
     pub fn move_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,

--- a/crates/padzapp/src/api/util.rs
+++ b/crates/padzapp/src/api/util.rs
@@ -2,6 +2,7 @@
 
 use crate::commands;
 use crate::error::Result;
+use crate::index::{DisplayIndex, PadSelector};
 use crate::model::{Pad, Scope};
 use crate::store::DataStore;
 
@@ -35,6 +36,18 @@ impl<S: DataStore> PadzApi<S> {
     pub fn get_path_by_id(&self, scope: Scope, id: uuid::Uuid) -> Result<std::path::PathBuf> {
         use crate::store::Bucket;
         self.store.get_pad_path(&id, scope, Bucket::Active)
+    }
+
+    /// Resolves an active pad's canonical display path from its durable identity.
+    pub fn display_path_by_id(&self, scope: Scope, id: uuid::Uuid) -> Result<Vec<DisplayIndex>> {
+        let mut resolved = commands::helpers::resolve_selectors(
+            &self.store,
+            scope,
+            &[PadSelector::Uuid(id)],
+            false,
+            commands::helpers::TitleBucket::Active,
+        )?;
+        Ok(resolved.remove(0).0)
     }
 
     /// Re-reads a pad from disk and syncs metadata (title, updated_at).

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -1,4 +1,4 @@
-use crate::commands::CmdResult;
+use crate::commands::{CmdNotice, CmdResult};
 use crate::error::Result;
 use crate::index::{DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
@@ -75,7 +75,10 @@ pub fn run_completed<S: DataStore>(store: &mut S, scope: Scope) -> Result<CmdRes
         .collect();
 
     if done_ids.is_empty() {
-        return Ok(CmdResult::default());
+        return Ok(CmdResult {
+            notices: vec![CmdNotice::NoCompletedPads],
+            ..Default::default()
+        });
     }
 
     let selectors: Vec<PadSelector> = done_ids.iter().map(|id| PadSelector::Uuid(*id)).collect();
@@ -367,6 +370,8 @@ mod tests {
 
         let result = run_completed(&mut store, Scope::Project).unwrap();
         assert!(result.affected_pads.is_empty());
+        assert!(result.messages.is_empty());
+        assert_eq!(result.notices, vec![CmdNotice::NoCompletedPads]);
 
         // Pad should still be active
         let active = get::run(&store, Scope::Project, get::PadFilter::default(), &[]).unwrap();

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -32,8 +32,10 @@
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
 //! Initialization, doctor, purge, and artifact-producing commands use dedicated
-//! outcome types where a generic result would obscure the operation's facts. The
-//! UI layer (CLI, web, etc.) decides how to render every result.
+//! outcome types where a generic result would obscure the operation's facts. Pad
+//! mutations that still use [`CmdResult`] attach presentation-free [`CmdOutcome`]
+//! and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides how to render
+//! every result.
 //!
 //! ## Testing Strategy
 //!
@@ -94,6 +96,49 @@ pub enum CmdNotice {
     },
     AlreadyUnpinned {
         path: Vec<crate::index::DisplayIndex>,
+    },
+    /// A move request found the pad under the requested parent already.
+    AlreadyAtDestination {
+        path: Vec<crate::index::DisplayIndex>,
+    },
+    /// A status request found the pad in the requested state already.
+    AlreadyInStatus {
+        path: Vec<crate::index::DisplayIndex>,
+        status: crate::model::TodoStatus,
+    },
+    /// A completed-pad deletion request found no completed pads.
+    NoCompletedPads,
+}
+
+/// How a pad's content reached the update command.
+///
+/// The distinction preserves the compatible human result while structured
+/// clients can identify the operation without parsing its sentence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateKind {
+    /// A typed [`PadUpdate`] changed explicit pad fields.
+    Structured,
+    /// Raw content was parsed and applied to one or more pads.
+    Content,
+    /// The store refreshed a pad after its backing file changed externally.
+    Refresh,
+}
+
+/// A semantic, presentation-free fact about a completed pad mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CmdOutcome {
+    /// A pad's title/content/status fields were updated.
+    Updated {
+        path: Vec<crate::index::DisplayIndex>,
+        title: String,
+        update_kind: UpdateKind,
+    },
+    /// A pad changed to the requested todo status.
+    StatusChanged {
+        path: Vec<crate::index::DisplayIndex>,
+        status: crate::model::TodoStatus,
     },
 }
 
@@ -207,6 +252,8 @@ pub struct CmdResult {
     pub messages: Vec<CmdMessage>,
     /// Semantic notices that clients render or inspect without parsing English.
     pub notices: Vec<CmdNotice>,
+    /// Semantic successful outcomes that clients inspect without parsing English.
+    pub outcomes: Vec<CmdOutcome>,
     /// The nesting mode used to produce listed_pads.
     pub nesting: NestingMode,
 }

--- a/crates/padzapp/src/commands/move_pads.rs
+++ b/crates/padzapp/src/commands/move_pads.rs
@@ -1,4 +1,6 @@
-use crate::commands::{CmdMessage, CmdResult, DisplayPad};
+//! Hierarchy-preserving pad moves with semantic no-op reporting.
+
+use crate::commands::{CmdNotice, CmdResult, DisplayPad};
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayIndex, PadSelector};
 use crate::model::Scope;
@@ -87,10 +89,9 @@ pub fn run<S: DataStore>(
 
         // Skip if already there
         if pad.metadata.parent_id == dest_uuid {
-            result.add_message(CmdMessage::info(format!(
-                "Pad '{}' is already at destination",
-                fmt_path(&display_index)
-            )));
+            result.notices.push(CmdNotice::AlreadyAtDestination {
+                path: display_index,
+            });
             continue;
         }
 
@@ -287,5 +288,26 @@ mod tests {
         // Depending on exact impl, fetching "1.1" might fail if it uses get_pad_at_path and relies on index which might shift?
         // But here the structure exists.
         assert!(res.unwrap_err().to_string().contains("descendant"));
+    }
+
+    #[test]
+    fn moving_a_nested_pad_to_its_current_parent_is_a_semantic_no_op() {
+        let (mut store, _root_id, _child_id) = setup_store();
+        let path = vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)];
+
+        let result = run(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(path.clone())],
+            Some(&PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        assert!(result.affected_pads.is_empty());
+        assert!(result.messages.is_empty());
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyAtDestination { path }]
+        );
     }
 }

--- a/crates/padzapp/src/commands/status.rs
+++ b/crates/padzapp/src/commands/status.rs
@@ -4,7 +4,7 @@
 //! - [`complete`]: Marks pads as Done
 //! - [`reopen`]: Reopens pads (sets them back to Planned)
 
-use crate::commands::{CmdMessage, CmdResult};
+use crate::commands::{CmdNotice, CmdOutcome, CmdResult};
 use crate::error::Result;
 use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::{Scope, TodoStatus};
@@ -46,18 +46,15 @@ fn set_status<S: DataStore>(
         let old_status = pad.metadata.status;
 
         if old_status == new_status {
-            // Already in desired state - add info message
-            let status_name = match new_status {
-                TodoStatus::Done => "done",
-                TodoStatus::Planned => "planned",
-                TodoStatus::InProgress => "in progress",
-            };
-            result.add_message(CmdMessage::info(format!(
-                "Pad {} is already {}",
-                super::helpers::fmt_path(&display_index),
-                status_name
-            )));
+            result.notices.push(CmdNotice::AlreadyInStatus {
+                path: display_index,
+                status: new_status,
+            });
         } else {
+            result.outcomes.push(CmdOutcome::StatusChanged {
+                path: display_index.clone(),
+                status: new_status,
+            });
             pad.metadata.status = new_status;
             pad.metadata.updated_at = chrono::Utc::now();
 
@@ -165,11 +162,14 @@ mod tests {
         // Complete again
         let result = complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        assert!(matches!(
-            result.messages[0].level,
-            crate::commands::MessageLevel::Info
-        ));
-        assert!(result.messages[0].content.contains("already done"));
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyInStatus {
+                path: vec![DisplayIndex::Regular(1)],
+                status: TodoStatus::Done,
+            }]
+        );
+        assert!(result.messages.is_empty());
     }
 
     #[test]
@@ -187,11 +187,62 @@ mod tests {
         // Reopen an already planned pad
         let result = reopen(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        assert!(matches!(
-            result.messages[0].level,
-            crate::commands::MessageLevel::Info
-        ));
-        assert!(result.messages[0].content.contains("already planned"));
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyInStatus {
+                path: vec![DisplayIndex::Regular(1)],
+                status: TodoStatus::Planned,
+            }]
+        );
+        assert!(result.messages.is_empty());
+    }
+
+    #[test]
+    fn complete_mixed_request_distinguishes_changed_and_no_op_pads() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Changed".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        create::run(&mut store, Scope::Project, "No op".into(), "".into(), None).unwrap();
+        let first = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+        complete(&mut store, Scope::Project, slice::from_ref(&first)).unwrap();
+
+        let result = complete(
+            &mut store,
+            Scope::Project,
+            &[first, PadSelector::Path(vec![DisplayIndex::Regular(2)])],
+        )
+        .unwrap();
+
+        assert_eq!(result.affected_pads.len(), 2);
+        assert_eq!(
+            result.notices,
+            vec![CmdNotice::AlreadyInStatus {
+                path: vec![DisplayIndex::Regular(1)],
+                status: TodoStatus::Done,
+            }]
+        );
+        assert!(result
+            .affected_pads
+            .iter()
+            .all(|pad| pad.pad.metadata.status == TodoStatus::Done));
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::StatusChanged {
+                path: vec![DisplayIndex::Regular(2)],
+                status: TodoStatus::Done,
+            }]
+        );
     }
 
     #[test]

--- a/crates/padzapp/src/commands/update.rs
+++ b/crates/padzapp/src/commands/update.rs
@@ -1,4 +1,10 @@
-use crate::commands::{CmdMessage, CmdResult, PadUpdate};
+//! Semantic pad updates.
+//!
+//! Both typed-field and raw-content updates return the affected pads plus an
+//! [`CmdOutcome`](crate::commands::CmdOutcome) for each update. Human wording is
+//! deliberately left to clients.
+
+use crate::commands::{CmdOutcome, CmdResult, PadUpdate, UpdateKind};
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayPad, PadSelector};
 use crate::model::{parse_pad_content, Scope};
@@ -50,12 +56,11 @@ pub fn run<S: DataStore>(store: &mut S, scope: Scope, updates: &[PadUpdate]) -> 
         // edit still surfaces the parent under `ordering = updated_at`.
         crate::todos::propagate_status_change(store, scope, parent_id)?;
 
-        // Fix: Use display_index directly as it's already formatted for display
-        result.add_message(CmdMessage::success(format!(
-            "Pad updated ({}): {}",
-            super::helpers::fmt_path(&display_index),
-            pad.metadata.title
-        )));
+        result.outcomes.push(CmdOutcome::Updated {
+            path: display_index.clone(),
+            title: pad.metadata.title.clone(),
+            update_kind: UpdateKind::Structured,
+        });
         // Index doesn't change after update (use the last segment of the path)
         let local_index = display_index
             .last()
@@ -110,11 +115,11 @@ pub fn run_from_content<S: DataStore>(
         // edit still surfaces the parent under `ordering = updated_at`.
         crate::todos::propagate_status_change(store, scope, parent_id)?;
 
-        result.add_message(CmdMessage::success(format!(
-            "Updated ({}): {}",
-            super::helpers::fmt_path(&display_index),
-            pad.metadata.title
-        )));
+        result.outcomes.push(CmdOutcome::Updated {
+            path: display_index.clone(),
+            title: pad.metadata.title.clone(),
+            update_kind: UpdateKind::Content,
+        });
 
         let local_index = display_index
             .last()
@@ -245,10 +250,25 @@ mod tests {
 
         let res = run(&mut store, Scope::Project, &updates).unwrap();
 
-        // Check results
-        assert_eq!(res.messages.len(), 2);
-        assert!(res.messages.iter().any(|m| m.content.contains("A Updated")));
-        assert!(res.messages.iter().any(|m| m.content.contains("B Updated")));
+        // Check semantic results without parsing presentation prose.
+        assert!(res.messages.is_empty());
+        assert_eq!(res.outcomes.len(), 2);
+        assert!(res.outcomes.iter().any(|outcome| matches!(
+            outcome,
+            CmdOutcome::Updated {
+                title,
+                update_kind: UpdateKind::Structured,
+                ..
+            } if title == "A Updated"
+        )));
+        assert!(res.outcomes.iter().any(|outcome| matches!(
+            outcome,
+            CmdOutcome::Updated {
+                title,
+                update_kind: UpdateKind::Structured,
+                ..
+            } if title == "B Updated"
+        )));
 
         // Check store state
         let pads = get::run(&store, Scope::Project, get::PadFilter::default(), &[])
@@ -356,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn update_success_message_format() {
+    fn update_returns_semantic_kind_path_and_title() {
         let mut store = BucketedStore::new(
             MemBackend::new(),
             MemBackend::new(),
@@ -372,10 +392,15 @@ mod tests {
         );
         let result = run(&mut store, Scope::Project, &[update]).unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert!(result.messages[0].content.contains("Pad updated"));
-        assert!(result.messages[0].content.contains("1")); // index
-        assert!(result.messages[0].content.contains("Updated Title"));
+        assert!(result.messages.is_empty());
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::Updated {
+                path: vec![DisplayIndex::Regular(1)],
+                title: "Updated Title".to_string(),
+                update_kind: UpdateKind::Structured,
+            }]
+        );
     }
 
     #[test]
@@ -508,6 +533,51 @@ mod tests {
         assert_eq!(
             result.affected_pads[0].pad.content,
             "New Title From Pipe\n\nNew body content from piped input."
+        );
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::Updated {
+                path: vec![DisplayIndex::Regular(1)],
+                title: "New Title From Pipe".to_string(),
+                update_kind: UpdateKind::Content,
+            }]
+        );
+    }
+
+    #[test]
+    fn run_from_content_reports_a_nested_canonical_path() {
+        let mut store = BucketedStore::new(
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+            MemBackend::new(),
+        );
+        create::run(&mut store, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut store,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+
+        let path = vec![DisplayIndex::Regular(1), DisplayIndex::Regular(1)];
+        let result = run_from_content(
+            &mut store,
+            Scope::Project,
+            &[PadSelector::Path(path.clone())],
+            "Edited child",
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.outcomes,
+            vec![CmdOutcome::Updated {
+                path,
+                title: "Edited child".to_string(),
+                update_kind: UpdateKind::Content,
+            }]
         );
     }
 


### PR DESCRIPTION
## Context

for #214

Why this approach: WS02 extends the semantic-result pattern established by #207 and merged in WS01/#224. `padzapp` now reports typed update and status-change outcomes plus typed same-parent move, repeated status, and empty completed-delete no-ops. Thin CLI adapters project those facts into a stable structured result, while `modification_result.jinja` retains the established human wording, modification ordering, status display, and semantic `info`/`success` styles.

Structured modification output intentionally changes where these facts live. Updates add an `outcomes` array with canonical display path, title, and `structured`/`content`/`refresh` update kind. Changed statuses add `status_changed` outcomes, while repeated complete/reopen, same-parent moves, and empty `delete --completed` requests add typed `notices` and remove the migrated English `messages`. External fixtures pin each new schema shape, and the unreleased changelog documents the transition. Mixed status requests expose changed and no-op paths independently without relying on current display ordering or parsing prose.

Out of scope: #215-#223, dependency changes, storage/selectors/hierarchy/order redesign, and broad output rewording or visual redesign. Standout v7.9.0 was already coherently pinned on the epic base and remains unchanged. Do not collapse the outcome/no-op distinction or move human sentences back into `padzapp` or handlers.

Verification:
- `env RUSTC_WRAPPER= pixi run test` — 863 passed, 1 skipped
- commit and push hooks — all 12 lint checks passed

Governing-doc self-check: reviewed every acceptance criterion and compatibility/non-goal boundary in epic #208 and issue #214, the semantic ownership pattern from #207, and merged WS01/PR #224. No separate ADR/spec list was supplied in the implementer brief; this mandatory brief-slot gap is recorded here rather than guessed.
