### PR TITLE
STD02-WS03: Epic: Complete Remaining Standout Ownership Work - Workstream: Semantic Tag Catalog and Assignment Outcomes

### DIFF
--- a/CHANGELOG/unreleased-semantic-tag-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-tag-outcomes.md
@@ -1,0 +1,8 @@
+- Tag listing now exposes an ordered `tags` array with an explicit
+  `empty`/`listed` status. Tag registry mutations expose `created`/`deleted`/`renamed`
+  actions with their relevant names and affected-pad counts; per-pad assignment and
+  removal expose requested tag arrays, modified-pad counts, and distinct
+  `all_already_present`/`none_present` no-ops. These dedicated structured schemas
+  replace the former prose-only `messages` and generic modification results. Human
+  wording, ordering, brackets, pluralization, pad rows, and semantic `info`/`success`
+  styling remain unchanged through CLI-owned MiniJinja templates.

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -18,8 +18,8 @@
 
 use super::handlers::AppState;
 use super::render::{
-    list_view_provider, modification_view_provider, terminal_provider, LIST_VIEW,
-    MODIFICATION_VIEW, TERMINAL,
+    list_view_provider, modification_view_provider, tagging_view_provider, terminal_provider,
+    LIST_VIEW, MODIFICATION_VIEW, TAGGING_VIEW, TERMINAL,
 };
 use super::setup::{
     build_command, invocation_default_command, parse_cli, Cli, Commands, CompletionAction,
@@ -93,6 +93,7 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
         .context_fn(TERMINAL, terminal_provider)
         .context_fn(LIST_VIEW, list_view_provider)
         .context_fn(MODIFICATION_VIEW, modification_view_provider)
+        .context_fn(TAGGING_VIEW, tagging_view_provider)
         .commands(Commands::dispatch_config())
         .expect("Failed to configure commands")
         .command_with("create", super::handlers::create__handler, |config| {

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -30,7 +30,7 @@ use std::cell::RefCell;
 use super::result::{
     DoctorResult, ExportReportResult, InitializationResult, ListRequest, MessagesResult,
     ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
-    PathResult, PurgeResult, UuidResult,
+    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UuidResult,
 };
 
 // =============================================================================
@@ -370,23 +370,23 @@ impl<'a> ScopedApi<'a> {
 
     // --- Tags subcommand operations ---
 
-    pub fn list_tags(&self) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.list_tags(scope))?;
-        self.messages(result)
+    pub fn list_tags(&self) -> Result<Output<TagCatalogResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.list_tags(scope))?;
+        Ok(Output::Render(outcome.into()))
     }
 
-    pub fn delete_tag(&self, name: &str) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.delete_tag(scope, name))?;
-        self.messages(result)
+    pub fn delete_tag(&self, name: &str) -> Result<Output<TagRegistryResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.delete_tag(scope, name))?;
+        Ok(Output::Render(outcome.into()))
     }
 
     pub fn rename_tag(
         &self,
         old_name: &str,
         new_name: &str,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
-        let result = self.call(|api, scope| api.rename_tag(scope, old_name, new_name))?;
-        self.messages(result)
+    ) -> Result<Output<TagRegistryResult>, anyhow::Error> {
+        let outcome = self.call(|api, scope| api.rename_tag(scope, old_name, new_name))?;
+        Ok(Output::Render(outcome.into()))
     }
 
     // --- List operations ---
