### PR TITLE
STD02-WS04: Epic: Complete Remaining Standout Ownership Work - Workstream: Semantic Import and Metadata Outcomes

### DIFF
--- a/CHANGELOG/unreleased-semantic-import-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-import-outcomes.md
@@ -1,0 +1,5 @@
+- Import results now expose a semantic report in structured output: overall
+  full/partial/no-import status and total, per-source status and counts, typed
+  metadata warnings, inline-metadata application, skipped archive entries, and
+  tag-registry merge outcomes. Human output retains its existing wording,
+  ordering, and semantic styles.

--- a/CHANGELOG/unreleased-semantic-import-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-import-outcomes.md
@@ -1,5 +1,5 @@
 - Import results now expose a semantic report in structured output: overall
   full/partial/no-import status and total, per-source status and counts, typed
-  metadata warnings, inline-metadata application, skipped archive entries, and
-  tag-registry merge outcomes. Human output retains its existing wording,
-  ordering, and semantic styles.
+  metadata warnings, inline-metadata application, skipped archive and directory
+  entries, and tag-registry merge outcomes. Human output retains its existing
+  wording, ordering, and semantic styles.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -28,9 +28,10 @@ use standout_macros::handler;
 use std::cell::RefCell;
 
 use super::result::{
-    DoctorResult, ExportReportResult, InitializationResult, ListRequest, MessagesResult,
-    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
-    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UuidResult,
+    DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
+    MessagesResult, ModificationRequest, ModificationResult, PadContent, PadContentResult,
+    PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
+    UuidResult,
 };
 
 // =============================================================================
@@ -334,13 +335,14 @@ impl<'a> ScopedApi<'a> {
         })
     }
 
+    /// Project the core semantic import report into the CLI's public DTO.
     pub fn import_pads(
         &self,
         paths: Vec<std::path::PathBuf>,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<ImportResult>, anyhow::Error> {
         let extensions = &self.state.import_extensions.0;
-        let result = self.call(|api, scope| api.import_pads(scope, paths.clone(), extensions))?;
-        self.messages(result)
+        let report = self.call(|api, scope| api.import_pads(scope, paths.clone(), extensions))?;
+        Ok(Output::Render(report.into()))
     }
 
     pub fn transfer_pads(
@@ -1174,11 +1176,12 @@ pub fn export(
     )
 }
 
+/// Import requested paths and return mode-independent semantic facts.
 #[handler]
 pub fn import(
     #[ctx] ctx: &CommandContext,
     #[arg] paths: Vec<String>,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<ImportResult>, anyhow::Error> {
     let paths: Vec<std::path::PathBuf> = paths.into_iter().map(std::path::PathBuf::from).collect();
     api(ctx).import_pads(paths)
 }

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -442,6 +442,14 @@ pub enum ArchiveEntrySkipReasonResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum DirectoryEntrySkipReasonResult {
+    ReadEntry,
+    InspectEntry,
+    ImportFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TagRegistryMergeStatusResult {
     Merged,
     Failed,
@@ -467,8 +475,16 @@ pub enum ImportDiagnosticResult {
         reason: ArchiveEntrySkipReasonResult,
         detail: String,
     },
+    DirectoryEntrySkipped {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        entry: Option<String>,
+        reason: DirectoryEntrySkipReasonResult,
+        detail: String,
+    },
     TagRegistryMerge {
         status: TagRegistryMergeStatusResult,
+        /// Number of registry entries successfully persisted by this merge.
+        /// Failed merges always report zero.
         added: usize,
         #[serde(skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
@@ -583,6 +599,25 @@ impl From<padzapp::commands::import::ImportDiagnostic> for ImportDiagnosticResul
                     }
                     padzapp::commands::import::ArchiveEntrySkipReason::StoreFailure => {
                         ArchiveEntrySkipReasonResult::StoreFailure
+                    }
+                },
+                detail,
+            },
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry,
+                reason,
+                detail,
+            } => Self::DirectoryEntrySkipped {
+                entry: entry.map(|path| path.display().to_string()),
+                reason: match reason {
+                    padzapp::commands::import::DirectoryEntrySkipReason::ReadEntry => {
+                        DirectoryEntrySkipReasonResult::ReadEntry
+                    }
+                    padzapp::commands::import::DirectoryEntrySkipReason::InspectEntry => {
+                        DirectoryEntrySkipReasonResult::InspectEntry
+                    }
+                    padzapp::commands::import::DirectoryEntrySkipReason::ImportFile => {
+                        DirectoryEntrySkipReasonResult::ImportFile
                     }
                 },
                 detail,

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -340,6 +340,306 @@ impl From<padzapp::commands::tagging::TaggingResult> for TaggingResult {
     }
 }
 