@@ -1285,32 +1285,28 @@ pub mod tag {
     pub fn add(
         #[ctx] ctx: &CommandContext,
         #[arg] args: Vec<String>,
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<TaggingResult>, anyhow::Error> {
         let (indexes, tags) = split_indexes_and_tags(&args)?;
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.add_tags_to_pads(state.scope, &indexes, &tags)
                 .map_err(to_anyhow)
         })?;
-        Ok(Output::Render(
-            api(ctx).modification_result("Tagged", result, false),
-        ))
+        Ok(Output::Render(result.into()))
     }
 
     #[handler]
     pub fn remove(
         #[ctx] ctx: &CommandContext,
         #[arg] args: Vec<String>,
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<TaggingResult>, anyhow::Error> {
         let (indexes, tags) = split_indexes_and_tags(&args)?;
         let state = get_state(ctx);
         let result = state.with_api(|api| {
             api.remove_tags_from_pads(state.scope, &indexes, &tags)
                 .map_err(to_anyhow)
         })?;
-        Ok(Output::Render(
-            api(ctx).modification_result("Untagged", result, false),
-        ))
+        Ok(Output::Render(result.into()))
     }
 
     #[handler]
@@ -1318,7 +1314,7 @@ pub mod tag {
         #[ctx] ctx: &CommandContext,
         #[arg(name = "old_name")] old_name: String,
         #[arg(name = "new_name")] new_name: String,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TagRegistryResult>, anyhow::Error> {
         api(ctx).rename_tag(&old_name, &new_name)
     }
 
@@ -1326,7 +1322,7 @@ pub mod tag {
     pub fn delete(
         #[ctx] ctx: &CommandContext,
         #[arg] name: String,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TagRegistryResult>, anyhow::Error> {
         api(ctx).delete_tag(&name)
     }
 
@@ -1334,14 +1330,14 @@ pub mod tag {
     pub fn list(
         #[ctx] ctx: &CommandContext,
         #[arg] ids: Vec<String>,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TagCatalogResult>, anyhow::Error> {
         if ids.is_empty() {
             api(ctx).list_tags()
         } else {
             let state = get_state(ctx);
-            let result =
+            let outcome =
                 state.with_api(|api| api.list_pad_tags(state.scope, &ids).map_err(to_anyhow))?;
-            Ok(Output::Render(MessagesResult::new(result.messages)))
+            Ok(Output::Render(outcome.into()))
         }
     }
 }

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -47,7 +47,7 @@
 
 use super::result::{
     ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadListResult, UpdateKindResult,
+    PadListResult, TaggingResult, UpdateKindResult,
 };
 use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
@@ -68,6 +68,8 @@ pub const DEFAULT_LINE_WIDTH: usize = 80;
 pub const LIST_VIEW: &str = "list_view";
 /// The context name `modification_result.jinja` reads its view data from.
 pub const MODIFICATION_VIEW: &str = "modification_view";
+/// The context name `tagging.jinja` reads its view data from.
+pub const TAGGING_VIEW: &str = "tagging_view";
 /// The context name every template reads layout width from.
 pub const TERMINAL: &str = "terminal";
 
@@ -241,6 +243,15 @@ pub struct MutationOutcomeView {
     pub update_kind: &'static str,
 }
 
+/// Template-ready view for per-pad tag assignment and removal.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaggingView {
+    pub action: &'static str,
+    pub requested_tags: Vec<String>,
+    pub modified_pads: usize,
+    pub rows: Vec<PadRow>,
+}
+
 // =============================================================================
 // Context providers (the render-time seam)
 // =============================================================================
@@ -267,6 +278,14 @@ pub fn list_view_provider(ctx: &RenderContext) -> Value {
 pub fn modification_view_provider(ctx: &RenderContext) -> Value {
     match serde_json::from_value::<ModificationResult>(ctx.data.clone()) {
         Ok(result) => Value::from_serialize(build_modification_view(&result)),
+        Err(_) => Value::UNDEFINED,
+    }
+}
+
+/// Context provider for `tagging.jinja`.
+pub fn tagging_view_provider(ctx: &RenderContext) -> Value {
+    match serde_json::from_value::<TaggingResult>(ctx.data.clone()) {
+        Ok(result) => Value::from_serialize(build_tagging_view(&result)),
         Err(_) => Value::UNDEFINED,
     }
 }
@@ -324,6 +343,43 @@ pub fn build_modification_view(result: &ModificationResult) -> ModificationView 
             .outcomes
             .iter()
             .filter_map(mutation_outcome)
+            .collect(),
+    }
+}
+
+/// Builds the template-ready view for a tag assignment or removal.
+pub fn build_tagging_view(result: &TaggingResult) -> TaggingView {
+    let (action, requested_tags, modified_pads, pads) = match result {
+        TaggingResult::Assigned {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("assigned", requested_tags, *modified_pads, pads),
+        TaggingResult::AllAlreadyPresent {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("all_already_present", requested_tags, *modified_pads, pads),
+        TaggingResult::Removed {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("removed", requested_tags, *modified_pads, pads),
+        TaggingResult::NonePresent {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => ("none_present", requested_tags, *modified_pads, pads),
+    };
+    let options = super::result::ListRequest::default();
+
+    TaggingView {
+        action,
+        requested_tags: requested_tags.clone(),
+        modified_pads,
+        rows: pads
+            .iter()
+            .map(|pad| row(pad, 0, SectionKind::of(&pad.index), &options))
             .collect(),
     }
 }

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -10,8 +10,8 @@
 //!
 //! These are CLI-only adapter types: they exist purely to establish the shell's
 //! result contract, so they live in the binary rather than in `padzapp`. The data
-//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`) is reusable domain data and
-//! stays in `padzapp`.
+//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`, semantic tag outcomes) is
+//! reusable domain data and stays in `padzapp`.
 //!
 //! ## Presentation is not in here
 //!
@@ -198,6 +198,144 @@ impl From<UpdateKind> for UpdateKindResult {
             UpdateKind::Structured => Self::Structured,
             UpdateKind::Content => Self::Content,
             UpdateKind::Refresh => Self::Refresh,
+        }
+    }
+}
+
+/// CLI projection of an ordered tag catalog with an explicit empty state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum TagCatalogResult {
+    Empty { tags: Vec<String> },
+    Listed { tags: Vec<String> },
+}
+
+impl From<padzapp::commands::tags::TagCatalogOutcome> for TagCatalogResult {
+    fn from(outcome: padzapp::commands::tags::TagCatalogOutcome) -> Self {
+        use padzapp::commands::tags::TagCatalogOutcome;
+
+        match outcome {
+            TagCatalogOutcome::Empty => Self::Empty { tags: Vec::new() },
+            TagCatalogOutcome::Listed { tags } => Self::Listed { tags },
+        }
+    }
+}
+
+/// CLI projection of a tag-registry mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum TagRegistryResult {
+    Created {
+        name: String,
+        affected_pads: usize,
+    },
+    Deleted {
+        name: String,
+        affected_pads: usize,
+    },
+    Renamed {
+        old_name: String,
+        new_name: String,
+        affected_pads: usize,
+    },
+}
+
+impl From<padzapp::commands::tags::TagRegistryOutcome> for TagRegistryResult {
+    fn from(outcome: padzapp::commands::tags::TagRegistryOutcome) -> Self {
+        use padzapp::commands::tags::TagRegistryOutcome;
+
+        match outcome {
+            TagRegistryOutcome::Created {
+                name,
+                affected_pads,
+            } => Self::Created {
+                name,
+                affected_pads,
+            },
+            TagRegistryOutcome::Deleted {
+                name,
+                affected_pads,
+            } => Self::Deleted {
+                name,
+                affected_pads,
+            },
+            TagRegistryOutcome::Renamed {
+                old_name,
+                new_name,
+                affected_pads,
+            } => Self::Renamed {
+                old_name,
+                new_name,
+                affected_pads,
+            },
+        }
+    }
+}
+
+/// CLI projection of a per-pad tag mutation or its explicit no-op.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum TaggingResult {
+    Assigned {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+    AllAlreadyPresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+    Removed {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+    NonePresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+        pads: Vec<DisplayPad>,
+    },
+}
+
+impl From<padzapp::commands::tagging::TaggingResult> for TaggingResult {
+    fn from(result: padzapp::commands::tagging::TaggingResult) -> Self {
+        use padzapp::commands::tagging::TaggingOutcome;
+
+        let pads = result.affected_pads;
+        match result.outcome {
+            TaggingOutcome::Assigned {
+                requested_tags,
+                modified_pads,
+            } => Self::Assigned {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
+            TaggingOutcome::AllAlreadyPresent {
+                requested_tags,
+                modified_pads,
+            } => Self::AllAlreadyPresent {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
+            TaggingOutcome::Removed {
+                requested_tags,
+                modified_pads,
+            } => Self::Removed {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
+            TaggingOutcome::NonePresent {
+                requested_tags,
+                modified_pads,
+            } => Self::NonePresent {
+                requested_tags,
+                modified_pads,
+                pads,
+            },
         }
     }
 }

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -832,7 +832,7 @@ pub enum ConfigSubcommand {
 pub enum TagCommands {
     /// Add tags to pads (auto-creates tags if needed)
     #[command(display_order = 25)]
-    #[dispatch(pure, template = "modification_result")]
+    #[dispatch(pure, template = "tagging")]
     Add {
         /// Pad selectors followed by tag names (e.g. 1 2 feature work)
         #[arg(required = true, num_args = 1..)]
@@ -841,7 +841,7 @@ pub enum TagCommands {
 
     /// Remove tags from pads
     #[command(display_order = 26)]
-    #[dispatch(pure, template = "modification_result")]
+    #[dispatch(pure, template = "tagging")]
     Remove {
         /// Pad selectors followed by tag names (e.g. 1 2 feature work)
         #[arg(required = true, num_args = 1..)]
@@ -850,7 +850,7 @@ pub enum TagCommands {
 
     /// Rename a tag (updates all pads)
     #[command(alias = "mv", display_order = 27)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "tag_registry")]
     Rename {
         /// Current name of the tag
         old_name: String,
@@ -860,7 +860,7 @@ pub enum TagCommands {
 
     /// Delete a tag (removes from all pads)
     #[command(alias = "rm", display_order = 28)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "tag_registry")]
     Delete {
         /// Name of the tag to delete
         name: String,
@@ -868,7 +868,7 @@ pub enum TagCommands {
 
     /// List all defined tags, or tags for specific pads
     #[command(alias = "ls", display_order = 29)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "tag_catalog")]
     List {
         /// Pad IDs to show tags for (e.g. 1, 2 3, 1-3). If omitted, lists all tags.
         #[arg(num_args = 0..)]

--- a/crates/padz/src/cli/templates/tag_catalog.jinja
+++ b/crates/padz/src/cli/templates/tag_catalog.jinja
@@ -1,0 +1,8 @@
+{#- Ordered tag catalog. The core supplies names and an explicit empty state. -#}
+{%- if status == "empty" -%}
+[info]No tags defined[/info]{{ "" | nl }}
+{%- else -%}
+{%- for tag in tags -%}
+[info]{{ tag }}[/info]{{ "" | nl }}
+{%- endfor -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/tag_registry.jinja
+++ b/crates/padz/src/cli/templates/tag_registry.jinja
@@ -1,0 +1,14 @@
+{#- Human wording for semantic tag-registry mutations. -#}
+{%- if action == "created" -%}
+[success]Created tag '{{ name }}'[/success]{{ "" | nl }}
+{%- elif action == "deleted" -%}
+[success]Deleted tag '{{ name }}'[/success]{{ "" | nl }}
+{%- if affected_pads > 0 -%}
+[info]Removed from {{ affected_pads }} {{ "pad" if affected_pads == 1 else "pads" }}[/info]{{ "" | nl }}
+{%- endif -%}
+{%- elif action == "renamed" -%}
+[success]Renamed tag '{{ old_name }}' to '{{ new_name }}'[/success]{{ "" | nl }}
+{%- if affected_pads > 0 -%}
+[info]Updated {{ affected_pads }} {{ "pad" if affected_pads == 1 else "pads" }}[/info]{{ "" | nl }}
+{%- endif -%}
+{%- endif -%}

--- a/crates/padz/src/cli/templates/tagging.jinja
+++ b/crates/padz/src/cli/templates/tagging.jinja
@@ -1,0 +1,25 @@
+{#- Per-pad tag changes. `tagging_view` is derived only for human rendering. -#}
+{%- set view = tagging_view -%}
+{%- set show_status = false -%}
+{%- set peek_mode = false -%}
+{%- set count = view.rows | length -%}
+
+{%- if count > 0 -%}
+[info]{{ "Untagged" if view.action in ["removed", "none_present"] else "Tagged" }} {{ count }} {{ "pad" if count == 1 else "pads" }}...[/info]{{ "" | nl }}
+{%- endif -%}
+
+{%- for pad in view.rows -%}
+{%- include "_pad_line.jinja" -%}
+{%- endfor -%}
+
+{%- set tag_count = view.requested_tags | length -%}
+{%- set tag_names = view.requested_tags | join(", ") -%}
+{%- if view.action == "assigned" -%}
+[success]Added {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}] to {{ view.modified_pads }} {{ "pad" if view.modified_pads == 1 else "pads" }}[/success]{{ "" | nl }}
+{%- elif view.action == "all_already_present" -%}
+[info]All pads already have {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}][/info]{{ "" | nl }}
+{%- elif view.action == "removed" -%}
+[success]Removed {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}] from {{ view.modified_pads }} {{ "pad" if view.modified_pads == 1 else "pads" }}[/success]{{ "" | nl }}
+{%- elif view.action == "none_present" -%}
+[info]No pads had {{ "tag" if tag_count == 1 else "tags" }} [{{ tag_names }}][/info]{{ "" | nl }}
+{%- endif -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-all-already-present.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-all-already-present.json
@@ -1,0 +1,5 @@
+{
+  "action": "all_already_present",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-assigned.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-assigned.json
@@ -1,0 +1,5 @@
+{
+  "action": "assigned",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 2
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-empty.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-empty.json
@@ -1,0 +1,4 @@
+{
+  "status": "empty",
+  "tags": []
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-listed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-listed.json
@@ -1,0 +1,4 @@
+{
+  "status": "listed",
+  "tags": ["work", "rust"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-singleton.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-catalog-singleton.json
@@ -1,0 +1,4 @@
+{
+  "status": "listed",
+  "tags": ["work"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-deleted.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-deleted.json
@@ -1,0 +1,5 @@
+{
+  "action": "deleted",
+  "name": "new",
+  "affected_pads": 1
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-none-present.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-none-present.json
@@ -1,0 +1,5 @@
+{
+  "action": "none_present",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 0
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-removed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-removed.json
@@ -1,0 +1,5 @@
+{
+  "action": "removed",
+  "requested_tags": ["work", "rust"],
+  "modified_pads": 1
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/tag-renamed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/tag-renamed.json
@@ -1,0 +1,6 @@
+{
+  "action": "renamed",
+  "old_name": "old",
+  "new_name": "new",
+  "affected_pads": 1
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -28,7 +28,8 @@ use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
     DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
     ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadContentResult, PadListResult, PathResult, PurgeResult, UpdateKindResult, UuidResult,
+    PadContentResult, PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult,
+    TaggingResult, UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -520,6 +521,154 @@ fn empty_delete_completed_maps_the_core_no_op() {
     assert_eq!(
         result.notices,
         vec![ModificationNoticeResult::NoCompletedPads]
+    );
+}
+
+// =============================================================================
+// Tag catalog and mutation outcomes
+// =============================================================================
+
+#[test]
+fn tag_list_maps_empty_and_ordered_catalog_states() {
+    let empty = Fixture::new();
+    let result = rendered(handlers::tag::list(&empty.ctx(), vec![]));
+    assert_eq!(result, TagCatalogResult::Empty { tags: vec![] });
+
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    state
+        .with_api(|api| api.create_tag(state.scope, "work"))
+        .unwrap();
+    state
+        .with_api(|api| api.create_tag(state.scope, "rust"))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::tag::list(&ctx, vec![]));
+    assert_eq!(
+        result,
+        TagCatalogResult::Listed {
+            tags: vec!["work".into(), "rust".into()]
+        }
+    );
+}
+
+#[test]
+fn tag_list_maps_selected_pad_tags_to_a_singleton_catalog() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into()]))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::tag::list(&ctx, vec!["1".into()]));
+    assert_eq!(
+        result,
+        TagCatalogResult::Listed {
+            tags: vec!["work".into()]
+        }
+    );
+}
+
+#[test]
+fn tag_assignment_maps_requested_tags_counts_and_no_op_kind() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    let ctx = support::ctx_with_state(state);
+    let args = vec!["1".into(), "work".into(), "rust".into()];
+
+    let changed = rendered(handlers::tag::add(&ctx, args.clone()));
+    match changed {
+        TaggingResult::Assigned {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => {
+            assert_eq!(requested_tags, vec!["work", "rust"]);
+            assert_eq!(modified_pads, 1);
+            assert_eq!(pads.len(), 1);
+        }
+        other => panic!("expected assigned outcome, got {other:?}"),
+    }
+
+    let no_op = rendered(handlers::tag::add(&ctx, args));
+    match no_op {
+        TaggingResult::AllAlreadyPresent {
+            requested_tags,
+            modified_pads,
+            pads,
+        } => {
+            assert_eq!(requested_tags, vec!["work", "rust"]);
+            assert_eq!(modified_pads, 0);
+            assert_eq!(pads.len(), 1);
+        }
+        other => panic!("expected all-already-present outcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn tag_removal_maps_requested_tags_counts_and_no_op_kind() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    let ctx = support::ctx_with_state(state);
+    let args = vec!["1".into(), "work".into()];
+    rendered(handlers::tag::add(&ctx, args.clone()));
+
+    let changed = rendered(handlers::tag::remove(&ctx, args.clone()));
+    assert!(matches!(
+        changed,
+        TaggingResult::Removed {
+            requested_tags,
+            modified_pads: 1,
+            ..
+        } if requested_tags == vec!["work"]
+    ));
+
+    let no_op = rendered(handlers::tag::remove(&ctx, args));
+    assert!(matches!(
+        no_op,
+        TaggingResult::NonePresent {
+            requested_tags,
+            modified_pads: 0,
+            ..
+        } if requested_tags == vec!["work"]
+    ));
+}
+
+#[test]
+fn tag_registry_handlers_map_names_and_affected_pad_counts() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.create_tag(state.scope, "old"))
+        .unwrap();
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["old".into()]))
+        .unwrap();
+    let ctx = support::ctx_with_state(state);
+
+    let renamed = rendered(handlers::tag::rename(&ctx, "old".into(), "new".into()));
+    assert_eq!(
+        renamed,
+        TagRegistryResult::Renamed {
+            old_name: "old".into(),
+            new_name: "new".into(),
+            affected_pads: 1,
+        }
+    );
+
+    let deleted = rendered(handlers::tag::delete(&ctx, "new".into()));
+    assert_eq!(
+        deleted,
+        TagRegistryResult::Deleted {
+            name: "new".into(),
+            affected_pads: 1,
+        }
     );
 }
 

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -595,6 +595,343 @@ fn empty_delete_completed_preserves_text_and_exposes_a_typed_no_op() {
     assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
 }
 
+// =============================================================================
+// Semantic tag catalog and mutation outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn tag_catalog_preserves_empty_and_ordered_human_and_structured_results() {
+    let empty_fx = Fixture::new();
+    let (app, cmd) = empty_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        empty_fx.argv(&["tag", "list", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "No tags defined\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        empty_fx.argv(&["tag", "list", "--output", "json"]),
+    );
+    json.assert_success();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-catalog-empty.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        expected
+    );
+    drop(json);
+
+    let listed_fx = Fixture::new();
+    let state = listed_fx.app_state();
+    state
+        .with_api(|api| api.create_tag(state.scope, "work"))
+        .unwrap();
+    state
+        .with_api(|api| api.create_tag(state.scope, "rust"))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = listed_fx.read_app();
+    let debug = TestHarness::new().run(
+        &app,
+        cmd.clone(),
+        listed_fx.argv(&["tag", "list", "--output", "term-debug"]),
+    );
+    debug.assert_success();
+    assert_eq!(debug.stdout(), "[info]work[/info]\n[info]rust[/info]\n");
+    drop(debug);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        listed_fx.argv(&["tag", "list", "--output", "json"]),
+    );
+    json.assert_success();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-catalog-listed.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        expected
+    );
+    drop(json);
+
+    let singleton_fx = Fixture::new();
+    let state = singleton_fx.app_state();
+    singleton_fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = singleton_fx.read_app();
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        singleton_fx.argv(&["tag", "list", "1", "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), "work\n");
+    drop(text);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        singleton_fx.argv(&["tag", "list", "1", "--output", "json"]),
+    );
+    json.assert_success();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-catalog-singleton.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(json.stdout()).unwrap(),
+        expected
+    );
+}
+
+#[test]
+#[serial]
+fn tag_assignment_preserves_wording_styles_counts_and_no_op_kind() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "one", "");
+    fx.seed_pad(&state, "two", "");
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let debug = TestHarness::new().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&[
+            "tag",
+            "add",
+            "1",
+            "2",
+            "work",
+            "rust",
+            "--output",
+            "term-debug",
+        ]),
+    );
+    debug.assert_success();
+    debug.assert_stdout_contains("[info]Tagged 2 pads...[/info]");
+    debug.assert_stdout_contains("[success]Added tags [work, rust] to 2 pads[/success]");
+    drop(debug);
+
+    let no_op = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "add", "1", "2", "work", "rust", "--output", "text"]),
+    );
+    no_op.assert_success();
+    no_op.assert_stdout_contains("Tagged 2 pads...");
+    no_op.assert_stdout_contains("All pads already have tags [work, rust]");
+    drop(no_op);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["tag", "add", "1", "2", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-all-already-present.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+    assert_eq!(value["pads"].as_array().map(Vec::len), Some(2));
+    drop(json);
+
+    let changed_fx = Fixture::new();
+    let state = changed_fx.app_state();
+    changed_fx.seed_pad(&state, "one", "");
+    changed_fx.seed_pad(&state, "two", "");
+    drop(state);
+    let (app, cmd) = changed_fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        changed_fx.argv(&["tag", "add", "1", "2", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-assigned.json")).unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+}
+
+#[test]
+#[serial]
+fn tag_removal_preserves_wording_counts_and_none_present_no_op() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into(), "rust".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "text"]),
+    );
+    text.assert_success();
+    text.assert_stdout_contains("Untagged 1 pad...");
+    text.assert_stdout_contains("Removed tags [work, rust] from 1 pad");
+    drop(text);
+
+    let no_op = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "text"]),
+    );
+    no_op.assert_success();
+    no_op.assert_stdout_contains("No pads had tags [work, rust]");
+    drop(no_op);
+
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/tag-none-present.json"
+    ))
+    .unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+    drop(json);
+
+    let changed_fx = Fixture::new();
+    let state = changed_fx.app_state();
+    changed_fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["work".into(), "rust".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = changed_fx.read_app();
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        changed_fx.argv(&["tag", "remove", "1", "work", "rust", "--output", "json"]),
+    );
+    json.assert_success();
+    let value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-removed.json")).unwrap();
+    assert_eq!(
+        serde_json::json!({
+            "action": value["action"].clone(),
+            "requested_tags": value["requested_tags"].clone(),
+            "modified_pads": value["modified_pads"].clone(),
+        }),
+        expected
+    );
+}
+
+#[test]
+#[serial]
+fn tag_registry_mutations_preserve_names_counts_and_human_wording() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["old".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = fx.read_app();
+
+    let rename = TestHarness::new().no_color().run(
+        &app,
+        cmd.clone(),
+        fx.argv(&["tag", "rename", "old", "new", "--output", "text"]),
+    );
+    rename.assert_success();
+    assert_eq!(
+        rename.stdout(),
+        "Renamed tag 'old' to 'new'\nUpdated 1 pad\n"
+    );
+    drop(rename);
+
+    let delete = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        fx.argv(&["tag", "delete", "new", "--output", "text"]),
+    );
+    delete.assert_success();
+    assert_eq!(delete.stdout(), "Deleted tag 'new'\nRemoved from 1 pad\n");
+    drop(delete);
+
+    let structured_fx = Fixture::new();
+    let state = structured_fx.app_state();
+    structured_fx.seed_pad(&state, "target", "");
+    state
+        .with_api(|api| api.add_tags_to_pads(state.scope, &["1"], &["old".into()]))
+        .unwrap();
+    drop(state);
+    let (app, cmd) = structured_fx.read_app();
+
+    let rename = TestHarness::new().run(
+        &app,
+        cmd.clone(),
+        structured_fx.argv(&["tag", "rename", "old", "new", "--output", "json"]),
+    );
+    rename.assert_success();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-renamed.json")).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(rename.stdout()).unwrap(),
+        expected
+    );
+    drop(rename);
+
+    let delete = TestHarness::new().run(
+        &app,
+        cmd,
+        structured_fx.argv(&["tag", "delete", "new", "--output", "json"]),
+    );
+    delete.assert_success();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/tag-deleted.json")).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(delete.stdout()).unwrap(),
+        expected
+    );
+}
+
 #[test]
 #[serial]
 fn uuid_flag_reaches_the_view_handler() {

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -82,6 +82,8 @@ pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
 pub use commands::init::InitializationOutcome;
 pub use commands::purge::PurgeOutcome;
+pub use commands::tagging::{TaggingOutcome, TaggingResult};
+pub use commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
 pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
 
 #[cfg(test)]

--- a/crates/padzapp/src/api/tags.rs
+++ b/crates/padzapp/src/api/tags.rs
@@ -1,6 +1,11 @@
 //! Tag registry CRUD and per-pad tagging.
+//!
+//! The facade preserves selector parsing while returning dedicated catalog and
+//! mutation outcomes. It does not turn those facts into presentation messages.
 
 use crate::commands;
+use crate::commands::tagging::TaggingResult;
+use crate::commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
 use crate::error::Result;
 use crate::model::Scope;
 use crate::store::DataStore;
@@ -9,59 +14,59 @@ use super::selectors::parse_selectors;
 use super::PadzApi;
 
 impl<S: DataStore> PadzApi<S> {
-    /// List all tags in the registry.
-    pub fn list_tags(&self, scope: Scope) -> Result<commands::CmdResult> {
+    /// List all tags in registry order, including an explicit empty state.
+    pub fn list_tags(&self, scope: Scope) -> Result<TagCatalogOutcome> {
         commands::tags::list_tags(&self.store, scope)
     }
 
-    /// List tags for specific pads.
+    /// List the unique tags for specific pads in lexical order.
     pub fn list_pad_tags<I: AsRef<str>>(
         &self,
         scope: Scope,
         indexes: &[I],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TagCatalogOutcome> {
         let selectors = parse_selectors(indexes)?;
         commands::tags::list_pad_tags(&self.store, scope, &selectors)
     }
 
-    /// Create a new tag in the registry.
-    pub fn create_tag(&mut self, scope: Scope, name: &str) -> Result<commands::CmdResult> {
+    /// Create a new tag and return its semantic registry action.
+    pub fn create_tag(&mut self, scope: Scope, name: &str) -> Result<TagRegistryOutcome> {
         commands::tags::create_tag(&mut self.store, scope, name)
     }
 
-    /// Delete a tag from the registry (cascades to remove from all pads).
-    pub fn delete_tag(&mut self, scope: Scope, name: &str) -> Result<commands::CmdResult> {
+    /// Delete a tag and report how many pads the cascade changed.
+    pub fn delete_tag(&mut self, scope: Scope, name: &str) -> Result<TagRegistryOutcome> {
         commands::tags::delete_tag(&mut self.store, scope, name)
     }
 
-    /// Rename a tag in the registry (updates all pads).
+    /// Rename a tag and report how many pads were updated.
     pub fn rename_tag(
         &mut self,
         scope: Scope,
         old_name: &str,
         new_name: &str,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TagRegistryOutcome> {
         commands::tags::rename_tag(&mut self.store, scope, old_name, new_name)
     }
 
-    /// Add tags to pads.
+    /// Add requested tags and distinguish changed pads from an all-present no-op.
     pub fn add_tags_to_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         tags: &[String],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TaggingResult> {
         let selectors = parse_selectors(indexes)?;
         commands::tagging::add_tags(&mut self.store, scope, &selectors, tags)
     }
 
-    /// Remove tags from pads.
+    /// Remove requested tags and distinguish changed pads from a none-present no-op.
     pub fn remove_tags_from_pads<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         tags: &[String],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<TaggingResult> {
         let selectors = parse_selectors(indexes)?;
         commands::tagging::remove_tags(&mut self.store, scope, &selectors, tags)
     }
@@ -70,6 +75,8 @@ impl<S: DataStore> PadzApi<S> {
 #[cfg(test)]
 mod tests {
     use crate::api::test_support::make_api;
+    use crate::commands::tagging::TaggingOutcome;
+    use crate::commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
     use crate::model::Scope;
 
     #[test]
@@ -79,7 +86,12 @@ mod tests {
 
         let result = api.list_tags(Scope::Project).unwrap();
 
-        assert!(result.messages.iter().any(|m| m.content.contains("work")));
+        assert_eq!(
+            result,
+            TagCatalogOutcome::Listed {
+                tags: vec!["work".into()]
+            }
+        );
     }
 
     #[test]
@@ -88,7 +100,13 @@ mod tests {
 
         let result = api.create_tag(Scope::Project, "rust").unwrap();
 
-        assert!(result.messages[0].content.contains("Created tag 'rust'"));
+        assert_eq!(
+            result,
+            TagRegistryOutcome::Created {
+                name: "rust".into(),
+                affected_pads: 0,
+            }
+        );
     }
 
     #[test]
@@ -98,7 +116,13 @@ mod tests {
 
         let result = api.delete_tag(Scope::Project, "work").unwrap();
 
-        assert!(result.messages[0].content.contains("Deleted tag 'work'"));
+        assert_eq!(
+            result,
+            TagRegistryOutcome::Deleted {
+                name: "work".into(),
+                affected_pads: 0,
+            }
+        );
     }
 
     #[test]
@@ -110,9 +134,14 @@ mod tests {
             .rename_tag(Scope::Project, "old-name", "new-name")
             .unwrap();
 
-        assert!(result.messages[0]
-            .content
-            .contains("Renamed tag 'old-name' to 'new-name'"));
+        assert_eq!(
+            result,
+            TagRegistryOutcome::Renamed {
+                old_name: "old-name".into(),
+                new_name: "new-name".into(),
+                affected_pads: 0,
+            }
+        );
     }
 
     #[test]
@@ -126,7 +155,13 @@ mod tests {
             .add_tags_to_pads(Scope::Project, &["1"], &["work".to_string()])
             .unwrap();
 
-        assert!(result.messages[0].content.contains("Added tag"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Assigned {
+                requested_tags: vec!["work".into()],
+                modified_pads: 1,
+            }
+        );
         assert!(result.affected_pads[0]
             .pad
             .metadata
@@ -147,7 +182,13 @@ mod tests {
             .remove_tags_from_pads(Scope::Project, &["1"], &["work".to_string()])
             .unwrap();
 
-        assert!(result.messages[0].content.contains("Removed tag"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Removed {
+                requested_tags: vec!["work".into()],
+                modified_pads: 1,
+            }
+        );
         assert!(result.affected_pads[0].pad.metadata.tags.is_empty());
     }
 }

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -31,11 +31,11 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! Initialization, doctor, purge, and artifact-producing commands use dedicated
-//! outcome types where a generic result would obscure the operation's facts. Pad
-//! mutations that still use [`CmdResult`] attach presentation-free [`CmdOutcome`]
-//! and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides how to render
-//! every result.
+//! Initialization, doctor, purge, tag catalog/mutation, and artifact-producing
+//! commands use dedicated outcome types where a generic result would obscure the
+//! operation's facts. Pad mutations that still use [`CmdResult`] attach
+//! presentation-free [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI,
+//! web, etc.) decides how to render every result.
 //!
 //! ## Testing Strategy
 //!
@@ -62,6 +62,8 @@
 //! - [`paths`]: Get filesystem paths to pads
 //! - [`init`]: Initialize scope directories
 //! - [`doctor`]: Verify and fix data consistency
+//! - [`tags`]: List and mutate the tag registry
+//! - [`tagging`]: Assign and remove tags on selected pads
 //! - [`helpers`]: Shared utilities (index resolution, etc.)
 
 use crate::error::{PadzError, Result};

--- a/crates/padzapp/src/commands/tagging.rs
+++ b/crates/padzapp/src/commands/tagging.rs
@@ -1,63 +1,83 @@
-//! Pad tagging commands.
+//! Semantic per-pad tag assignment and removal.
 //!
-//! This module provides operations for managing tags on pads:
-//! - `add_tags`: Add tags to pads (auto-creates tags if needed)
-//! - `remove_tags`: Remove specific tags from pads
+//! Requested tag order, changed-pad counts, and no-op distinctions are domain
+//! facts. Human sentences, brackets, pluralization, and styles belong to clients.
 
 use crate::attributes::AttrValue;
 use crate::commands::helpers::{indexed_pads, resolve_selectors, TitleBucket};
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayIndex, DisplayPad, PadSelector};
 use crate::model::Scope;
-use crate::store::Bucket;
-use crate::store::DataStore;
+use crate::store::{Bucket, DataStore};
 
-/// Add tags to selected pads.
+/// The semantic result of applying or removing requested tags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaggingOutcome {
+    Assigned {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+    AllAlreadyPresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+    Removed {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+    NonePresent {
+        requested_tags: Vec<String>,
+        modified_pads: usize,
+    },
+}
+
+/// Selected pads after a tag mutation, paired with its semantic outcome.
+#[derive(Debug, Clone)]
+pub struct TaggingResult {
+    pub affected_pads: Vec<DisplayPad>,
+    pub outcome: TaggingOutcome,
+}
+
+/// Add tags to selected pads, auto-creating missing registry entries.
 ///
-/// Tags are auto-created in the registry if they don't already exist.
-/// Adding a tag that a pad already has is a no-op (idempotent).
+/// Adding tags that every selected pad already carries is an explicit no-op.
 pub fn add_tags<S: DataStore>(
     store: &mut S,
     scope: Scope,
     selectors: &[PadSelector],
     tags: &[String],
-) -> Result<CmdResult> {
+) -> Result<TaggingResult> {
     if tags.is_empty() {
         return Err(PadzError::Api("No tags specified".to_string()));
     }
 
-    // Auto-create tags that don't exist in the registry
     let mut registry = store.load_tags(scope)?;
-    let mut created_tags = Vec::new();
+    let mut registry_changed = false;
     for tag in tags {
-        if !registry.iter().any(|t| t.name == *tag) {
+        if !registry.iter().any(|entry| entry.name == *tag) {
             use crate::tags::{validate_tag_name, TagEntry};
             validate_tag_name(tag).map_err(|e| PadzError::Api(e.to_string()))?;
             registry.push(TagEntry::new(tag.clone()));
-            created_tags.push(tag.clone());
+            registry_changed = true;
         }
     }
-    if !created_tags.is_empty() {
+    if registry_changed {
         store.save_tags(scope, &registry)?;
     }
 
     let resolved = resolve_selectors(store, scope, selectors, false, TitleBucket::Active)?;
-    let mut result = CmdResult::default();
-    let mut modified_count = 0;
+    let mut affected_pads = Vec::with_capacity(resolved.len());
+    let mut modified_pads = 0;
 
     for (display_index, uuid) in resolved {
         let mut pad = store.get_pad(&uuid, scope, Bucket::Active)?;
-
-        // Get current tags via attribute API
         let current_tags = pad
             .metadata
             .get_attr("tags")
-            .and_then(|v| v.as_list().map(|l| l.to_vec()))
+            .and_then(|value| value.as_list().map(<[String]>::to_vec))
             .unwrap_or_default();
         let original_count = current_tags.len();
 
-        // Add tags that aren't already present
         let mut new_tags = current_tags;
         for tag in tags {
             if !new_tags.contains(tag) {
@@ -65,19 +85,16 @@ pub fn add_tags<S: DataStore>(
             }
         }
 
-        // Sort and save if changed
         if new_tags.len() > original_count {
             new_tags.sort();
             pad.metadata.set_attr("tags", AttrValue::List(new_tags));
             store.save_pad(&pad, scope, Bucket::Active)?;
-            modified_count += 1;
+            modified_pads += 1;
         }
 
-        // Re-index to get updated pad with correct index
-        let indexed = indexed_pads(store, scope)?;
-        if let Some(dp) = find_pad_by_uuid_any(&indexed, uuid) {
-            result.affected_pads.push(DisplayPad {
-                pad: dp.pad.clone(),
+        if let Some(display_pad) = find_pad_by_uuid_any(&indexed_pads(store, scope)?, uuid) {
+            affected_pads.push(DisplayPad {
+                pad: display_pad.pad.clone(),
                 index: display_index
                     .last()
                     .cloned()
@@ -88,72 +105,65 @@ pub fn add_tags<S: DataStore>(
         }
     }
 
-    let tag_list = tags.join(", ");
-    if modified_count > 0 {
-        result.add_message(CmdMessage::success(format!(
-            "Added tag{} [{}] to {} pad{}",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list,
-            modified_count,
-            if modified_count == 1 { "" } else { "s" }
-        )));
+    let requested_tags = tags.to_vec();
+    let outcome = if modified_pads == 0 {
+        TaggingOutcome::AllAlreadyPresent {
+            requested_tags,
+            modified_pads,
+        }
     } else {
-        result.add_message(CmdMessage::info(format!(
-            "All pads already have tag{} [{}]",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list
-        )));
-    }
+        TaggingOutcome::Assigned {
+            requested_tags,
+            modified_pads,
+        }
+    };
 
-    Ok(result)
+    Ok(TaggingResult {
+        affected_pads,
+        outcome,
+    })
 }
 
-/// Remove specific tags from selected pads.
+/// Remove requested tags from selected pads.
 ///
-/// Removing a tag that a pad doesn't have is a no-op (idempotent).
+/// A request where none of the selected pads carries any requested tag is an
+/// explicit no-op. Registry entries are not removed.
 pub fn remove_tags<S: DataStore>(
     store: &mut S,
     scope: Scope,
     selectors: &[PadSelector],
     tags: &[String],
-) -> Result<CmdResult> {
+) -> Result<TaggingResult> {
     if tags.is_empty() {
         return Err(PadzError::Api("No tags specified".to_string()));
     }
 
     let resolved = resolve_selectors(store, scope, selectors, false, TitleBucket::Active)?;
-    let mut result = CmdResult::default();
-    let mut modified_count = 0;
+    let mut affected_pads = Vec::with_capacity(resolved.len());
+    let mut modified_pads = 0;
 
     for (display_index, uuid) in resolved {
         let mut pad = store.get_pad(&uuid, scope, Bucket::Active)?;
-
-        // Get current tags via attribute API
         let current_tags = pad
             .metadata
             .get_attr("tags")
-            .and_then(|v| v.as_list().map(|l| l.to_vec()))
+            .and_then(|value| value.as_list().map(<[String]>::to_vec))
             .unwrap_or_default();
         let original_count = current_tags.len();
-
-        // Remove specified tags
-        let new_tags: Vec<String> = current_tags
+        let new_tags = current_tags
             .into_iter()
-            .filter(|t| !tags.contains(t))
-            .collect();
+            .filter(|tag| !tags.contains(tag))
+            .collect::<Vec<_>>();
 
-        // Save if changed
         if new_tags.len() < original_count {
             pad.metadata.set_attr("tags", AttrValue::List(new_tags));
             store.save_pad(&pad, scope, Bucket::Active)?;
-            modified_count += 1;
+            modified_pads += 1;
         }
 
-        // Re-index to get updated pad with correct index
-        let indexed = indexed_pads(store, scope)?;
-        if let Some(dp) = find_pad_by_uuid_any(&indexed, uuid) {
-            result.affected_pads.push(DisplayPad {
-                pad: dp.pad.clone(),
+        if let Some(display_pad) = find_pad_by_uuid_any(&indexed_pads(store, scope)?, uuid) {
+            affected_pads.push(DisplayPad {
+                pad: display_pad.pad.clone(),
                 index: display_index
                     .last()
                     .cloned()
@@ -164,33 +174,31 @@ pub fn remove_tags<S: DataStore>(
         }
     }
 
-    let tag_list = tags.join(", ");
-    if modified_count > 0 {
-        result.add_message(CmdMessage::success(format!(
-            "Removed tag{} [{}] from {} pad{}",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list,
-            modified_count,
-            if modified_count == 1 { "" } else { "s" }
-        )));
+    let requested_tags = tags.to_vec();
+    let outcome = if modified_pads == 0 {
+        TaggingOutcome::NonePresent {
+            requested_tags,
+            modified_pads,
+        }
     } else {
-        result.add_message(CmdMessage::info(format!(
-            "No pads had tag{} [{}]",
-            if tags.len() == 1 { "" } else { "s" },
-            tag_list
-        )));
-    }
+        TaggingOutcome::Removed {
+            requested_tags,
+            modified_pads,
+        }
+    };
 
-    Ok(result)
+    Ok(TaggingResult {
+        affected_pads,
+        outcome,
+    })
 }
 
-/// Find a pad by UUID in the indexed tree (any index type).
 fn find_pad_by_uuid_any(pads: &[DisplayPad], uuid: uuid::Uuid) -> Option<&DisplayPad> {
-    for dp in pads {
-        if dp.pad.metadata.id == uuid {
-            return Some(dp);
+    for pad in pads {
+        if pad.pad.metadata.id == uuid {
+            return Some(pad);
         }
-        if let Some(found) = find_pad_by_uuid_any(&dp.children, uuid) {
+        if let Some(found) = find_pad_by_uuid_any(&pad.children, uuid) {
             return Some(found);
         }
     }
@@ -204,168 +212,163 @@ mod tests {
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
 
-    fn setup_store_with_tag() -> BucketedStore<MemBackend> {
-        let mut store = BucketedStore::new(
+    fn store() -> BucketedStore<MemBackend> {
+        BucketedStore::new(
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
+        )
+    }
+
+    fn selectors(count: usize) -> Vec<PadSelector> {
+        (1..=count)
+            .map(|index| PadSelector::Path(vec![DisplayIndex::Regular(index)]))
+            .collect()
+    }
+
+    #[test]
+    fn assigning_one_tag_returns_requested_tags_and_modified_pad_count() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+
+        let result = add_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
+
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Assigned {
+                requested_tags: vec!["work".into()],
+                modified_pads: 1,
+            }
         );
-        tags::create_tag(&mut store, Scope::Project, "work").unwrap();
-        tags::create_tag(&mut store, Scope::Project, "rust").unwrap();
-        store
+        assert_eq!(result.affected_pads[0].pad.metadata.tags, vec!["work"]);
+        assert!(store
+            .load_tags(Scope::Project)
+            .unwrap()
+            .iter()
+            .any(|tag| tag.name == "work"));
     }
 
     #[test]
-    fn test_add_tags_single_pad() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(
+    fn assigning_multiple_tags_counts_pads_not_tag_applications() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "One".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Two".into(), "".into(), None).unwrap();
+        add_tags(
             &mut store,
             Scope::Project,
-            &selectors,
-            &["work".to_string()],
+            &selectors(1),
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
-        assert!(result.messages[0].content.contains("Added tag"));
+        let result = add_tags(
+            &mut store,
+            Scope::Project,
+            &selectors(2),
+            &["work".into(), "rust".into()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Assigned {
+                requested_tags: vec!["work".into(), "rust".into()],
+                modified_pads: 1,
+            }
+        );
+        assert_eq!(result.affected_pads.len(), 2);
+    }
+
+    #[test]
+    fn repeated_assignment_is_a_distinct_all_already_present_no_op() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        add_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
+
+        let result = add_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
+
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::AllAlreadyPresent {
+                requested_tags: vec!["work".into()],
+                modified_pads: 0,
+            }
+        );
         assert_eq!(result.affected_pads.len(), 1);
-        assert!(result.affected_pads[0]
-            .pad
-            .metadata
-            .tags
-            .contains(&"work".to_string()));
     }
 
     #[test]
-    fn test_add_tags_multiple_tags() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string(), "rust".to_string()],
-        )
-        .unwrap();
-
-        assert!(result.messages[0].content.contains("Added tags"));
-        let tags = &result.affected_pads[0].pad.metadata.tags;
-        assert!(tags.contains(&"work".to_string()));
-        assert!(tags.contains(&"rust".to_string()));
-    }
-
-    #[test]
-    fn test_add_tags_auto_creates_tag() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["newbie".to_string()],
-        )
-        .unwrap();
-
-        assert!(result.messages[0].content.contains("Added tag"));
-        assert!(result.affected_pads[0]
-            .pad
-            .metadata
-            .tags
-            .contains(&"newbie".to_string()));
-
-        // Verify the tag was auto-created in the registry
-        let registry = store.load_tags(Scope::Project).unwrap();
-        assert!(registry.iter().any(|t| t.name == "newbie"));
-    }
-
-    #[test]
-    fn test_add_tags_idempotent() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
+    fn removing_tags_returns_requested_tags_and_modified_pad_count() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
         add_tags(
             &mut store,
             Scope::Project,
-            &selectors,
-            &["work".to_string()],
-        )
-        .unwrap();
-
-        // Adding same tag again
-        let result = add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string()],
-        )
-        .unwrap();
-
-        assert!(result.messages[0].content.contains("already have"));
-    }
-
-    #[test]
-    fn test_remove_tags() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
-
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        add_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string()],
+            &selectors(1),
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
         let result = remove_tags(
             &mut store,
             Scope::Project,
-            &selectors,
-            &["work".to_string()],
+            &selectors(1),
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
-        assert!(result.messages[0].content.contains("Removed tag"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::Removed {
+                requested_tags: vec!["work".into(), "rust".into()],
+                modified_pads: 1,
+            }
+        );
         assert!(result.affected_pads[0].pad.metadata.tags.is_empty());
     }
 
     #[test]
-    fn test_remove_tags_not_present() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
+    fn removing_absent_tags_is_a_distinct_none_present_no_op() {
+        let mut store = store();
+        tags::create_tag(&mut store, Scope::Project, "work").unwrap();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
 
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = remove_tags(
-            &mut store,
-            Scope::Project,
-            &selectors,
-            &["work".to_string()],
-        )
-        .unwrap();
+        let result =
+            remove_tags(&mut store, Scope::Project, &selectors(1), &["work".into()]).unwrap();
 
-        assert!(result.messages[0].content.contains("No pads had"));
+        assert_eq!(
+            result.outcome,
+            TaggingOutcome::NonePresent {
+                requested_tags: vec!["work".into()],
+                modified_pads: 0,
+            }
+        );
+        assert_eq!(result.affected_pads.len(), 1);
     }
 
     #[test]
-    fn test_add_tags_no_tags_error() {
-        let mut store = setup_store_with_tag();
-        create::run(&mut store, Scope::Project, "Test".into(), "".into(), None).unwrap();
+    fn empty_tag_requests_preserve_validation_error() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        let error = add_tags(&mut store, Scope::Project, &selectors(1), &[]).unwrap_err();
+        assert!(error.to_string().contains("No tags specified"));
+    }
 
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = add_tags(&mut store, Scope::Project, &selectors, &[]);
+    #[test]
+    fn invalid_auto_created_tag_preserves_validation_error_without_registry_write() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("No tags specified"));
+        let error = add_tags(
+            &mut store,
+            Scope::Project,
+            &selectors(1),
+            &["-invalid".into()],
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must start"));
+        assert!(store.load_tags(Scope::Project).unwrap().is_empty());
     }
 }

--- a/crates/padzapp/src/commands/tags.rs
+++ b/crates/padzapp/src/commands/tags.rs
@@ -1,43 +1,68 @@
-//! Tag management commands.
+//! Semantic tag-registry operations.
 //!
-//! This module provides CRUD operations for the tag registry:
-//! - `list_tags`: List all tags in a scope
-//! - `create_tag`: Create a new tag
-//! - `delete_tag`: Delete a tag (cascades to pads)
-//! - `rename_tag`: Rename a tag (updates all pads)
+//! Registry order and affected-pad counts are application facts. Human prose,
+//! pluralization, line layout, and styling belong to clients.
 
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::model::Scope;
-use crate::store::Bucket;
-use crate::store::DataStore;
+use crate::store::{Bucket, DataStore};
 use crate::tags::{validate_tag_name, TagEntry};
 
-/// List all tags in the registry.
-pub fn list_tags<S: DataStore>(store: &S, scope: Scope) -> Result<CmdResult> {
-    let tags = store.load_tags(scope)?;
-    let mut result = CmdResult::default();
-
-    if tags.is_empty() {
-        result.add_message(CmdMessage::info("No tags defined"));
-    } else {
-        for tag in &tags {
-            result.add_message(CmdMessage::info(tag.name.clone()));
-        }
-    }
-
-    Ok(result)
+/// An ordered catalog of tag names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TagCatalogOutcome {
+    /// No tags are defined for the requested registry or pad selection.
+    Empty,
+    /// Tags in the order the command contract exposes them.
+    Listed { tags: Vec<String> },
 }
 
-/// List tags for specific pads.
+impl TagCatalogOutcome {
+    fn from_names(tags: Vec<String>) -> Self {
+        if tags.is_empty() {
+            Self::Empty
+        } else {
+            Self::Listed { tags }
+        }
+    }
+}
+
+/// A completed tag-registry mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TagRegistryOutcome {
+    Created {
+        name: String,
+        affected_pads: usize,
+    },
+    Deleted {
+        name: String,
+        affected_pads: usize,
+    },
+    Renamed {
+        old_name: String,
+        new_name: String,
+        affected_pads: usize,
+    },
+}
+
+/// List all tags in registry order.
+pub fn list_tags<S: DataStore>(store: &S, scope: Scope) -> Result<TagCatalogOutcome> {
+    let tags = store
+        .load_tags(scope)?
+        .into_iter()
+        .map(|tag| tag.name)
+        .collect();
+    Ok(TagCatalogOutcome::from_names(tags))
+}
+
+/// List the unique tags on selected pads in lexical order.
 ///
-/// Collects all unique tags from the resolved pads and outputs them
-/// in the same format as `list_tags` (one tag name per line).
+/// The lexical ordering preserves the established `tag list <id>...` contract.
 pub fn list_pad_tags<S: DataStore>(
     store: &S,
     scope: Scope,
     selectors: &[crate::index::PadSelector],
-) -> Result<CmdResult> {
+) -> Result<TagCatalogOutcome> {
     use crate::commands::helpers::{resolve_selectors, TitleBucket};
     use std::collections::BTreeSet;
 
@@ -46,446 +71,283 @@ pub fn list_pad_tags<S: DataStore>(
 
     for (_display_index, uuid) in resolved {
         let pad = store.get_pad(&uuid, scope, Bucket::Active)?;
-        for tag in &pad.metadata.tags {
-            all_tags.insert(tag.clone());
-        }
+        all_tags.extend(pad.metadata.tags);
     }
 
-    let mut result = CmdResult::default();
-    if all_tags.is_empty() {
-        result.add_message(CmdMessage::info("No tags defined"));
-    } else {
-        for tag in &all_tags {
-            result.add_message(CmdMessage::info(tag.clone()));
-        }
-    }
-
-    Ok(result)
+    Ok(TagCatalogOutcome::from_names(
+        all_tags.into_iter().collect(),
+    ))
 }
 
 /// Create a new tag in the registry.
 ///
-/// Returns an error if the tag name is invalid or already exists.
-pub fn create_tag<S: DataStore>(store: &mut S, scope: Scope, name: &str) -> Result<CmdResult> {
-    // Validate tag name
+/// Returns an error if the tag name is invalid or already exists. Creation does
+/// not modify any pads, so the semantic affected count is always zero.
+pub fn create_tag<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    name: &str,
+) -> Result<TagRegistryOutcome> {
     validate_tag_name(name).map_err(|e| PadzError::Api(e.to_string()))?;
 
-    // Check if tag already exists
     let mut tags = store.load_tags(scope)?;
-    if tags.iter().any(|t| t.name == name) {
+    if tags.iter().any(|tag| tag.name == name) {
         return Err(PadzError::Api(format!("Tag '{}' already exists", name)));
     }
 
-    // Create and save the tag
-    let tag = TagEntry::new(name.to_string());
-    tags.push(tag);
+    tags.push(TagEntry::new(name.to_string()));
     store.save_tags(scope, &tags)?;
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!("Created tag '{}'", name)));
-    Ok(result)
+    Ok(TagRegistryOutcome::Created {
+        name: name.to_string(),
+        affected_pads: 0,
+    })
 }
 
-/// Delete a tag from the registry.
-///
-/// This cascades to all pads that have the tag - the tag is removed from their metadata.
-pub fn delete_tag<S: DataStore>(store: &mut S, scope: Scope, name: &str) -> Result<CmdResult> {
+/// Delete a registry tag and remove it from every active pad that carries it.
+pub fn delete_tag<S: DataStore>(
+    store: &mut S,
+    scope: Scope,
+    name: &str,
+) -> Result<TagRegistryOutcome> {
     let mut tags = store.load_tags(scope)?;
-
-    // Find and remove the tag
     let original_len = tags.len();
-    tags.retain(|t| t.name != name);
+    tags.retain(|tag| tag.name != name);
 
     if tags.len() == original_len {
         return Err(PadzError::Api(format!("Tag '{}' not found", name)));
     }
 
-    // Save updated tag registry
     store.save_tags(scope, &tags)?;
 
-    // Cascade: remove tag from all pads
-    let pads = store.list_pads(scope, Bucket::Active)?;
-    let mut affected_count = 0;
-    for mut pad in pads {
-        if pad.metadata.tags.contains(&name.to_string()) {
-            pad.metadata.tags.retain(|t| t != name);
+    let mut affected_pads = 0;
+    for mut pad in store.list_pads(scope, Bucket::Active)? {
+        if pad.metadata.tags.iter().any(|tag| tag == name) {
+            pad.metadata.tags.retain(|tag| tag != name);
             store.save_pad(&pad, scope, Bucket::Active)?;
-            affected_count += 1;
+            affected_pads += 1;
         }
     }
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!("Deleted tag '{}'", name)));
-    if affected_count > 0 {
-        result.add_message(CmdMessage::info(format!(
-            "Removed from {} pad{}",
-            affected_count,
-            if affected_count == 1 { "" } else { "s" }
-        )));
-    }
-    Ok(result)
+    Ok(TagRegistryOutcome::Deleted {
+        name: name.to_string(),
+        affected_pads,
+    })
 }
 
-/// Rename a tag in the registry.
-///
-/// This updates all pads that have the old tag name to use the new name.
+/// Rename a registry tag and update every active pad that carries it.
 pub fn rename_tag<S: DataStore>(
     store: &mut S,
     scope: Scope,
     old_name: &str,
     new_name: &str,
-) -> Result<CmdResult> {
-    // Validate new tag name
+) -> Result<TagRegistryOutcome> {
     validate_tag_name(new_name).map_err(|e| PadzError::Api(e.to_string()))?;
 
     let mut tags = store.load_tags(scope)?;
-
-    // Check if old tag exists
     let tag_idx = tags
         .iter()
-        .position(|t| t.name == old_name)
+        .position(|tag| tag.name == old_name)
         .ok_or_else(|| PadzError::Api(format!("Tag '{}' not found", old_name)))?;
 
-    // Check if new name already exists
-    if tags.iter().any(|t| t.name == new_name) {
+    if tags.iter().any(|tag| tag.name == new_name) {
         return Err(PadzError::Api(format!("Tag '{}' already exists", new_name)));
     }
 
-    // Update the tag name in the registry
     tags[tag_idx].name = new_name.to_string();
     store.save_tags(scope, &tags)?;
 
-    // Update all pads that have this tag
-    let pads = store.list_pads(scope, Bucket::Active)?;
-    let mut affected_count = 0;
-    for mut pad in pads {
-        if let Some(pos) = pad.metadata.tags.iter().position(|t| t == old_name) {
+    let mut affected_pads = 0;
+    for mut pad in store.list_pads(scope, Bucket::Active)? {
+        if let Some(pos) = pad.metadata.tags.iter().position(|tag| tag == old_name) {
             pad.metadata.tags[pos] = new_name.to_string();
             store.save_pad(&pad, scope, Bucket::Active)?;
-            affected_count += 1;
+            affected_pads += 1;
         }
     }
 
-    let mut result = CmdResult::default();
-    result.add_message(CmdMessage::success(format!(
-        "Renamed tag '{}' to '{}'",
-        old_name, new_name
-    )));
-    if affected_count > 0 {
-        result.add_message(CmdMessage::info(format!(
-            "Updated {} pad{}",
-            affected_count,
-            if affected_count == 1 { "" } else { "s" }
-        )));
-    }
-    Ok(result)
+    Ok(TagRegistryOutcome::Renamed {
+        old_name: old_name.to_string(),
+        new_name: new_name.to_string(),
+        affected_pads,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::create;
+    use crate::commands::{create, tagging};
+    use crate::index::{DisplayIndex, PadSelector};
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
 
-    #[test]
-    fn test_list_tags_empty() {
-        let store = BucketedStore::new(
+    fn store() -> BucketedStore<MemBackend> {
+        BucketedStore::new(
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
             MemBackend::new(),
-        );
-        let result = list_tags(&store, Scope::Project).unwrap();
-        assert!(result.messages[0].content.contains("No tags defined"));
+        )
     }
 
     #[test]
-    fn test_list_tags_no_preamble() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
+    fn empty_registry_is_an_explicit_catalog_state() {
+        assert_eq!(
+            list_tags(&store(), Scope::Project).unwrap(),
+            TagCatalogOutcome::Empty
         );
+    }
+
+    #[test]
+    fn registry_catalog_preserves_creation_order() {
+        let mut store = store();
         create_tag(&mut store, Scope::Project, "work").unwrap();
         create_tag(&mut store, Scope::Project, "rust").unwrap();
 
-        let result = list_tags(&store, Scope::Project).unwrap();
-        // Should just be the tag names, no "X tags defined" preamble
-        assert_eq!(result.messages.len(), 2);
-        assert_eq!(result.messages[0].content, "work");
-        assert_eq!(result.messages[1].content, "rust");
+        assert_eq!(
+            list_tags(&store, Scope::Project).unwrap(),
+            TagCatalogOutcome::Listed {
+                tags: vec!["work".into(), "rust".into()]
+            }
+        );
     }
 
     #[test]
-    fn test_create_tag() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = create_tag(&mut store, Scope::Project, "work").unwrap();
-        assert!(result.messages[0].content.contains("Created tag 'work'"));
+    fn create_returns_the_name_and_zero_affected_pads() {
+        let mut store = store();
 
-        // Verify tag exists
-        let tags = store.load_tags(Scope::Project).unwrap();
-        assert_eq!(tags.len(), 1);
-        assert_eq!(tags[0].name, "work");
+        assert_eq!(
+            create_tag(&mut store, Scope::Project, "work").unwrap(),
+            TagRegistryOutcome::Created {
+                name: "work".into(),
+                affected_pads: 0,
+            }
+        );
+        assert_eq!(store.load_tags(Scope::Project).unwrap()[0].name, "work");
     }
 
     #[test]
-    fn test_create_tag_invalid_name() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = create_tag(&mut store, Scope::Project, "-invalid");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_create_tag_duplicate() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
+    fn create_preserves_invalid_and_duplicate_errors() {
+        let mut store = store();
+        assert!(create_tag(&mut store, Scope::Project, "-invalid").is_err());
         create_tag(&mut store, Scope::Project, "work").unwrap();
-        let result = create_tag(&mut store, Scope::Project, "work");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already exists"));
+        let error = create_tag(&mut store, Scope::Project, "work").unwrap_err();
+        assert!(error.to_string().contains("already exists"));
     }
 
     #[test]
-    fn test_delete_tag() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
+    fn delete_returns_its_name_and_cascade_count() {
+        let mut store = store();
         create_tag(&mut store, Scope::Project, "work").unwrap();
-
-        let result = delete_tag(&mut store, Scope::Project, "work").unwrap();
-        assert!(result.messages[0].content.contains("Deleted tag 'work'"));
-
-        // Verify tag is gone
-        let tags = store.load_tags(Scope::Project).unwrap();
-        assert!(tags.is_empty());
-    }
-
-    #[test]
-    fn test_delete_tag_not_found() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = delete_tag(&mut store, Scope::Project, "nonexistent");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[test]
-    fn test_delete_tag_cascades_to_pads() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-
-        // Create a tag and a pad with that tag
-        create_tag(&mut store, Scope::Project, "work").unwrap();
-        create::run(
+        create::run(&mut store, Scope::Project, "One".into(), "".into(), None).unwrap();
+        create::run(&mut store, Scope::Project, "Two".into(), "".into(), None).unwrap();
+        tagging::add_tags(
             &mut store,
             Scope::Project,
-            "Test Pad".into(),
-            "".into(),
-            None,
+            &[
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+            ],
+            &["work".into()],
         )
         .unwrap();
 
-        // Manually add tag to pad
-        let mut pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        pads[0].metadata.tags.push("work".to_string());
-        store
-            .save_pad(&pads[0], Scope::Project, Bucket::Active)
-            .unwrap();
-
-        // Delete the tag
-        let result = delete_tag(&mut store, Scope::Project, "work").unwrap();
-        assert!(result.messages[1].content.contains("Removed from 1 pad"));
-
-        // Verify tag is removed from pad
-        let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        assert!(pads[0].metadata.tags.is_empty());
+        assert_eq!(
+            delete_tag(&mut store, Scope::Project, "work").unwrap(),
+            TagRegistryOutcome::Deleted {
+                name: "work".into(),
+                affected_pads: 2,
+            }
+        );
+        assert!(store
+            .list_pads(Scope::Project, Bucket::Active)
+            .unwrap()
+            .iter()
+            .all(|pad| pad.metadata.tags.is_empty()));
     }
 
     #[test]
-    fn test_rename_tag() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "old-name").unwrap();
-
-        let result = rename_tag(&mut store, Scope::Project, "old-name", "new-name").unwrap();
-        assert!(result.messages[0]
-            .content
-            .contains("Renamed tag 'old-name' to 'new-name'"));
-
-        // Verify old tag is gone, new tag exists
-        let tags = store.load_tags(Scope::Project).unwrap();
-        assert_eq!(tags.len(), 1);
-        assert_eq!(tags[0].name, "new-name");
+    fn delete_preserves_not_found_error() {
+        let error = delete_tag(&mut store(), Scope::Project, "missing").unwrap_err();
+        assert!(error.to_string().contains("not found"));
     }
 
     #[test]
-    fn test_rename_tag_not_found() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        let result = rename_tag(&mut store, Scope::Project, "nonexistent", "new-name");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_rename_tag_to_existing() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "tag-a").unwrap();
-        create_tag(&mut store, Scope::Project, "tag-b").unwrap();
-
-        let result = rename_tag(&mut store, Scope::Project, "tag-a", "tag-b");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already exists"));
-    }
-
-    #[test]
-    fn test_rename_tag_invalid_new_name() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "valid").unwrap();
-
-        let result = rename_tag(&mut store, Scope::Project, "valid", "-invalid");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_rename_tag_updates_pads() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-
-        // Create a tag and a pad with that tag
-        create_tag(&mut store, Scope::Project, "old-tag").unwrap();
-        create::run(
+    fn rename_returns_both_names_and_update_count() {
+        let mut store = store();
+        create_tag(&mut store, Scope::Project, "old").unwrap();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        tagging::add_tags(
             &mut store,
             Scope::Project,
-            "Test Pad".into(),
-            "".into(),
-            None,
+            &[PadSelector::Path(vec![DisplayIndex::Regular(1)])],
+            &["old".into()],
         )
         .unwrap();
 
-        // Manually add tag to pad
-        let mut pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        pads[0].metadata.tags.push("old-tag".to_string());
-        store
-            .save_pad(&pads[0], Scope::Project, Bucket::Active)
-            .unwrap();
-
-        // Rename the tag
-        let result = rename_tag(&mut store, Scope::Project, "old-tag", "new-tag").unwrap();
-        assert!(result.messages[1].content.contains("Updated 1 pad"));
-
-        // Verify tag is updated in pad
-        let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
-        assert_eq!(pads[0].metadata.tags, vec!["new-tag"]);
+        assert_eq!(
+            rename_tag(&mut store, Scope::Project, "old", "new").unwrap(),
+            TagRegistryOutcome::Renamed {
+                old_name: "old".into(),
+                new_name: "new".into(),
+                affected_pads: 1,
+            }
+        );
+        assert_eq!(
+            store.list_pads(Scope::Project, Bucket::Active).unwrap()[0]
+                .metadata
+                .tags,
+            vec!["new"]
+        );
     }
 
     #[test]
-    fn test_list_pad_tags() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create_tag(&mut store, Scope::Project, "work").unwrap();
-        create_tag(&mut store, Scope::Project, "rust").unwrap();
-        create::run(
-            &mut store,
-            Scope::Project,
-            "Test Pad".into(),
-            "".into(),
-            None,
-        )
-        .unwrap();
+    fn rename_preserves_validation_duplicate_and_not_found_errors() {
+        let mut store = store();
+        create_tag(&mut store, Scope::Project, "one").unwrap();
+        create_tag(&mut store, Scope::Project, "two").unwrap();
 
-        // Add tags to the pad
-        use crate::commands::tagging::add_tags;
-        use crate::index::{DisplayIndex, PadSelector};
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        add_tags(
+        assert!(rename_tag(&mut store, Scope::Project, "one", "-invalid").is_err());
+        assert!(rename_tag(&mut store, Scope::Project, "one", "two")
+            .unwrap_err()
+            .to_string()
+            .contains("already exists"));
+        assert!(rename_tag(&mut store, Scope::Project, "missing", "three")
+            .unwrap_err()
+            .to_string()
+            .contains("not found"));
+    }
+
+    #[test]
+    fn pad_catalog_is_unique_and_lexically_ordered() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        let selectors = [PadSelector::Path(vec![DisplayIndex::Regular(1)])];
+        tagging::add_tags(
             &mut store,
             Scope::Project,
             &selectors,
-            &["work".to_string(), "rust".to_string()],
+            &["work".into(), "rust".into()],
         )
         .unwrap();
 
-        let result = list_pad_tags(&store, Scope::Project, &selectors).unwrap();
-        // Output is just tag names, one per message, sorted
-        assert_eq!(result.messages.len(), 2);
-        assert_eq!(result.messages[0].content, "rust");
-        assert_eq!(result.messages[1].content, "work");
+        assert_eq!(
+            list_pad_tags(&store, Scope::Project, &selectors).unwrap(),
+            TagCatalogOutcome::Listed {
+                tags: vec!["rust".into(), "work".into()]
+            }
+        );
     }
 
     #[test]
-    fn test_list_pad_tags_no_tags() {
-        let mut store = BucketedStore::new(
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-            MemBackend::new(),
-        );
-        create::run(
-            &mut store,
-            Scope::Project,
-            "Empty Pad".into(),
-            "".into(),
-            None,
-        )
-        .unwrap();
+    fn untagged_pad_has_an_explicit_empty_catalog() {
+        let mut store = store();
+        create::run(&mut store, Scope::Project, "Pad".into(), "".into(), None).unwrap();
+        let selectors = [PadSelector::Path(vec![DisplayIndex::Regular(1)])];
 
-        use crate::index::{DisplayIndex, PadSelector};
-        let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = list_pad_tags(&store, Scope::Project, &selectors).unwrap();
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].content, "No tags defined");
+        assert_eq!(
+            list_pad_tags(&store, Scope::Project, &selectors).unwrap(),
+            TagCatalogOutcome::Empty
+        );
     }
 }

--- a/crates/padzapp/src/lib.rs
+++ b/crates/padzapp/src/lib.rs
@@ -29,7 +29,7 @@
 //! │  API Layer (api.rs)                                         │
 //! │  - Thin facade over commands                                │
 //! │  - Normalizes inputs (indexes → UUIDs)                      │
-//! │  - Returns structured Result<CmdResult>                     │
+//! │  - Returns structured results and semantic outcomes         │
 //! └─────────────────────────────────────────────────────────────┘
 //!                              │
 //!                              ▼
@@ -52,7 +52,7 @@
 //!
 //! From `api.rs` inward, code:
 //! - Takes regular Rust function arguments
-//! - Returns regular Rust types (`Result<CmdResult>`)
+//! - Returns regular Rust types (`Result<CmdResult>` or dedicated outcomes)
 //! - **Never** writes to stdout/stderr
 //! - **Never** calls `std::process::exit`
 //! - **Never** assumes a terminal environment
@@ -70,8 +70,8 @@
 //! 1. **CLI**: `clap` parses `1`. `handle_delete` receives `vec!["1"]`.
 //! 2. **API**: `parse_selectors` maps `"1"` → `PadSelector::Index(Regular(1))`.
 //! 3. **Command**: Resolves to UUID, checks protection, marks as deleted.
-//! 4. **Return**: `CmdResult` with message "Deleted 1 pad".
-//! 5. **CLI**: Renders the message to terminal.
+//! 4. **Return**: A structured result containing the affected pad.
+//! 5. **CLI**: Renders compatible human feedback or serializes the facts.
 //!
 //! ## Testing Strategy
 //!


### PR DESCRIPTION
## Context

for #215

Why this approach: WS03 extends the semantic-result pattern established by #207 and integrated through WS01/#224 and WS02/#226. padzapp now returns dedicated ordered tag catalogs, registry mutation actions, and per-pad assignment/removal outcomes. Thin CLI handlers project those facts into dedicated structured DTOs, while CLI-owned MiniJinja templates preserve established human wording, order, brackets, pluralization, pad rows, and existing semantic info/success styling.

Structured tag output intentionally changes from prose-only messages and generic modification results to dedicated tagged schemas. Catalogs expose status plus an ordered tags array, registry mutations expose action/names/affected-pad counts, and assignment/removal expose action/requested_tags/modified_pads/pads with distinct all_already_present and none_present no-ops. External fixtures pin empty, singleton, multiple, changed, and no-op shapes, and the unreleased changelog records the transition.

Out of scope: #216-#223, dependency changes, storage/selectors/order changes, adding a standalone public tag-create command, and broad wording/visual redesign. Standout v7.9.0 remains coherently pinned. Do not move human sentences back into padzapp or handlers, collapse no-op distinctions, or substitute selected-pad count for modified-pad count. Tag creation remains core/API-only because the unified public CLI intentionally has no standalone create command.

Verification:
- env RUSTC_WRAPPER= pixi run test — 867 passed, 1 skipped
- commit and push hooks — lint passed all 12 checks

Governing-doc self-check: reviewed every acceptance criterion and compatibility/non-goal boundary in epic #208 and issue #215, the semantic ownership pattern from #207, and integrated WS01/PR #224 plus WS02/PR #226. No separate ADR/spec list was supplied in the implementer brief; this mandatory brief-slot gap is recorded here rather than guessed.