+/// CLI projection of a semantic import report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportResult {
+    pub status: ImportStatusResult,
+    pub total_imported: usize,
+    pub sources: Vec<ImportSourceResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportStatusResult {
+    FullSuccess,
+    PartialSuccess,
+    NoImports,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceKindResult {
+    File,
+    Directory,
+    JsonArchive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceStatusResult {
+    Imported,
+    Skipped,
+    Missing,
+    Unreadable,
+    Invalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportSourceResult {
+    pub source: String,
+    pub source_kind: ImportSourceKindResult,
+    pub status: ImportSourceStatusResult,
+    pub imported: usize,
+    pub processed_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub diagnostics: Vec<ImportDiagnosticResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportBucketResult {
+    Active,
+    Archived,
+    Deleted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningSeverityResult {
+    Info,
+    Warning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningCategoryResult {
+    Metadata,
+    Field,
+    Tags,
+    Parent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningReasonResult {
+    NotAnObject,
+    InvalidValue,
+    NonStringEntries,
+    OutsideImportSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetadataWarningResult {
+    pub source_label: String,
+    pub category: MetadataWarningCategoryResult,
+    pub reason: MetadataWarningReasonResult,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    pub severity: MetadataWarningSeverityResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArchiveEntrySkipReasonResult {
+    MissingFile,
+    InvalidEncoding,
+    EmptyContent,
+    StoreFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagRegistryMergeStatusResult {
+    Merged,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportDiagnosticResult {
+    InlineMetadataApplied {
+        source_label: String,
+        bucket: ImportBucketResult,
+        warning_count: usize,
+    },
+    ArchiveMetadataSummary {
+        pad_id: String,
+        warning_count: usize,
+    },
+    MetadataWarning {
+        warning: MetadataWarningResult,
+    },
+    ArchiveEntrySkipped {
+        entry: String,
+        reason: ArchiveEntrySkipReasonResult,
+        detail: String,
+    },
+    TagRegistryMerge {
+        status: TagRegistryMergeStatusResult,
+        added: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+impl From<padzapp::commands::import::ImportReport> for ImportResult {
+    fn from(report: padzapp::commands::import::ImportReport) -> Self {
+        Self {
+            status: report.status.into(),
+            total_imported: report.total_imported,
+            sources: report.sources.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::import::ImportStatus> for ImportStatusResult {
+    fn from(status: padzapp::commands::import::ImportStatus) -> Self {
+        use padzapp::commands::import::ImportStatus;
+        match status {
+            ImportStatus::FullSuccess => Self::FullSuccess,
+            ImportStatus::PartialSuccess => Self::PartialSuccess,
+            ImportStatus::NoImports => Self::NoImports,
+        }
+    }
+}
+
+impl From<padzapp::commands::import::ImportSourceReport> for ImportSourceResult {
+    fn from(source: padzapp::commands::import::ImportSourceReport) -> Self {
+        Self {
+            source: source.source.display().to_string(),
+            source_kind: match source.source_kind {
+                padzapp::commands::import::ImportSourceKind::File => ImportSourceKindResult::File,
+                padzapp::commands::import::ImportSourceKind::Directory => {
+                    ImportSourceKindResult::Directory
+                }
+                padzapp::commands::import::ImportSourceKind::JsonArchive => {
+                    ImportSourceKindResult::JsonArchive
+                }
+            },
+            status: match source.status {
+                padzapp::commands::import::ImportSourceStatus::Imported => {
+                    ImportSourceStatusResult::Imported
+                }
+                padzapp::commands::import::ImportSourceStatus::Skipped => {
+                    ImportSourceStatusResult::Skipped
+                }
+                padzapp::commands::import::ImportSourceStatus::Missing => {
+                    ImportSourceStatusResult::Missing
+                }
+                padzapp::commands::import::ImportSourceStatus::Unreadable => {
+                    ImportSourceStatusResult::Unreadable
+                }
+                padzapp::commands::import::ImportSourceStatus::Invalid => {
+                    ImportSourceStatusResult::Invalid
+                }
+            },
+            imported: source.imported,
+            processed_files: source
+                .processed_files
+                .into_iter()
+                .map(|path| path.display().to_string())
+                .collect(),
+            detail: source.detail,
+            diagnostics: source.diagnostics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::import::ImportDiagnostic> for ImportDiagnosticResult {
+    fn from(diagnostic: padzapp::commands::import::ImportDiagnostic) -> Self {
+        use padzapp::commands::import::ImportDiagnostic;
+        match diagnostic {
+            ImportDiagnostic::InlineMetadataApplied {
+                source_label,
+                bucket,
+                warning_count,
+            } => Self::InlineMetadataApplied {
+                source_label,
+                bucket: match bucket {
+                    padzapp::store::Bucket::Active => ImportBucketResult::Active,
+                    padzapp::store::Bucket::Archived => ImportBucketResult::Archived,
+                    padzapp::store::Bucket::Deleted => ImportBucketResult::Deleted,
+                },
+                warning_count,
+            },
+            ImportDiagnostic::ArchiveMetadataSummary {
+                pad_id,
+                warning_count,
+            } => Self::ArchiveMetadataSummary {
+                pad_id: pad_id.to_string(),
+                warning_count,
+            },
+            ImportDiagnostic::MetadataWarning { warning } => Self::MetadataWarning {
+                warning: warning.into(),
+            },
+            ImportDiagnostic::ArchiveEntrySkipped {
+                entry,
+                reason,
+                detail,
+            } => Self::ArchiveEntrySkipped {
+                entry,
+                reason: match reason {
+                    padzapp::commands::import::ArchiveEntrySkipReason::MissingFile => {
+                        ArchiveEntrySkipReasonResult::MissingFile
+                    }
+                    padzapp::commands::import::ArchiveEntrySkipReason::InvalidEncoding => {
+                        ArchiveEntrySkipReasonResult::InvalidEncoding
+                    }
+                    padzapp::commands::import::ArchiveEntrySkipReason::EmptyContent => {
+                        ArchiveEntrySkipReasonResult::EmptyContent
+                    }
+                    padzapp::commands::import::ArchiveEntrySkipReason::StoreFailure => {
+                        ArchiveEntrySkipReasonResult::StoreFailure
+                    }
+                },
+                detail,
+            },
+            ImportDiagnostic::TagRegistryMerge {
+                status,
+                added,
+                detail,
+            } => Self::TagRegistryMerge {
+                status: match status {
+                    padzapp::commands::import::TagRegistryMergeStatus::Merged => {
+                        TagRegistryMergeStatusResult::Merged
+                    }
+                    padzapp::commands::import::TagRegistryMergeStatus::Failed => {
+                        TagRegistryMergeStatusResult::Failed
+                    }
+                },
+                added,
+                detail,
+            },
+        }
+    }
+}
+
+impl From<padzapp::commands::metadata_apply::MetadataApplicationWarning> for MetadataWarningResult {
+    fn from(warning: padzapp::commands::metadata_apply::MetadataApplicationWarning) -> Self {
+        use padzapp::commands::metadata_apply::{
+            MetadataWarningCategory, MetadataWarningReason, MetadataWarningSeverity,
+        };
+        Self {
+            source_label: warning.source_label,
+            category: match warning.category {
+                MetadataWarningCategory::Metadata => MetadataWarningCategoryResult::Metadata,
+                MetadataWarningCategory::Field => MetadataWarningCategoryResult::Field,
+                MetadataWarningCategory::Tags => MetadataWarningCategoryResult::Tags,
+                MetadataWarningCategory::Parent => MetadataWarningCategoryResult::Parent,
+            },
+            reason: match warning.reason {
+                MetadataWarningReason::NotAnObject => MetadataWarningReasonResult::NotAnObject,
+                MetadataWarningReason::InvalidValue => MetadataWarningReasonResult::InvalidValue,
+                MetadataWarningReason::NonStringEntries => {
+                    MetadataWarningReasonResult::NonStringEntries
+                }
+                MetadataWarningReason::OutsideImportSet => {
+                    MetadataWarningReasonResult::OutsideImportSet
+                }
+            },
+            field: warning.field,
+            count: warning.count,
+            severity: match warning.severity {
+                MetadataWarningSeverity::Info => MetadataWarningSeverityResult::Info,
+                MetadataWarningSeverity::Warning => MetadataWarningSeverityResult::Warning,
+            },
+        }
+    }
+}
+
 /// A command whose whole result is user-facing messages.
 ///
 /// Rendered by `messages.jinja`, which reads `CmdMessage` directly — no view

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -713,7 +713,7 @@ pub enum Commands {
 
     /// Import files as pads
     #[command(display_order = 22)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "import")]
     Import {
         /// Paths to files or directories to import
         #[arg(required = true, num_args = 1..)]

--- a/crates/padz/src/cli/templates/import.jinja
+++ b/crates/padz/src/cli/templates/import.jinja
@@ -1,0 +1,47 @@
+{#- Semantic import facts rendered with the historical human wording/order. -#}
+{% for source in sources -%}
+{% if source.source_kind == "json_archive" -%}
+{% if source.status == "imported" or source.status == "skipped" -%}
+[info]Imported {{ source.imported }} pads from {{ source.source }}[/info]
+{% else -%}
+[warning]Failed to import JSON archive {{ source.source }}: {{ source.detail }}[/warning]
+{% endif -%}
+{% else -%}
+{% for file in source.processed_files -%}
+[info]Imported: {{ file }}[/info]
+{% endfor -%}
+{% if source.status == "missing" -%}
+[warning]Path not found: {{ source.source }}[/warning]
+{% elif source.status == "unreadable" or source.status == "invalid" -%}
+[warning]Failed to import: {{ source.source }}[/warning]
+{% endif -%}
+{% endif -%}
+{% for diagnostic in source.diagnostics -%}
+{% if diagnostic.kind == "inline_metadata_applied" and diagnostic.warning_count > 0 -%}
+[info]{{ diagnostic.source_label }}: applied inline metadata[/info]
+{% elif diagnostic.kind == "archive_metadata_summary" -%}
+[info]Pad {{ diagnostic.pad_id }} imported; {{ diagnostic.warning_count }} metadata warning(s)[/info]
+{% elif diagnostic.kind == "metadata_warning" -%}
+{% set warning = diagnostic.warning -%}
+{% if warning.reason == "not_an_object" -%}
+{% set message = warning.source_label ~ ": metadata is not an object, keeping existing fields" -%}
+{% elif warning.reason == "invalid_value" and warning.field == "id" -%}
+{% set message = warning.source_label ~ ": invalid id field, keeping existing UUID" -%}
+{% elif warning.reason == "invalid_value" -%}
+{% set message = warning.source_label ~ ": invalid " ~ warning.field -%}
+{% elif warning.reason == "non_string_entries" -%}
+{% set message = warning.source_label ~ ": " ~ warning.count ~ " non-string tag entries ignored" -%}
+{% else -%}
+{% set message = warning.source_label ~ ": parent not in import set, orphaned to root" -%}
+{% endif -%}
+{{ message | style_as(warning.severity) }}
+{% elif diagnostic.kind == "archive_entry_skipped" -%}
+[warning]Skipping pad entry {{ diagnostic.entry }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "tag_registry_merge" and diagnostic.status == "failed" -%}
+[warning]Failed to merge tag registry: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "tag_registry_merge" and diagnostic.added > 0 -%}
+[info]Merged {{ diagnostic.added }} tag registry entry/entries[/info]
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+[success]Total imported: {{ total_imported }}[/success]{{ "" | nl }}

--- a/crates/padz/src/cli/templates/import.jinja
+++ b/crates/padz/src/cli/templates/import.jinja
@@ -37,6 +37,10 @@
 {{ message | style_as(warning.severity) }}
 {% elif diagnostic.kind == "archive_entry_skipped" -%}
 [warning]Skipping pad entry {{ diagnostic.entry }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "directory_entry_skipped" and diagnostic.entry -%}
+[warning]Skipping directory entry {{ diagnostic.entry }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "directory_entry_skipped" -%}
+[warning]Skipping unreadable directory entry: {{ diagnostic.detail }}[/warning]
 {% elif diagnostic.kind == "tag_registry_merge" and diagnostic.status == "failed" -%}
 [warning]Failed to merge tag registry: {{ diagnostic.detail }}[/warning]
 {% elif diagnostic.kind == "tag_registry_merge" and diagnostic.added > 0 -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/import-partial.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/import-partial.json
@@ -1,0 +1,31 @@
+{
+  "status": "partial_success",
+  "total_imported": 1,
+  "sources": [
+    {
+      "source": "<SOURCE>",
+      "source_kind": "file",
+      "status": "imported",
+      "imported": 1,
+      "processed_files": ["<SOURCE>"],
+      "diagnostics": [
+        {
+          "kind": "inline_metadata_applied",
+          "source_label": "<SOURCE>",
+          "bucket": "active",
+          "warning_count": 1
+        },
+        {
+          "kind": "metadata_warning",
+          "warning": {
+            "source_label": "<SOURCE>",
+            "category": "field",
+            "reason": "invalid_value",
+            "field": "status",
+            "severity": "warning"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,10 +26,11 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    DoctorResult, ExportFormat, ExportStatus, ExportWarning, InitializationResult,
-    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadContentResult, PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult,
-    TaggingResult, UpdateKindResult, UuidResult,
+    DoctorResult, ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
+    ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
+    MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
+    MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
+    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -768,6 +769,40 @@ fn empty_export_stays_a_non_artifact_result() {
     assert_eq!(report.status, ExportStatus::Empty);
     assert_eq!(report.format, ExportFormat::Archive);
     assert_eq!(report.exported, 0);
+}
+
+// =============================================================================
+// Semantic import reports
+// =============================================================================
+
+#[test]
+fn import_maps_core_source_and_metadata_warning_facts() {
+    let fx = Fixture::new();
+    let source = fx.root().join("bad.md");
+    std::fs::write(
+        &source,
+        "---\npadz.status: NotAThing\n---\n\nImported title\n\nBody",
+    )
+    .unwrap();
+    let state = fx.app_state_for(&["import", source.to_str().unwrap()]);
+    let ctx = support::ctx_with_state(state);
+
+    let result: ImportResult = rendered(handlers::import(&ctx, vec![source.display().to_string()]));
+
+    assert_eq!(result.status, ImportStatusResult::PartialSuccess);
+    assert_eq!(result.total_imported, 1);
+    assert_eq!(result.sources[0].source, source.display().to_string());
+    assert_eq!(result.sources[0].source_kind, ImportSourceKindResult::File);
+    assert_eq!(result.sources[0].status, ImportSourceStatusResult::Imported);
+    assert!(result.sources[0]
+        .diagnostics
+        .iter()
+        .any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnosticResult::MetadataWarning { warning }
+                if warning.reason == MetadataWarningReasonResult::InvalidValue
+                    && warning.field.as_deref() == Some("status")
+        )));
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -401,6 +401,103 @@ fn empty_purge_is_distinct_in_text_and_structured_output() {
     );
 }
 
+#[test]
+#[serial]
+fn import_preserves_warning_text_and_exposes_partial_success_facts() {
+    let text_fx = Fixture::new();
+    let source = text_fx.root().join("bad.md");
+    std::fs::write(
+        &source,
+        "---\npadz.status: NotAThing\n---\n\nImported title\n\nBody",
+    )
+    .unwrap();
+    let source_text = source.display().to_string();
+    let (app, cmd) = text_fx.app(&["import", &source_text]);
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        text_fx.argv(&["import", &source_text, "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(
+        text.stdout(),
+        format!(
+            "Imported: {source_text}\n{source_text}: applied inline metadata\n\
+             {source_text}: invalid status\nTotal imported: 1\n"
+        )
+    );
+    drop(text);
+
+    let json_fx = Fixture::new();
+    let source = json_fx.root().join("bad.md");
+    std::fs::write(
+        &source,
+        "---\npadz.status: NotAThing\n---\n\nImported title\n\nBody",
+    )
+    .unwrap();
+    let source_text = source.display().to_string();
+    let (app, cmd) = json_fx.app(&["import", &source_text]);
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        json_fx.argv(&["import", &source_text, "--output", "json"]),
+    );
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    value["sources"][0]["source"] = serde_json::json!("<SOURCE>");
+    value["sources"][0]["processed_files"][0] = serde_json::json!("<SOURCE>");
+    value["sources"][0]["diagnostics"][0]["source_label"] = serde_json::json!("<SOURCE>");
+    value["sources"][0]["diagnostics"][1]["warning"]["source_label"] =
+        serde_json::json!("<SOURCE>");
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/import-partial.json"
+    ))
+    .unwrap();
+    assert_eq!(value, fixture);
+    assert!(value.get("messages").is_none());
+}
+
+#[test]
+#[serial]
+fn import_report_serializes_in_every_structured_mode() {
+    for mode in ["json", "yaml", "xml", "csv"] {
+        let fx = Fixture::new();
+        let source = fx.root().join("plain.md");
+        std::fs::write(&source, "Imported title\n\nBody").unwrap();
+        let source = source.display().to_string();
+        let (app, cmd) = fx.app(&["import", &source]);
+        let result =
+            TestHarness::new().run(&app, cmd, fx.argv(&["import", &source, "--output", mode]));
+        result.assert_success();
+        match mode {
+            "json" => {
+                serde_json::from_str::<serde_json::Value>(result.stdout()).unwrap();
+            }
+            "yaml" => {
+                serde_yaml::from_str::<serde_yaml::Value>(result.stdout()).unwrap();
+            }
+            "xml" => {
+                let mut reader = quick_xml::Reader::from_str(result.stdout());
+                loop {
+                    match reader.read_event() {
+                        Ok(quick_xml::events::Event::Eof) => break,
+                        Ok(_) => {}
+                        Err(error) => panic!("invalid import XML: {error}\n{}", result.stdout()),
+                    }
+                }
+            }
+            "csv" => {
+                let mut reader = csv::Reader::from_reader(result.stdout().as_bytes());
+                reader.headers().unwrap();
+                for row in reader.records() {
+                    row.unwrap();
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
 // =============================================================================
 // Semantic pad mutation outcomes
 // =============================================================================

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -80,6 +80,7 @@ impl<S: DataStore> PadzApi<S> {
 pub use crate::model::TodoStatus;
 pub use commands::doctor::DoctorOutcome;
 pub use commands::get::{PadFilter, PadStatusFilter};
+pub use commands::import::ImportReport;
 pub use commands::init::InitializationOutcome;
 pub use commands::purge::PurgeOutcome;
 pub use commands::tagging::{TaggingOutcome, TaggingResult};

--- a/crates/padzapp/src/api/transfer.rs
+++ b/crates/padzapp/src/api/transfer.rs
@@ -41,12 +41,14 @@ impl<S: DataStore> PadzApi<S> {
         commands::export::run_json(&self.store, scope, &selectors, nesting)
     }
 
+    /// Import independent filesystem sources into `scope` and retain partial
+    /// success, metadata, archive-entry, and tag-registry facts in one report.
     pub fn import_pads(
         &mut self,
         scope: Scope,
         paths: Vec<std::path::PathBuf>,
         import_exts: &[String],
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::import::ImportReport> {
         commands::import::run(&mut self.store, scope, paths, import_exts)
     }
 
@@ -159,10 +161,8 @@ mod tests {
             .import_pads(Scope::Project, vec![file_path], &[".md".to_string()])
             .unwrap();
 
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(result.total_imported, 1);
+        assert_eq!(result.status, commands::import::ImportStatus::FullSuccess);
     }
 
     // ------------------------------------------------------------------------

--- a/crates/padzapp/src/commands/io/import.rs
+++ b/crates/padzapp/src/commands/io/import.rs
@@ -1,14 +1,22 @@
+//! Semantic import pipeline for plain files, directories, inline metadata,
+//! and full-fidelity JSON archives.
+//!
+//! Every requested source produces one typed report. Recoverable source and
+//! archive-entry failures remain local so independent inputs continue, while
+//! metadata and tag-registry effects stay observable without authored prose.
+
 use crate::commands::inline_metadata::{parse_lex_metadata, parse_md_frontmatter};
 use crate::commands::metadata_apply::{
-    apply_metadata_defensively, parse_bucket_or_active, ParentPolicy,
+    apply_metadata_defensively, parse_bucket_or_active, MetadataApplicationWarning,
+    MetadataWarningSeverity, ParentPolicy,
 };
 use crate::commands::metadata_schema::{Archive, PadEntry};
-use crate::commands::{CmdMessage, CmdResult};
 use crate::error::{PadzError, Result};
 use crate::model::{parse_pad_content, Pad, Scope};
 use crate::store::{Bucket, DataStore};
 use crate::tags::TagEntry;
 use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
@@ -16,94 +24,269 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportStatus {
+    FullSuccess,
+    PartialSuccess,
+    NoImports,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceKind {
+    File,
+    Directory,
+    JsonArchive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSourceStatus {
+    Imported,
+    Skipped,
+    Missing,
+    Unreadable,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArchiveEntrySkipReason {
+    MissingFile,
+    InvalidEncoding,
+    EmptyContent,
+    StoreFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagRegistryMergeStatus {
+    Merged,
+    Failed,
+}
+
+/// Ordered, source-local facts emitted while importing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportDiagnostic {
+    InlineMetadataApplied {
+        source_label: String,
+        bucket: Bucket,
+        warning_count: usize,
+    },
+    ArchiveMetadataSummary {
+        pad_id: Uuid,
+        warning_count: usize,
+    },
+    MetadataWarning {
+        warning: MetadataApplicationWarning,
+    },
+    ArchiveEntrySkipped {
+        entry: String,
+        reason: ArchiveEntrySkipReason,
+        detail: String,
+    },
+    TagRegistryMerge {
+        status: TagRegistryMergeStatus,
+        added: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+/// Report for one path explicitly requested by the caller.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportSourceReport {
+    pub source: PathBuf,
+    pub source_kind: ImportSourceKind,
+    pub status: ImportSourceStatus,
+    pub imported: usize,
+    /// Plain files successfully read from this source, even when empty content
+    /// caused the file to be skipped rather than imported.
+    pub processed_files: Vec<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub diagnostics: Vec<ImportDiagnostic>,
+}
+
+/// Complete semantic import report, independent of any presentation client.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportReport {
+    pub status: ImportStatus,
+    pub total_imported: usize,
+    pub sources: Vec<ImportSourceReport>,
+}
+
+/// Import every requested path and return one presentation-free report.
 pub fn run<S: DataStore>(
     store: &mut S,
     scope: Scope,
     paths: Vec<PathBuf>,
     import_exts: &[String],
-) -> Result<CmdResult> {
-    let mut result = CmdResult::default();
-    let mut imported_count = 0;
+) -> Result<ImportReport> {
+    let mut sources = Vec::with_capacity(paths.len());
 
     for path in paths {
         if is_json_archive(&path) {
-            match import_json_archive(store, scope, &path) {
-                Ok((count, messages)) => {
-                    imported_count += count;
-                    result.add_message(CmdMessage::info(format!(
-                        "Imported {} pads from {}",
-                        count,
-                        path.display()
-                    )));
-                    for m in messages {
-                        result.add_message(m);
-                    }
-                }
-                Err(e) => {
-                    result.add_message(CmdMessage::warning(format!(
-                        "Failed to import JSON archive {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            }
+            sources.push(match import_json_archive(store, scope, &path) {
+                Ok(archive) => ImportSourceReport {
+                    source: path,
+                    source_kind: ImportSourceKind::JsonArchive,
+                    status: if archive.imported > 0 {
+                        ImportSourceStatus::Imported
+                    } else {
+                        ImportSourceStatus::Skipped
+                    },
+                    imported: archive.imported,
+                    processed_files: Vec::new(),
+                    detail: None,
+                    diagnostics: archive.diagnostics,
+                },
+                Err(error) => ImportSourceReport {
+                    source: path,
+                    source_kind: ImportSourceKind::JsonArchive,
+                    status: source_error_status(&error),
+                    imported: 0,
+                    processed_files: Vec::new(),
+                    detail: Some(error.to_string()),
+                    diagnostics: Vec::new(),
+                },
+            });
             continue;
         }
 
         if path.is_dir() {
-            // Import directory of plain files
-            let entries = fs::read_dir(&path).map_err(PadzError::Io)?;
+            let entries = match fs::read_dir(&path) {
+                Ok(entries) => entries,
+                Err(error) => {
+                    sources.push(ImportSourceReport {
+                        source: path,
+                        source_kind: ImportSourceKind::Directory,
+                        status: source_error_status(&PadzError::Io(error)),
+                        imported: 0,
+                        processed_files: Vec::new(),
+                        detail: Some("directory could not be read".to_string()),
+                        diagnostics: Vec::new(),
+                    });
+                    continue;
+                }
+            };
+            let mut imported = 0;
+            let mut processed_files = Vec::new();
+            let mut diagnostics = Vec::new();
             for entry in entries {
-                let entry = entry.map_err(PadzError::Io)?;
+                let Ok(entry) = entry else { continue };
                 let sub_path = entry.path();
                 if sub_path.is_file() {
                     if let Some(ext) = sub_path.extension() {
                         let ext_str = format!(".{}", ext.to_string_lossy());
                         if import_exts.contains(&ext_str) {
                             if let Ok(res) = import_file(store, scope, &sub_path) {
-                                imported_count += res.imported;
-                                result.add_message(CmdMessage::info(format!(
-                                    "Imported: {}",
-                                    sub_path.display()
-                                )));
-                                for w in res.warnings {
-                                    result.add_message(w);
-                                }
+                                imported += res.imported;
+                                processed_files.push(sub_path);
+                                diagnostics.extend(res.diagnostics());
                             }
                         }
                     }
                 }
             }
+            sources.push(ImportSourceReport {
+                source: path,
+                source_kind: ImportSourceKind::Directory,
+                status: if imported > 0 {
+                    ImportSourceStatus::Imported
+                } else {
+                    ImportSourceStatus::Skipped
+                },
+                imported,
+                processed_files,
+                detail: None,
+                diagnostics,
+            });
         } else if path.is_file() {
-            // Import file directly (try as text)
-            match import_file(store, scope, &path) {
+            sources.push(match import_file(store, scope, &path) {
                 Ok(res) => {
-                    imported_count += res.imported;
-                    result.add_message(CmdMessage::info(format!("Imported: {}", path.display())));
-                    for w in res.warnings {
-                        result.add_message(w);
+                    let status = if res.imported > 0 {
+                        ImportSourceStatus::Imported
+                    } else {
+                        ImportSourceStatus::Skipped
+                    };
+                    ImportSourceReport {
+                        source: path.clone(),
+                        source_kind: ImportSourceKind::File,
+                        status,
+                        imported: res.imported,
+                        processed_files: vec![path],
+                        detail: None,
+                        diagnostics: res.diagnostics(),
                     }
                 }
-                Err(_) => {
-                    result.add_message(CmdMessage::warning(format!(
-                        "Failed to import: {}",
-                        path.display()
-                    )));
-                }
-            }
+                Err(error) => ImportSourceReport {
+                    source: path,
+                    source_kind: ImportSourceKind::File,
+                    status: source_error_status(&error),
+                    imported: 0,
+                    processed_files: Vec::new(),
+                    detail: Some(error.to_string()),
+                    diagnostics: Vec::new(),
+                },
+            });
         } else {
-            result.add_message(CmdMessage::warning(format!(
-                "Path not found: {}",
-                path.display()
-            )));
+            sources.push(ImportSourceReport {
+                source: path,
+                source_kind: ImportSourceKind::File,
+                status: ImportSourceStatus::Missing,
+                imported: 0,
+                processed_files: Vec::new(),
+                detail: None,
+                diagnostics: Vec::new(),
+            });
         }
     }
 
-    result.add_message(CmdMessage::success(format!(
-        "Total imported: {}",
-        imported_count
-    )));
-    Ok(result)
+    let total_imported = sources.iter().map(|source| source.imported).sum();
+    let status = if total_imported == 0 {
+        ImportStatus::NoImports
+    } else if sources.iter().any(source_is_partial) {
+        ImportStatus::PartialSuccess
+    } else {
+        ImportStatus::FullSuccess
+    };
+    Ok(ImportReport {
+        status,
+        total_imported,
+        sources,
+    })
+}
+
+fn source_error_status(error: &PadzError) -> ImportSourceStatus {
+    match error {
+        PadzError::Io(error) if error.kind() != std::io::ErrorKind::InvalidData => {
+            ImportSourceStatus::Unreadable
+        }
+        _ => ImportSourceStatus::Invalid,
+    }
+}
+
+fn source_is_partial(source: &ImportSourceReport) -> bool {
+    if source.status != ImportSourceStatus::Imported {
+        return true;
+    }
+    source
+        .diagnostics
+        .iter()
+        .any(|diagnostic| match diagnostic {
+            ImportDiagnostic::MetadataWarning { warning } => {
+                warning.severity == MetadataWarningSeverity::Warning
+            }
+            ImportDiagnostic::ArchiveEntrySkipped { .. } => true,
+            ImportDiagnostic::TagRegistryMerge { status, .. } => {
+                *status == TagRegistryMergeStatus::Failed
+            }
+            ImportDiagnostic::InlineMetadataApplied { .. }
+            | ImportDiagnostic::ArchiveMetadataSummary { .. } => false,
+        })
 }
 
 /// Heuristic: `.tar.gz` / `.tgz` files are candidates for JSON archive import.
@@ -123,7 +306,27 @@ fn is_json_archive(path: &Path) -> bool {
 /// Result of importing a single file: pads created + any per-field warnings.
 struct FileImportResult {
     imported: usize,
-    warnings: Vec<CmdMessage>,
+    warnings: Vec<MetadataApplicationWarning>,
+    inline_metadata: Option<(String, Bucket)>,
+}
+
+impl FileImportResult {
+    fn diagnostics(self) -> Vec<ImportDiagnostic> {
+        let mut diagnostics = Vec::new();
+        if let Some((source_label, bucket)) = self.inline_metadata {
+            diagnostics.push(ImportDiagnostic::InlineMetadataApplied {
+                source_label,
+                bucket,
+                warning_count: self.warnings.len(),
+            });
+        }
+        diagnostics.extend(
+            self.warnings
+                .into_iter()
+                .map(|warning| ImportDiagnostic::MetadataWarning { warning }),
+        );
+        diagnostics
+    }
 }
 
 fn import_file<S: DataStore>(store: &mut S, scope: Scope, path: &Path) -> Result<FileImportResult> {
@@ -157,11 +360,12 @@ fn import_content<S: DataStore>(
             return Ok(FileImportResult {
                 imported: 0,
                 warnings: Vec::new(),
+                inline_metadata: None,
             });
         };
 
         let mut pad = Pad::new(title.clone(), strip_title_from_body(&normalized, &title));
-        let mut warnings = apply_metadata_defensively(
+        let warnings = apply_metadata_defensively(
             &mut pad,
             &metadata_value,
             ParentPolicy::Trust,
@@ -181,16 +385,10 @@ fn import_content<S: DataStore>(
 
         store.save_pad(&pad, scope, bucket)?;
 
-        if !warnings.is_empty() {
-            warnings.insert(
-                0,
-                CmdMessage::info(format!("{}: applied inline metadata", source_label)),
-            );
-        }
-
         return Ok(FileImportResult {
             imported: 1,
             warnings,
+            inline_metadata: Some((source_label.to_string(), bucket)),
         });
     }
 
@@ -200,26 +398,26 @@ fn import_content<S: DataStore>(
         Ok(FileImportResult {
             imported: 1,
             warnings: Vec::new(),
+            inline_metadata: None,
         })
     } else {
         Ok(FileImportResult {
             imported: 0,
             warnings: Vec::new(),
+            inline_metadata: None,
         })
     }
 }
 
 /// Import a `.tar.gz` JSON archive.
 ///
-/// Returns `(imported_count, metadata_warnings)`. The function is optimistic:
-/// as long as the archive is readable, every pad file lands in the store.
-/// Metadata that fails to parse becomes a per-field warning; the pad itself
-/// always imports with at least a title and content.
+/// Returns imported counts and ordered semantic diagnostics. The function is
+/// optimistic: one bad entry does not prevent independent entries from landing.
 fn import_json_archive<S: DataStore>(
     store: &mut S,
     scope: Scope,
     archive_path: &Path,
-) -> Result<(usize, Vec<CmdMessage>)> {
+) -> Result<ArchiveImportResult> {
     let file = fs::File::open(archive_path).map_err(PadzError::Io)?;
     let decoder = GzDecoder::new(file);
     let mut tar = tar::Archive::new(decoder);
@@ -230,15 +428,21 @@ fn import_json_archive<S: DataStore>(
     // without meaningful savings. Keep everything keyed by archive-relative
     // path so we can cross-reference `db.json` against the pad files.
     let mut files: HashMap<String, Vec<u8>> = HashMap::new();
-    for entry in tar.entries().map_err(PadzError::Io)? {
-        let mut entry = entry.map_err(PadzError::Io)?;
+    for entry in tar
+        .entries()
+        .map_err(|error| PadzError::Api(format!("Invalid archive: {error}")))?
+    {
+        let mut entry =
+            entry.map_err(|error| PadzError::Api(format!("Invalid archive: {error}")))?;
         let archive_path = entry
             .path()
-            .map_err(PadzError::Io)?
+            .map_err(|error| PadzError::Api(format!("Invalid archive path: {error}")))?
             .to_string_lossy()
             .to_string();
         let mut buf = Vec::new();
-        entry.read_to_end(&mut buf).map_err(PadzError::Io)?;
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|error| PadzError::Api(format!("Invalid archive entry: {error}")))?;
         files.insert(archive_path, buf);
     }
 
@@ -251,7 +455,7 @@ fn import_json_archive<S: DataStore>(
     let archive: Archive = serde_json::from_slice(db_bytes)
         .map_err(|e| PadzError::Api(format!("Invalid db.json: {}", e)))?;
 
-    let mut warnings: Vec<CmdMessage> = Vec::new();
+    let mut diagnostics = Vec::new();
     let mut imported = 0usize;
 
     // 3. Index of UUIDs present in this archive, for parent_id orphaning.
@@ -260,33 +464,50 @@ fn import_json_archive<S: DataStore>(
     // 4. Import each pad entry.
     for entry in &archive.pads {
         match import_pad_entry(store, scope, entry, &files, &archive_ids) {
-            Ok((id, mut entry_warnings)) => {
+            Ok((id, entry_warnings)) => {
                 imported += 1;
                 if !entry_warnings.is_empty() {
-                    warnings.push(CmdMessage::info(format!(
-                        "Pad {} imported; {} metadata warning(s)",
-                        id,
-                        entry_warnings.len()
-                    )));
-                    warnings.append(&mut entry_warnings);
+                    diagnostics.push(ImportDiagnostic::ArchiveMetadataSummary {
+                        pad_id: id,
+                        warning_count: entry_warnings.len(),
+                    });
+                    diagnostics.extend(
+                        entry_warnings
+                            .into_iter()
+                            .map(|warning| ImportDiagnostic::MetadataWarning { warning }),
+                    );
                 }
             }
             Err(e) => {
-                warnings.push(CmdMessage::warning(format!(
-                    "Skipping pad entry {}: {}",
-                    entry.file, e
-                )));
+                diagnostics.push(ImportDiagnostic::ArchiveEntrySkipped {
+                    entry: entry.file.clone(),
+                    reason: e.reason(),
+                    detail: e.to_string(),
+                });
             }
         }
     }
 
     // 5. Merge referenced tag registry entries (don't overwrite existing).
-    let existing_tags: HashMap<String, TagEntry> = store
-        .load_tags(scope)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|t| (t.name.clone(), t))
-        .collect();
+    let existing_tags: HashMap<String, TagEntry> = match store.load_tags(scope) {
+        Ok(tags) => tags
+            .into_iter()
+            .map(|tag| (tag.name.clone(), tag))
+            .collect(),
+        Err(error) => {
+            if !archive.tags.is_empty() {
+                diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+                    status: TagRegistryMergeStatus::Failed,
+                    added: archive.tags.len(),
+                    detail: Some(error.to_string()),
+                });
+            }
+            return Ok(ArchiveImportResult {
+                imported,
+                diagnostics,
+            });
+        }
+    };
     let mut new_tags: Vec<TagEntry> = existing_tags.values().cloned().collect();
     let mut added_tags = 0usize;
     for t in &archive.tags {
@@ -300,19 +521,35 @@ fn import_json_archive<S: DataStore>(
     }
     if added_tags > 0 {
         if let Err(e) = store.save_tags(scope, &new_tags) {
-            warnings.push(CmdMessage::warning(format!(
-                "Failed to merge tag registry: {}",
-                e
-            )));
+            diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+                status: TagRegistryMergeStatus::Failed,
+                added: added_tags,
+                detail: Some(e.to_string()),
+            });
         } else {
-            warnings.push(CmdMessage::info(format!(
-                "Merged {} tag registry entry/entries",
-                added_tags
-            )));
+            diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+                status: TagRegistryMergeStatus::Merged,
+                added: added_tags,
+                detail: None,
+            });
         }
+    } else if !archive.tags.is_empty() {
+        diagnostics.push(ImportDiagnostic::TagRegistryMerge {
+            status: TagRegistryMergeStatus::Merged,
+            added: 0,
+            detail: None,
+        });
     }
 
-    Ok((imported, warnings))
+    Ok(ArchiveImportResult {
+        imported,
+        diagnostics,
+    })
+}
+
+struct ArchiveImportResult {
+    imported: usize,
+    diagnostics: Vec<ImportDiagnostic>,
 }
 
 fn pad_id_from_entry(entry: &PadEntry) -> Option<Uuid> {
@@ -332,18 +569,17 @@ fn import_pad_entry<S: DataStore>(
     entry: &PadEntry,
     files: &HashMap<String, Vec<u8>>,
     archive_ids: &HashSet<Uuid>,
-) -> Result<(Uuid, Vec<CmdMessage>)> {
+) -> std::result::Result<(Uuid, Vec<MetadataApplicationWarning>), ArchiveEntryError> {
     // Resolve file: db.json uses relative paths ("pads/pad-<uuid>.lex"); tar
     // entries include the "padz/" prefix.
     let content_bytes = files
         .get(&format!("padz/{}", entry.file))
         .or_else(|| files.get(&entry.file))
-        .ok_or_else(|| PadzError::Api(format!("Missing file: {}", entry.file)))?;
+        .ok_or_else(|| ArchiveEntryError::MissingFile(entry.file.clone()))?;
 
     let raw = std::str::from_utf8(content_bytes)
-        .map_err(|e| PadzError::Api(format!("Non-UTF-8 content: {}", e)))?;
-    let (title, content) =
-        parse_pad_content(raw).ok_or_else(|| PadzError::Api("Empty pad content".to_string()))?;
+        .map_err(|error| ArchiveEntryError::InvalidEncoding(error.to_string()))?;
+    let (title, content) = parse_pad_content(raw).ok_or(ArchiveEntryError::EmptyContent)?;
 
     // Start from a fresh Pad so we have a valid baseline, then overlay fields.
     let mut pad = Pad::new(title.clone(), strip_title_from_body(&content, &title));
@@ -362,9 +598,34 @@ fn import_pad_entry<S: DataStore>(
     }
 
     let bucket = parse_bucket_or_active(&entry.bucket);
-    store.save_pad(&pad, scope, bucket)?;
+    store
+        .save_pad(&pad, scope, bucket)
+        .map_err(|error| ArchiveEntryError::StoreFailure(error.to_string()))?;
 
     Ok((pad.metadata.id, warnings))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ArchiveEntryError {
+    #[error("Missing file: {0}")]
+    MissingFile(String),
+    #[error("Non-UTF-8 content: {0}")]
+    InvalidEncoding(String),
+    #[error("Empty pad content")]
+    EmptyContent,
+    #[error("{0}")]
+    StoreFailure(String),
+}
+
+impl ArchiveEntryError {
+    fn reason(&self) -> ArchiveEntrySkipReason {
+        match self {
+            Self::MissingFile(_) => ArchiveEntrySkipReason::MissingFile,
+            Self::InvalidEncoding(_) => ArchiveEntrySkipReason::InvalidEncoding,
+            Self::EmptyContent => ArchiveEntrySkipReason::EmptyContent,
+            Self::StoreFailure(_) => ArchiveEntrySkipReason::StoreFailure,
+        }
+    }
 }
 
 /// `parse_pad_content` returns `(title, "title\n\nbody")`. `Pad::new` expects
@@ -447,17 +708,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            res.messages
-                .iter()
-                .filter(|m| m.content.contains("Imported:"))
-                .count(),
-            2
-        );
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 2")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 2);
+        assert_eq!(res.sources[0].source_kind, ImportSourceKind::Directory);
+        assert_eq!(res.sources[0].processed_files.len(), 2);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -482,11 +736,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages[0].content.contains("Imported:"));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Imported);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -509,7 +761,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages[0].content.contains("Path not found"));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Missing);
     }
 
     #[test]
@@ -540,11 +793,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages[0].content.contains("Failed to import"));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 0")));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Invalid);
     }
 
     #[test]
@@ -563,10 +813,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 0")));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Skipped);
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
             .unwrap();
@@ -579,10 +827,8 @@ mod tests {
 
         let res = run(&mut store, Scope::Project, vec![], &[".md".to_string()]).unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 0")));
+        assert_eq!(res.status, ImportStatus::NoImports);
+        assert!(res.sources.is_empty());
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
             .unwrap();
@@ -607,15 +853,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Path not found")));
-        assert!(res.messages.iter().any(|m| m.content.contains("Imported:")));
+        assert_eq!(res.status, ImportStatus::PartialSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert_eq!(res.sources[0].status, ImportSourceStatus::Imported);
+        assert_eq!(res.sources[1].status, ImportSourceStatus::Missing);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -642,10 +883,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -671,10 +909,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)
@@ -710,10 +945,11 @@ mod tests {
         std::fs::write(&path, body).unwrap();
 
         let res = run(&mut store, Scope::Project, vec![path], &[".md".into()]).unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
+        assert!(matches!(
+            res.sources[0].diagnostics[0],
+            ImportDiagnostic::InlineMetadataApplied { .. }
+        ));
 
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -746,10 +982,11 @@ mod tests {
         std::fs::write(&path, body).unwrap();
 
         let res = run(&mut store, Scope::Project, vec![path], &[".lex".into()]).unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.total_imported, 1);
+        assert!(matches!(
+            res.sources[0].diagnostics[0],
+            ImportDiagnostic::InlineMetadataApplied { .. }
+        ));
 
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -808,10 +1045,12 @@ mod tests {
 
         let res = run(&mut store, Scope::Project, vec![path], &[".md".into()]).unwrap();
 
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("invalid status")));
+        assert_eq!(res.status, ImportStatus::PartialSuccess);
+        assert!(res.sources[0].diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::MetadataWarning { warning }
+                if warning.field.as_deref() == Some("status")
+        )));
 
         let pads = store.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -855,6 +1094,112 @@ mod tests {
         path
     }
 
+    fn handcrafted_archive(db: serde_json::Value, files: &[(&str, &[u8])]) -> std::path::PathBuf {
+        let temp = tempfile::NamedTempFile::with_suffix(".tar.gz").unwrap();
+        let (file, path) = temp.keep().unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        for (path, content) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append_data(&mut header, format!("padz/{path}"), *content)
+                .unwrap();
+        }
+        let db = serde_json::to_vec(&db).unwrap();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(db.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, "padz/db.json", db.as_slice())
+            .unwrap();
+        tar.into_inner().unwrap().finish().unwrap();
+        path
+    }
+
+    #[test]
+    fn archive_entry_skip_is_typed_and_other_entries_continue() {
+        let good_id = Uuid::new_v4();
+        let missing_id = Uuid::new_v4();
+        let good_file = format!("pads/pad-{good_id}.txt");
+        let missing_file = format!("pads/pad-{missing_id}.txt");
+        let db = serde_json::json!({
+            "schema_version": 1,
+            "exported_at": "2026-04-22T00:00:00Z",
+            "padz_version": "1.9.0",
+            "pads": [
+                {"file": good_file.clone(), "metadata": {"id": good_id.to_string()}},
+                {"file": missing_file.clone(), "metadata": {"id": missing_id.to_string()}}
+            ],
+            "tags": []
+        });
+        let archive = handcrafted_archive(db, &[(good_file.as_str(), b"Good\n\nBody")]);
+        let mut store = new_store();
+
+        let report = run(
+            &mut store,
+            Scope::Project,
+            vec![archive.clone()],
+            &[".txt".into()],
+        )
+        .unwrap();
+
+        assert_eq!(report.status, ImportStatus::PartialSuccess);
+        assert_eq!(report.total_imported, 1);
+        assert!(report.sources[0]
+            .diagnostics
+            .iter()
+            .any(|diagnostic| matches!(
+                diagnostic,
+                ImportDiagnostic::ArchiveEntrySkipped {
+                    entry,
+                    reason: ArchiveEntrySkipReason::MissingFile,
+                    ..
+                } if entry == &missing_file
+            )));
+        std::fs::remove_file(archive).ok();
+    }
+
+    #[test]
+    fn tag_registry_merge_failure_is_typed_partial_success() {
+        let id = Uuid::new_v4();
+        let file = format!("pads/pad-{id}.txt");
+        let db = serde_json::json!({
+            "schema_version": 1,
+            "exported_at": "2026-04-22T00:00:00Z",
+            "padz_version": "1.9.0",
+            "pads": [{"file": file.clone(), "metadata": {"id": id.to_string(), "tags": ["work"]}}],
+            "tags": [{"name": "work", "created_at": "2026-04-22T00:00:00Z"}]
+        });
+        let archive = handcrafted_archive(db, &[(file.as_str(), b"Tagged\n\nBody")]);
+        let mut store = new_store();
+        store.tag_backend.set_simulate_write_error(true);
+
+        let report = run(
+            &mut store,
+            Scope::Project,
+            vec![archive.clone()],
+            &[".txt".into()],
+        )
+        .unwrap();
+
+        assert_eq!(report.status, ImportStatus::PartialSuccess);
+        assert_eq!(report.total_imported, 1);
+        assert!(report.sources[0]
+            .diagnostics
+            .iter()
+            .any(|diagnostic| matches!(
+                diagnostic,
+                ImportDiagnostic::TagRegistryMerge {
+                    status: TagRegistryMergeStatus::Failed,
+                    added: 1,
+                    ..
+                }
+            )));
+        std::fs::remove_file(archive).ok();
+    }
+
     #[test]
     fn test_json_roundtrip_preserves_metadata() {
         let mut src = new_store();
@@ -896,10 +1241,16 @@ mod tests {
             &[".md".into(), ".txt".into(), ".lex".into()],
         )
         .unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert!(res.sources[0].diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::TagRegistryMerge {
+                status: TagRegistryMergeStatus::Merged,
+                added: 1,
+                ..
+            }
+        )));
 
         let pads = dst.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -1081,14 +1432,13 @@ mod tests {
             &[".md".into()],
         )
         .unwrap();
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
-        assert!(
-            res.messages.iter().any(|m| m.content.contains("status")),
-            "expected a warning mentioning the bad status field"
-        );
+        assert_eq!(res.status, ImportStatus::PartialSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert!(res.sources[0].diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::MetadataWarning { warning }
+                if warning.field.as_deref() == Some("status")
+        )));
 
         let pads = dst.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(pads.len(), 1);
@@ -1166,11 +1516,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(res.messages.iter().any(|m| m.content.contains("Imported:")));
-        assert!(res
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Total imported: 1")));
+        assert_eq!(res.status, ImportStatus::FullSuccess);
+        assert_eq!(res.total_imported, 1);
+        assert_eq!(res.sources[0].processed_files.len(), 1);
 
         let pads = store
             .list_pads(Scope::Project, crate::store::Bucket::Active)

--- a/crates/padzapp/src/commands/io/import.rs
+++ b/crates/padzapp/src/commands/io/import.rs
@@ -61,6 +61,14 @@ pub enum ArchiveEntrySkipReason {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum DirectoryEntrySkipReason {
+    ReadEntry,
+    InspectEntry,
+    ImportFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TagRegistryMergeStatus {
     Merged,
     Failed,
@@ -87,8 +95,16 @@ pub enum ImportDiagnostic {
         reason: ArchiveEntrySkipReason,
         detail: String,
     },
+    DirectoryEntrySkipped {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        entry: Option<PathBuf>,
+        reason: DirectoryEntrySkipReason,
+        detail: String,
+    },
     TagRegistryMerge {
         status: TagRegistryMergeStatus,
+        /// Number of registry entries successfully persisted by this merge.
+        /// Failed merges always report zero.
         added: usize,
         #[serde(skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
@@ -119,6 +135,10 @@ pub struct ImportReport {
 }
 
 /// Import every requested path and return one presentation-free report.
+///
+/// Recoverable directory-entry inspection and file-import failures are
+/// retained as diagnostics so a partly imported directory cannot appear fully
+/// successful.
 pub fn run<S: DataStore>(
     store: &mut S,
     scope: Scope,
@@ -160,49 +180,28 @@ pub fn run<S: DataStore>(
             let entries = match fs::read_dir(&path) {
                 Ok(entries) => entries,
                 Err(error) => {
-                    sources.push(ImportSourceReport {
-                        source: path,
-                        source_kind: ImportSourceKind::Directory,
-                        status: source_error_status(&PadzError::Io(error)),
-                        imported: 0,
-                        processed_files: Vec::new(),
-                        detail: Some("directory could not be read".to_string()),
-                        diagnostics: Vec::new(),
-                    });
+                    sources.push(unreadable_directory_report(path, error));
                     continue;
                 }
             };
-            let mut imported = 0;
-            let mut processed_files = Vec::new();
-            let mut diagnostics = Vec::new();
-            for entry in entries {
-                let Ok(entry) = entry else { continue };
-                let sub_path = entry.path();
-                if sub_path.is_file() {
-                    if let Some(ext) = sub_path.extension() {
-                        let ext_str = format!(".{}", ext.to_string_lossy());
-                        if import_exts.contains(&ext_str) {
-                            if let Ok(res) = import_file(store, scope, &sub_path) {
-                                imported += res.imported;
-                                processed_files.push(sub_path);
-                                diagnostics.extend(res.diagnostics());
-                            }
-                        }
-                    }
-                }
-            }
+            let directory = import_directory_entries(
+                store,
+                scope,
+                entries.map(|entry| entry.map(|entry| entry.path())),
+                import_exts,
+            );
             sources.push(ImportSourceReport {
                 source: path,
                 source_kind: ImportSourceKind::Directory,
-                status: if imported > 0 {
+                status: if directory.imported > 0 {
                     ImportSourceStatus::Imported
                 } else {
                     ImportSourceStatus::Skipped
                 },
-                imported,
-                processed_files,
+                imported: directory.imported,
+                processed_files: directory.processed_files,
                 detail: None,
-                diagnostics,
+                diagnostics: directory.diagnostics,
             });
         } else if path.is_file() {
             sources.push(match import_file(store, scope, &path) {
@@ -260,6 +259,94 @@ pub fn run<S: DataStore>(
     })
 }
 
+fn unreadable_directory_report(path: PathBuf, error: std::io::Error) -> ImportSourceReport {
+    let detail = error.to_string();
+    let status = source_error_status(&PadzError::Io(error));
+    ImportSourceReport {
+        source: path,
+        source_kind: ImportSourceKind::Directory,
+        status,
+        imported: 0,
+        processed_files: Vec::new(),
+        detail: Some(detail),
+        diagnostics: Vec::new(),
+    }
+}
+
+struct DirectoryImportResult {
+    imported: usize,
+    processed_files: Vec<PathBuf>,
+    diagnostics: Vec<ImportDiagnostic>,
+}
+
+/// Import matching directory entries while retaining every recoverable entry
+/// failure as an ordered diagnostic.
+fn import_directory_entries<S, I>(
+    store: &mut S,
+    scope: Scope,
+    entries: I,
+    import_exts: &[String],
+) -> DirectoryImportResult
+where
+    S: DataStore,
+    I: IntoIterator<Item = std::io::Result<PathBuf>>,
+{
+    let mut imported = 0;
+    let mut processed_files = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for entry in entries {
+        let sub_path = match entry {
+            Ok(path) => path,
+            Err(error) => {
+                diagnostics.push(ImportDiagnostic::DirectoryEntrySkipped {
+                    entry: None,
+                    reason: DirectoryEntrySkipReason::ReadEntry,
+                    detail: error.to_string(),
+                });
+                continue;
+            }
+        };
+        let Some(ext) = sub_path.extension() else {
+            continue;
+        };
+        let ext = format!(".{}", ext.to_string_lossy());
+        if !import_exts.contains(&ext) {
+            continue;
+        }
+        match fs::metadata(&sub_path) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => continue,
+            Err(error) => {
+                diagnostics.push(ImportDiagnostic::DirectoryEntrySkipped {
+                    entry: Some(sub_path),
+                    reason: DirectoryEntrySkipReason::InspectEntry,
+                    detail: error.to_string(),
+                });
+                continue;
+            }
+        }
+        match import_file(store, scope, &sub_path) {
+            Ok(result) => {
+                imported += result.imported;
+                processed_files.push(sub_path);
+                diagnostics.extend(result.diagnostics());
+            }
+            Err(error) => diagnostics.push(ImportDiagnostic::DirectoryEntrySkipped {
+                entry: Some(sub_path),
+                reason: DirectoryEntrySkipReason::ImportFile,
+                detail: error.to_string(),
+            }),
+        }
+    }
+
+    DirectoryImportResult {
+        imported,
+        processed_files,
+        diagnostics,
+    }
+}
+
 fn source_error_status(error: &PadzError) -> ImportSourceStatus {
     match error {
         PadzError::Io(error) if error.kind() != std::io::ErrorKind::InvalidData => {
@@ -280,7 +367,8 @@ fn source_is_partial(source: &ImportSourceReport) -> bool {
             ImportDiagnostic::MetadataWarning { warning } => {
                 warning.severity == MetadataWarningSeverity::Warning
             }
-            ImportDiagnostic::ArchiveEntrySkipped { .. } => true,
+            ImportDiagnostic::ArchiveEntrySkipped { .. }
+            | ImportDiagnostic::DirectoryEntrySkipped { .. } => true,
             ImportDiagnostic::TagRegistryMerge { status, .. } => {
                 *status == TagRegistryMergeStatus::Failed
             }
@@ -498,7 +586,7 @@ fn import_json_archive<S: DataStore>(
             if !archive.tags.is_empty() {
                 diagnostics.push(ImportDiagnostic::TagRegistryMerge {
                     status: TagRegistryMergeStatus::Failed,
-                    added: archive.tags.len(),
+                    added: 0,
                     detail: Some(error.to_string()),
                 });
             }
@@ -523,7 +611,7 @@ fn import_json_archive<S: DataStore>(
         if let Err(e) = store.save_tags(scope, &new_tags) {
             diagnostics.push(ImportDiagnostic::TagRegistryMerge {
                 status: TagRegistryMergeStatus::Failed,
-                added: added_tags,
+                added: 0,
                 detail: Some(e.to_string()),
             });
         } else {
@@ -719,6 +807,82 @@ mod tests {
         assert_eq!(pads.len(), 2);
         assert!(pads.iter().any(|p| p.metadata.title == "# Note 1"));
         assert!(pads.iter().any(|p| p.metadata.title == "Note 2"));
+    }
+
+    #[test]
+    fn unreadable_directory_report_retains_io_error_detail() {
+        let report = unreadable_directory_report(
+            PathBuf::from("locked"),
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "permission denied while listing",
+            ),
+        );
+
+        assert_eq!(report.status, ImportSourceStatus::Unreadable);
+        assert_eq!(
+            report.detail.as_deref(),
+            Some("permission denied while listing")
+        );
+    }
+
+    #[test]
+    fn directory_entry_failures_are_typed_and_make_import_partial() {
+        let mut store = new_store();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let imported_path = temp_dir.path().join("imported.md");
+        let invalid_path = temp_dir.path().join("invalid.md");
+        let vanished_path = temp_dir.path().join("vanished.md");
+        std::fs::write(&imported_path, "Imported\n\nBody").unwrap();
+        std::fs::write(&invalid_path, [0xff, 0xfe]).unwrap();
+
+        let directory = import_directory_entries(
+            &mut store,
+            Scope::Project,
+            vec![
+                Ok(imported_path.clone()),
+                Ok(invalid_path.clone()),
+                Ok(vanished_path.clone()),
+                Err(std::io::Error::other("entry vanished while listing")),
+            ],
+            &[".md".to_string()],
+        );
+
+        assert_eq!(directory.imported, 1);
+        assert_eq!(directory.processed_files, vec![imported_path]);
+        assert!(directory.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry: Some(entry),
+                reason: DirectoryEntrySkipReason::ImportFile,
+                ..
+            } if entry == &invalid_path
+        )));
+        assert!(directory.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry: Some(entry),
+                reason: DirectoryEntrySkipReason::InspectEntry,
+                ..
+            } if entry == &vanished_path
+        )));
+        assert!(directory.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            ImportDiagnostic::DirectoryEntrySkipped {
+                entry: None,
+                reason: DirectoryEntrySkipReason::ReadEntry,
+                ..
+            }
+        )));
+        assert!(source_is_partial(&ImportSourceReport {
+            source: temp_dir.path().to_path_buf(),
+            source_kind: ImportSourceKind::Directory,
+            status: ImportSourceStatus::Imported,
+            imported: directory.imported,
+            processed_files: directory.processed_files,
+            detail: None,
+            diagnostics: directory.diagnostics,
+        }));
     }
 
     #[test]
@@ -1193,7 +1357,7 @@ mod tests {
                 diagnostic,
                 ImportDiagnostic::TagRegistryMerge {
                     status: TagRegistryMergeStatus::Failed,
-                    added: 1,
+                    added: 0,
                     ..
                 }
             )));

--- a/crates/padzapp/src/commands/metadata_apply.rs
+++ b/crates/padzapp/src/commands/metadata_apply.rs
@@ -144,12 +144,20 @@ mod tests {
         );
 
         assert_eq!(warnings.len(), 2);
-        assert_eq!(warnings[0].source_label, "entry.lex");
-        assert_eq!(warnings[0].category, MetadataWarningCategory::Field);
-        assert_eq!(warnings[0].reason, MetadataWarningReason::InvalidValue);
-        assert_eq!(warnings[0].field.as_deref(), Some("status"));
-        assert_eq!(warnings[0].severity, MetadataWarningSeverity::Warning);
-        assert_eq!(warnings[1].category, MetadataWarningCategory::Tags);
-        assert_eq!(warnings[1].count, Some(1));
+        assert!(warnings.iter().all(|warning| {
+            warning.source_label == "entry.lex"
+                && warning.severity == MetadataWarningSeverity::Warning
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.category == MetadataWarningCategory::Field
+                && warning.reason == MetadataWarningReason::InvalidValue
+                && warning.field.as_deref() == Some("status")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.category == MetadataWarningCategory::Tags
+                && warning.reason == MetadataWarningReason::NonStringEntries
+                && warning.field.as_deref() == Some("tags")
+                && warning.count == Some(1)
+        }));
     }
 }

--- a/crates/padzapp/src/commands/metadata_apply.rs
+++ b/crates/padzapp/src/commands/metadata_apply.rs
@@ -1,44 +1,119 @@
-//! Thin CLI-layer adapter over [`crate::model::Metadata::apply_json_patch`].
+//! Thin import-boundary adapter over [`crate::model::Metadata::apply_json_patch`].
 //!
-//! The defensive "apply every field, collect per-field warnings" logic lives
-//! on the `Metadata` model — see [`crate::model::Metadata::apply_json_patch`].
-//! This module's job is only:
-//!
-//! - convert model-level [`crate::model::MetadataPatchWarning`]s into
-//!   user-facing [`CmdMessage`]s, tagging each with the source (file name /
-//!   pad id)
-//! - parse bucket labels coming off the wire (a store concept, not a model one)
-//!
-//! The JSON-archive import and the md/lex inline-metadata import both go
-//! through this adapter so warning formatting stays consistent.
+//! The defensive "apply every field, collect per-field outcomes" logic lives
+//! on the [`crate::model::Metadata`] model. This module adds the source label
+//! and stable semantic categories needed by import clients. It deliberately
+//! returns no authored prose: a CLI can render compatible diagnostics while a
+//! structured client branches on category, reason, field, count, and severity.
 
-use crate::commands::CmdMessage;
 use crate::model::{MetadataPatchWarning, Pad};
 use crate::store::Bucket;
+use serde::{Deserialize, Serialize};
 
 pub use crate::model::ParentPolicy;
 
-/// Apply `value` to `pad.metadata` defensively and return user-facing
-/// messages prefixed with `source_label` (e.g. a file path or pad id).
+/// Severity of a recoverable metadata-application outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningSeverity {
+    Info,
+    Warning,
+}
+
+/// Stable area of metadata affected by a warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningCategory {
+    Metadata,
+    Field,
+    Tags,
+    Parent,
+}
+
+/// Stable reason a metadata value was not applied as requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataWarningReason {
+    NotAnObject,
+    InvalidValue,
+    NonStringEntries,
+    OutsideImportSet,
+}
+
+/// One typed, source-labelled metadata application warning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetadataApplicationWarning {
+    pub source_label: String,
+    pub category: MetadataWarningCategory,
+    pub reason: MetadataWarningReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    pub severity: MetadataWarningSeverity,
+}
+
+/// Apply `value` to `pad.metadata` defensively and return stable warning facts.
 pub fn apply_metadata_defensively(
     pad: &mut Pad,
     value: &serde_json::Value,
     parent_policy: ParentPolicy<'_>,
     source_label: &str,
-) -> Vec<CmdMessage> {
+) -> Vec<MetadataApplicationWarning> {
     pad.metadata
         .apply_json_patch(value, &parent_policy)
         .into_iter()
-        .map(|w| warning_to_message(w, source_label))
+        .map(|warning| warning_fact(warning, source_label))
         .collect()
 }
 
-fn warning_to_message(w: MetadataPatchWarning, source_label: &str) -> CmdMessage {
-    let text = format!("{}: {}", source_label, w);
-    if w.is_info() {
-        CmdMessage::info(text)
-    } else {
-        CmdMessage::warning(text)
+fn warning_fact(warning: MetadataPatchWarning, source_label: &str) -> MetadataApplicationWarning {
+    use MetadataPatchWarning as Warning;
+
+    let (category, reason, field, count) = match warning {
+        Warning::NotAnObject => (
+            MetadataWarningCategory::Metadata,
+            MetadataWarningReason::NotAnObject,
+            None,
+            None,
+        ),
+        Warning::InvalidId => (
+            MetadataWarningCategory::Field,
+            MetadataWarningReason::InvalidValue,
+            Some("id".to_string()),
+            None,
+        ),
+        Warning::InvalidField(field) => (
+            MetadataWarningCategory::Field,
+            MetadataWarningReason::InvalidValue,
+            Some(field.to_string()),
+            None,
+        ),
+        Warning::NonStringTags(count) => (
+            MetadataWarningCategory::Tags,
+            MetadataWarningReason::NonStringEntries,
+            Some("tags".to_string()),
+            Some(count),
+        ),
+        Warning::ParentOrphaned => (
+            MetadataWarningCategory::Parent,
+            MetadataWarningReason::OutsideImportSet,
+            Some("parent_id".to_string()),
+            None,
+        ),
+    };
+
+    MetadataApplicationWarning {
+        source_label: source_label.to_string(),
+        category,
+        reason,
+        field,
+        count,
+        severity: if warning.is_info() {
+            MetadataWarningSeverity::Info
+        } else {
+            MetadataWarningSeverity::Warning
+        },
     }
 }
 
@@ -50,5 +125,31 @@ pub fn parse_bucket_or_active(s: &str) -> Bucket {
         "Archived" => Bucket::Archived,
         "Deleted" => Bucket::Deleted,
         _ => Bucket::Active,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Pad;
+
+    #[test]
+    fn warning_facts_keep_source_category_reason_field_count_and_severity() {
+        let mut pad = Pad::new("Title".into(), "Body".into());
+        let warnings = apply_metadata_defensively(
+            &mut pad,
+            &serde_json::json!({"status": "broken", "tags": ["ok", 7]}),
+            ParentPolicy::Trust,
+            "entry.lex",
+        );
+
+        assert_eq!(warnings.len(), 2);
+        assert_eq!(warnings[0].source_label, "entry.lex");
+        assert_eq!(warnings[0].category, MetadataWarningCategory::Field);
+        assert_eq!(warnings[0].reason, MetadataWarningReason::InvalidValue);
+        assert_eq!(warnings[0].field.as_deref(), Some("status"));
+        assert_eq!(warnings[0].severity, MetadataWarningSeverity::Warning);
+        assert_eq!(warnings[1].category, MetadataWarningCategory::Tags);
+        assert_eq!(warnings[1].count, Some(1));
     }
 }

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -31,9 +31,9 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! Initialization, doctor, purge, tag catalog/mutation, and artifact-producing
-//! commands use dedicated outcome types where a generic result would obscure the
-//! operation's facts. Pad mutations that still use [`CmdResult`] attach
+//! Initialization, doctor, purge, import, tag catalog/mutation, and
+//! artifact-producing commands use dedicated outcome types where a generic
+//! result would obscure the operation's facts. Pad mutations that still use [`CmdResult`] attach
 //! presentation-free [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI,
 //! web, etc.) decides how to render every result.
 //!


### PR DESCRIPTION
## Context

for #216

Why this approach: WS04 extends the semantic-result pattern established by #207 and integrated through #224, #226, and #227. padzapp now returns one ordered import report with full-success, partial-success, or no-import status; one typed outcome per requested source; typed metadata warnings; inline-metadata effects; archive-entry skips; and tag-registry merge outcomes. Thin CLI adapters project those facts into a stable structured DTO, while import.jinja preserves the existing human wording, order, final summary, and info/warning/success styles.

Structured import output intentionally changes from a prose-only messages array to status, total_imported, and source-local factual outcomes. The external import-partial JSON fixture pins the schema, TestHarness proves JSON/YAML/XML/CSV serialization, and the unreleased changelog documents the transition. Recoverable source and archive-entry failures continue independent inputs; warning-level metadata loss, archive skips, source skips/failures, and tag-merge failure yield partial success, while informational parent orphaning alone does not.

Standout v7.9.0 was already coherently pinned on the epic base before this workstream, so no dependency change is included here.

Out of scope: #217-#223, dependency changes, storage/tag validation redesign, archive-format changes, and broad wording or visual redesign. Do not move human sentences back into padzapp or handlers, collapse warning/partial-success distinctions, or drop source-local ordering.

Verification:
- env RUSTC_WRAPPER= pixi run test — 873 passed, 1 skipped
- commit and push hooks — all 12 lint checks passed

Governing-doc self-check: reviewed every acceptance criterion and compatibility/non-goal boundary in epic #208 and issue #216, the semantic ownership pattern from #207, and integrated workstreams #224, #226, and #227. No separate ADR/spec list was supplied in the implementer brief; this mandatory brief-slot gap is recorded here rather than guessed.