### PR TITLE
STD02-WS05: Epic: Complete Remaining Standout Ownership Work - Workstream: Semantic Cross-Store Transfer Outcomes

### DIFF
--- a/CHANGELOG/unreleased-semantic-transfer-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-transfer-outcomes.md
@@ -1,0 +1,9 @@
+- Clone and migrate now expose one semantic cross-store transfer report in
+  structured output. The report identifies operation, direction, resolved peer
+  store, requested selection, copied pad IDs/count, and explicit empty,
+  full-success, partial-success, or no-copy status. Ordered typed diagnostics
+  distinguish source-read and destination-write copy failures, parent orphaning,
+  destination bucket enumeration failures, tag-registry merge failures, and
+  migrate source-delete failures. This intentionally replaces the former
+  prose-only `messages` schema; human wording, ordering, and styles remain
+  compatible through the CLI-owned transfer template.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -31,7 +31,7 @@ use super::result::{
     DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
     MessagesResult, ModificationRequest, ModificationResult, PadContent, PadContentResult,
     PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
-    UuidResult,
+    TransferResult, UuidResult,
 };
 
 // =============================================================================
@@ -170,11 +170,6 @@ impl<'a> ScopedApi<'a> {
                 status: self.state.wants_status(force_show_status),
             },
         }
-    }
-
-    /// Map a CmdResult (messages only) into the typed messages result
-    fn messages(&self, result: CmdResult) -> Result<Output<MessagesResult>, anyhow::Error> {
-        Ok(Output::Render(MessagesResult::new(result.messages)))
     }
 
     // --- Modification operations ---
@@ -351,19 +346,19 @@ impl<'a> ScopedApi<'a> {
         to: Option<&str>,
         from: Option<&str>,
         mode: padzapp::commands::transfer::TransferMode,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<TransferResult>, anyhow::Error> {
         match (to, from) {
             (Some(dest), None) => {
                 let path = std::path::PathBuf::from(dest);
                 let result =
                     self.call(|api, scope| api.transfer_pads_to(scope, indexes, &path, mode))?;
-                self.messages(result)
+                Ok(Output::Render(result.into()))
             }
             (None, Some(src)) => {
                 let path = std::path::PathBuf::from(src);
                 let result =
                     self.call(|api, scope| api.transfer_pads_from(scope, indexes, &path, mode))?;
-                self.messages(result)
+                Ok(Output::Render(result.into()))
             }
             (Some(_), Some(_)) => Err(anyhow::anyhow!("--to and --from are mutually exclusive")),
             (None, None) => Err(anyhow::anyhow!("exactly one of --to or --from is required")),
@@ -1192,7 +1187,7 @@ pub fn clone(
     #[arg] indexes: Vec<String>,
     #[arg] to: Option<String>,
     #[arg] from: Option<String>,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<TransferResult>, anyhow::Error> {
     api(ctx).transfer_pads(
         &indexes,
         to.as_deref(),
@@ -1207,7 +1202,7 @@ pub fn migrate(
     #[arg] indexes: Vec<String>,
     #[arg] to: Option<String>,
     #[arg] from: Option<String>,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<TransferResult>, anyhow::Error> {
     api(ctx).transfer_pads(
         &indexes,
         to.as_deref(),

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -10,7 +10,7 @@
 //!
 //! These are CLI-only adapter types: they exist purely to establish the shell's
 //! result contract, so they live in the binary rather than in `padzapp`. The data
-//! they carry (`DisplayPad`, `CmdMessage`, `PeekResult`, semantic tag outcomes) is
+//! they carry (`DisplayPad`, `CmdMessage`, semantic tag/transfer outcomes) is
 //! reusable domain data and stays in `padzapp`.
 //!
 //! ## Presentation is not in here
@@ -670,6 +670,173 @@ impl From<padzapp::commands::metadata_apply::MetadataApplicationWarning> for Met
             severity: match warning.severity {
                 MetadataWarningSeverity::Info => MetadataWarningSeverityResult::Info,
                 MetadataWarningSeverity::Warning => MetadataWarningSeverityResult::Warning,
+            },
+        }
+    }
+}
+
+/// CLI-owned projection of a complete cross-store clone/migrate report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferResult {
+    pub status: TransferStatusResult,
+    pub operation: TransferOperationResult,
+    pub direction: TransferDirectionResult,
+    pub peer_store: String,
+    pub requested_selection: TransferSelectionResult,
+    pub copied_pad_ids: Vec<String>,
+    pub copied_count: usize,
+    pub diagnostics: Vec<TransferDiagnosticResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferStatusResult {
+    Empty,
+    FullSuccess,
+    PartialSuccess,
+    NoCopies,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferOperationResult {
+    Clone,
+    Migrate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirectionResult {
+    To,
+    From,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferSelectionResult {
+    AllNonDeleted,
+    Explicit { selectors: Vec<String> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferBucketResult {
+    Active,
+    Archived,
+    Deleted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopyFailureCategoryResult {
+    SourceRead,
+    DestinationWrite,
+}
+
+/// Ordered transfer diagnostics; the template renders the compatible prose.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferDiagnosticResult {
+    DestinationBucketEnumerationFailed {
+        bucket: TransferBucketResult,
+        detail: String,
+    },
+    ParentOrphaned {
+        pad_id: String,
+        parent_id: String,
+    },
+    CopyFailed {
+        pad_id: String,
+        category: CopyFailureCategoryResult,
+        detail: String,
+    },
+    TagRegistryMergeFailed {
+        detail: String,
+    },
+    SourceDeleteFailed {
+        pad_id: String,
+        detail: String,
+    },
+}
+
+impl From<padzapp::commands::transfer::TransferReport> for TransferResult {
+    fn from(report: padzapp::commands::transfer::TransferReport) -> Self {
+        use padzapp::commands::transfer::{
+            TransferDirection, TransferMode, TransferSelection, TransferStatus,
+        };
+
+        Self {
+            status: match report.status {
+                TransferStatus::Empty => TransferStatusResult::Empty,
+                TransferStatus::FullSuccess => TransferStatusResult::FullSuccess,
+                TransferStatus::PartialSuccess => TransferStatusResult::PartialSuccess,
+                TransferStatus::NoCopies => TransferStatusResult::NoCopies,
+            },
+            operation: match report.operation {
+                TransferMode::Clone => TransferOperationResult::Clone,
+                TransferMode::Migrate => TransferOperationResult::Migrate,
+            },
+            direction: match report.direction {
+                TransferDirection::To => TransferDirectionResult::To,
+                TransferDirection::From => TransferDirectionResult::From,
+            },
+            peer_store: report.peer_store.display().to_string(),
+            requested_selection: match report.requested_selection {
+                TransferSelection::AllNonDeleted => TransferSelectionResult::AllNonDeleted,
+                TransferSelection::Explicit { selectors } => {
+                    TransferSelectionResult::Explicit { selectors }
+                }
+            },
+            copied_pad_ids: report
+                .copied_pad_ids
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect(),
+            copied_count: report.copied_count,
+            diagnostics: report.diagnostics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<padzapp::commands::transfer::TransferDiagnostic> for TransferDiagnosticResult {
+    fn from(diagnostic: padzapp::commands::transfer::TransferDiagnostic) -> Self {
+        use padzapp::commands::transfer::{CopyFailureCategory, TransferDiagnostic};
+
+        match diagnostic {
+            TransferDiagnostic::DestinationBucketEnumerationFailed { bucket, detail } => {
+                Self::DestinationBucketEnumerationFailed {
+                    bucket: match bucket {
+                        padzapp::store::Bucket::Active => TransferBucketResult::Active,
+                        padzapp::store::Bucket::Archived => TransferBucketResult::Archived,
+                        padzapp::store::Bucket::Deleted => TransferBucketResult::Deleted,
+                    },
+                    detail,
+                }
+            }
+            TransferDiagnostic::ParentOrphaned { pad_id, parent_id } => Self::ParentOrphaned {
+                pad_id: pad_id.to_string(),
+                parent_id: parent_id.to_string(),
+            },
+            TransferDiagnostic::CopyFailed {
+                pad_id,
+                category,
+                detail,
+            } => Self::CopyFailed {
+                pad_id: pad_id.to_string(),
+                category: match category {
+                    CopyFailureCategory::SourceRead => CopyFailureCategoryResult::SourceRead,
+                    CopyFailureCategory::DestinationWrite => {
+                        CopyFailureCategoryResult::DestinationWrite
+                    }
+                },
+                detail,
+            },
+            TransferDiagnostic::TagRegistryMergeFailed { detail } => {
+                Self::TagRegistryMergeFailed { detail }
+            }
+            TransferDiagnostic::SourceDeleteFailed { pad_id, detail } => Self::SourceDeleteFailed {
+                pad_id: pad_id.to_string(),
+                detail,
             },
         }
     }

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -722,7 +722,7 @@ pub enum Commands {
 
     /// Copy pads to (or from) another padz store (source is kept)
     #[command(display_order = 23)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "transfer")]
     Clone {
         /// Indexes of the pads (e.g. 1 2) - if omitted, all non-deleted pads (active + archived)
         #[arg(required = false, num_args = 0.., add = active_pads_completer())]
@@ -739,7 +739,7 @@ pub enum Commands {
 
     /// Move pads to (or from) another padz store (source is removed on success)
     #[command(display_order = 24)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "transfer")]
     Migrate {
         /// Indexes of the pads (e.g. 1 2) - if omitted, all non-deleted pads (active + archived)
         #[arg(required = false, num_args = 0.., add = active_pads_completer())]

--- a/crates/padz/src/cli/templates/transfer.jinja
+++ b/crates/padz/src/cli/templates/transfer.jinja
@@ -1,0 +1,28 @@
+{#- Semantic cross-store facts rendered with the historical wording/order. -#}
+{% for diagnostic in diagnostics -%}
+{% if diagnostic.kind == "destination_bucket_enumeration_failed" -%}
+{% if diagnostic.bucket == "active" -%}
+{% set bucket = "Active" -%}
+{% elif diagnostic.bucket == "archived" -%}
+{% set bucket = "Archived" -%}
+{% else -%}
+{% set bucket = "Deleted" -%}
+{% endif -%}
+[warning]Could not enumerate destination bucket {{ bucket }}: {{ diagnostic.detail }}. Parent relationships that cross this bucket may be orphaned.[/warning]
+{% elif diagnostic.kind == "parent_orphaned" -%}
+[info]Pad {{ diagnostic.pad_id }}: parent not in move set, orphaned to root[/info]
+{% elif diagnostic.kind == "copy_failed" -%}
+[warning]Failed to {{ operation }} pad {{ diagnostic.pad_id }}: {{ diagnostic.detail }}[/warning]
+{% elif diagnostic.kind == "tag_registry_merge_failed" -%}
+[warning]Tag registry merge failed: {{ diagnostic.detail }}[/warning]
+{% else -%}
+[warning]Copied but failed to remove from source, pad {{ diagnostic.pad_id }}: {{ diagnostic.detail }}[/warning]
+{% endif -%}
+{% endfor -%}
+{% if status == "empty" -%}
+[info]No pads to transfer.[/info]
+{% elif status == "no_copies" -%}
+[warning]No pads were {{ "cloned" if operation == "clone" else "migrated" }} to {{ peer_store }}[/warning]
+{% else -%}
+[success]{{ "Cloned" if operation == "clone" else "Migrated" }} {{ copied_count }} pad(s) to {{ peer_store }}[/success]
+{% endif %}

--- a/crates/padz/tests/fixtures/semantic_outcomes/clone-success.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/clone-success.json
@@ -1,0 +1,13 @@
+{
+  "status": "full_success",
+  "operation": "clone",
+  "direction": "to",
+  "peer_store": "<PEER_STORE>",
+  "requested_selection": {
+    "kind": "explicit",
+    "selectors": ["1"]
+  },
+  "copied_pad_ids": ["<PAD_ID>"],
+  "copied_count": 1,
+  "diagnostics": []
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -30,7 +30,9 @@ use padz::cli::result::{
     ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
     MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
     MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
-    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, UpdateKindResult, UuidResult,
+    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferDirectionResult,
+    TransferOperationResult, TransferResult, TransferSelectionResult, TransferStatusResult,
+    UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -803,6 +805,49 @@ fn import_maps_core_source_and_metadata_warning_facts() {
                 if warning.reason == MetadataWarningReasonResult::InvalidValue
                     && warning.field.as_deref() == Some("status")
         )));
+}
+
+// =============================================================================
+// Cross-store transfer reports
+// =============================================================================
+
+#[test]
+fn clone_maps_operation_direction_peer_selection_and_copied_ids() {
+    let source = Fixture::new();
+    let peer = Fixture::new();
+    let state = source.app_state();
+    source.seed_pad(&state, "transfer me", "body");
+    let ctx = support::ctx_with_state(state);
+
+    let result: TransferResult = rendered(handlers::clone(
+        &ctx,
+        vec!["1".to_string()],
+        Some(peer.project().display().to_string()),
+        None,
+    ));
+
+    assert_eq!(result.status, TransferStatusResult::FullSuccess);
+    assert_eq!(result.operation, TransferOperationResult::Clone);
+    assert_eq!(result.direction, TransferDirectionResult::To);
+    assert_eq!(
+        result.peer_store,
+        peer.project()
+            .join(".padz")
+            .canonicalize()
+            .unwrap()
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        result.requested_selection,
+        TransferSelectionResult::Explicit {
+            selectors: vec!["1".to_string()]
+        }
+    );
+    assert_eq!(result.copied_count, 1);
+    assert_eq!(result.copied_pad_ids.len(), 1);
+    assert!(uuid::Uuid::parse_str(&result.copied_pad_ids[0]).is_ok());
+    assert!(result.diagnostics.is_empty());
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -499,6 +499,199 @@ fn import_report_serializes_in_every_structured_mode() {
 }
 
 // =============================================================================
+// Semantic cross-store transfer outcomes
+// =============================================================================
+
+#[test]
+#[serial]
+fn clone_preserves_text_and_exposes_transfer_facts() {
+    let text_source = Fixture::new();
+    let text_peer = Fixture::new();
+    let state = text_source.app_state();
+    text_source.seed_pad(&state, "Alpha", "body");
+    drop(state);
+    let peer_arg = text_peer.project().display().to_string();
+    let peer_store = text_peer
+        .project()
+        .join(".padz")
+        .canonicalize()
+        .unwrap()
+        .display()
+        .to_string();
+    let (app, cmd) = text_source.app(&["clone", "1", "--to", &peer_arg]);
+    let text = TestHarness::new().no_color().run(
+        &app,
+        cmd,
+        text_source.argv(&["clone", "1", "--to", &peer_arg, "--output", "text"]),
+    );
+    text.assert_success();
+    assert_eq!(text.stdout(), format!("Cloned 1 pad(s) to {peer_store}\n"));
+    drop(text);
+
+    let (app, cmd) = text_source.app(&["clone", "1", "--to", &peer_arg]);
+    let styled = TestHarness::new().run(
+        &app,
+        cmd,
+        text_source.argv(&["clone", "1", "--to", &peer_arg, "--output", "term-debug"]),
+    );
+    styled.assert_success();
+    assert_eq!(
+        styled.stdout(),
+        format!("[success]Cloned 1 pad(s) to {peer_store}[/success]\n")
+    );
+    drop(styled);
+
+    let json_source = Fixture::new();
+    let json_peer = Fixture::new();
+    let state = json_source.app_state();
+    json_source.seed_pad(&state, "Alpha", "body");
+    drop(state);
+    let peer_arg = json_peer.project().display().to_string();
+    let (app, cmd) = json_source.app(&["clone", "1", "--to", &peer_arg]);
+    let json = TestHarness::new().run(
+        &app,
+        cmd,
+        json_source.argv(&["clone", "1", "--to", &peer_arg, "--output", "json"]),
+    );
+    json.assert_success();
+    let mut value: serde_json::Value = serde_json::from_str(json.stdout()).unwrap();
+    value["peer_store"] = serde_json::json!("<PEER_STORE>");
+    value["copied_pad_ids"][0] = serde_json::json!("<PAD_ID>");
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/clone-success.json"
+    ))
+    .unwrap();
+    assert_eq!(value, expected);
+    assert!(value.get("messages").is_none());
+}
+
+#[test]
+#[serial]
+fn clone_empty_and_parent_orphaning_are_explicit_states() {
+    let empty_source = Fixture::new();
+    let empty_peer = Fixture::new();
+    let peer_arg = empty_peer.project().display().to_string();
+    let (app, cmd) = empty_source.app(&["clone", "--to", &peer_arg]);
+    let empty = TestHarness::new().run(
+        &app,
+        cmd,
+        empty_source.argv(&["clone", "--to", &peer_arg, "--output", "json"]),
+    );
+    empty.assert_success();
+    let empty_value: serde_json::Value = serde_json::from_str(empty.stdout()).unwrap();
+    assert_eq!(empty_value["status"], "empty");
+    assert_eq!(
+        empty_value["requested_selection"]["kind"],
+        "all_non_deleted"
+    );
+    assert_eq!(empty_value["copied_count"], 0);
+    assert_eq!(empty_value["diagnostics"], serde_json::json!([]));
+    drop(empty);
+
+    let source = Fixture::new();
+    let peer = Fixture::new();
+    let state = source.app_state();
+    source.seed_pad(&state, "Parent", "");
+    source.seed_child(&state, "1", "Child", "");
+    drop(state);
+    let peer_arg = peer.project().display().to_string();
+    let (app, cmd) = source.app(&["clone", "1.1", "--to", &peer_arg]);
+    let orphaned = TestHarness::new().run(
+        &app,
+        cmd,
+        source.argv(&["clone", "1.1", "--to", &peer_arg, "--output", "json"]),
+    );
+    orphaned.assert_success();
+    let value: serde_json::Value = serde_json::from_str(orphaned.stdout()).unwrap();
+    assert_eq!(value["status"], "partial_success");
+    assert_eq!(value["copied_count"], 1);
+    assert_eq!(value["diagnostics"][0]["kind"], "parent_orphaned");
+    assert_eq!(
+        value["diagnostics"][0]["pad_id"],
+        value["copied_pad_ids"][0]
+    );
+    assert!(value["diagnostics"][0]["parent_id"].is_string());
+    drop(orphaned);
+
+    let styled_peer = Fixture::new();
+    let styled_peer_arg = styled_peer.project().display().to_string();
+    let (app, cmd) = source.app(&["clone", "1.1", "--to", &styled_peer_arg]);
+    let styled = TestHarness::new().run(
+        &app,
+        cmd,
+        source.argv(&[
+            "clone",
+            "1.1",
+            "--to",
+            &styled_peer_arg,
+            "--output",
+            "term-debug",
+        ]),
+    );
+    styled.assert_success();
+    let orphan_position = styled
+        .stdout()
+        .find("[info]Pad ")
+        .expect("orphan info style");
+    let summary_position = styled
+        .stdout()
+        .find("[success]Cloned 1 pad(s)")
+        .expect("success summary style");
+    assert!(orphan_position < summary_position);
+    assert!(styled
+        .stdout()
+        .contains("parent not in move set, orphaned to root[/info]"));
+}
+
+#[test]
+#[serial]
+fn transfer_report_serializes_in_every_structured_mode() {
+    for mode in ["json", "yaml", "xml", "csv"] {
+        let source = Fixture::new();
+        let peer = Fixture::new();
+        let state = source.app_state();
+        source.seed_pad(&state, "Alpha", "body");
+        drop(state);
+        let peer_arg = peer.project().display().to_string();
+        let (app, cmd) = source.app(&["clone", "1", "--to", &peer_arg]);
+        let result = TestHarness::new().run(
+            &app,
+            cmd,
+            source.argv(&["clone", "1", "--to", &peer_arg, "--output", mode]),
+        );
+        result.assert_success();
+        match mode {
+            "json" => {
+                serde_json::from_str::<serde_json::Value>(result.stdout()).unwrap();
+            }
+            "yaml" => {
+                serde_yaml::from_str::<serde_yaml::Value>(result.stdout()).unwrap();
+            }
+            "xml" => {
+                let mut reader = quick_xml::Reader::from_str(result.stdout());
+                loop {
+                    match reader.read_event() {
+                        Ok(quick_xml::events::Event::Eof) => break,
+                        Ok(_) => {}
+                        Err(error) => {
+                            panic!("invalid transfer XML: {error}\n{}", result.stdout())
+                        }
+                    }
+                }
+            }
+            "csv" => {
+                let mut reader = csv::Reader::from_reader(result.stdout().as_bytes());
+                reader.headers().unwrap();
+                for row in reader.records() {
+                    row.unwrap();
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+// =============================================================================
 // Semantic pad mutation outcomes
 // =============================================================================
 

--- a/crates/padzapp/src/api/transfer.rs
+++ b/crates/padzapp/src/api/transfer.rs
@@ -52,16 +52,23 @@ impl<S: DataStore> PadzApi<S> {
         commands::import::run(&mut self.store, scope, paths, import_exts)
     }
 
-    /// Direction for clone/migrate: the external path is either the
-    /// destination (`--to`) or the source (`--from`).
+    /// Copy or migrate the requested selection into a resolved peer store.
+    ///
+    /// The returned report identifies the peer, direction, original selection,
+    /// copied IDs, and every partial-success diagnostic without presentation
+    /// prose.
     pub fn transfer_pads_to<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         dest_path: &std::path::Path,
         mode: commands::transfer::TransferMode,
-    ) -> Result<commands::CmdResult> {
-        let selectors = parse_selectors(indexes)?;
+    ) -> Result<commands::transfer::TransferReport> {
+        let requested: Vec<String> = indexes
+            .iter()
+            .map(|index| index.as_ref().to_string())
+            .collect();
+        let selectors = parse_selectors(&requested)?;
         let dest_padz =
             commands::transfer::resolve_target_dir(dest_path, self.paths.home.as_deref())?;
         // Refuse to transfer to the same store. For migrate the user would
@@ -81,20 +88,26 @@ impl<S: DataStore> PadzApi<S> {
             &mut dest_store,
             Scope::Project,
             &selectors,
-            &dest_padz,
-            mode,
+            commands::transfer::TransferRequest {
+                operation: mode,
+                direction: commands::transfer::TransferDirection::To,
+                peer_store: dest_padz,
+                requested_selection: requested_selection(requested),
+            },
         )
     }
 
-    /// `--from <path>`: read selectors from the external store, write into
-    /// the current store.
+    /// Copy or migrate the requested selection from a resolved peer store.
+    ///
+    /// Selectors resolve against the external source, while the report retains
+    /// the exact caller-supplied selector strings and resolved peer path.
     pub fn transfer_pads_from<I: AsRef<str>>(
         &mut self,
         scope: Scope,
         indexes: &[I],
         source_path: &std::path::Path,
         mode: commands::transfer::TransferMode,
-    ) -> Result<commands::CmdResult> {
+    ) -> Result<commands::transfer::TransferReport> {
         let source_padz =
             commands::transfer::resolve_target_dir(source_path, self.paths.home.as_deref())?;
         let current_padz = self.paths.scope_dir(scope)?;
@@ -105,16 +118,33 @@ impl<S: DataStore> PadzApi<S> {
             )));
         }
         let mut source_store = commands::transfer::open_target_store(&source_padz)?;
-        let selectors = parse_selectors(indexes).map_err(|e| PadzError::Api(format!("{}", e)))?;
+        let requested: Vec<String> = indexes
+            .iter()
+            .map(|index| index.as_ref().to_string())
+            .collect();
+        let selectors =
+            parse_selectors(&requested).map_err(|e| PadzError::Api(format!("{}", e)))?;
         commands::transfer::run(
             &mut source_store,
             Scope::Project,
             &mut self.store,
             scope,
             &selectors,
-            &source_padz,
-            mode,
+            commands::transfer::TransferRequest {
+                operation: mode,
+                direction: commands::transfer::TransferDirection::From,
+                peer_store: source_padz,
+                requested_selection: requested_selection(requested),
+            },
         )
+    }
+}
+
+fn requested_selection(selectors: Vec<String>) -> commands::transfer::TransferSelection {
+    if selectors.is_empty() {
+        commands::transfer::TransferSelection::AllNonDeleted
+    } else {
+        commands::transfer::TransferSelection::Explicit { selectors }
     }
 }
 
@@ -188,14 +218,18 @@ mod tests {
             .transfer_pads_to(Scope::Project, empty, &dest_padz, TransferMode::Clone)
             .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("Cloned 2 pad(s)")),
-            "expected Cloned message; got {:?}",
-            result.messages
+        assert_eq!(
+            result.status,
+            commands::transfer::TransferStatus::FullSuccess
         );
+        assert_eq!(result.operation, TransferMode::Clone);
+        assert_eq!(result.direction, commands::transfer::TransferDirection::To);
+        assert_eq!(result.peer_store, dest_padz.canonicalize().unwrap());
+        assert_eq!(
+            result.requested_selection,
+            commands::transfer::TransferSelection::AllNonDeleted
+        );
+        assert_eq!(result.copied_count, 2);
 
         // Source must still hold both pads after a clone.
         let still_there = api
@@ -269,14 +303,16 @@ mod tests {
             .transfer_pads_from(Scope::Project, empty, &src_padz, TransferMode::Clone)
             .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("Cloned 1 pad(s)")),
-            "expected Cloned message; got {:?}",
-            result.messages
+        assert_eq!(
+            result.status,
+            commands::transfer::TransferStatus::FullSuccess
         );
+        assert_eq!(
+            result.direction,
+            commands::transfer::TransferDirection::From
+        );
+        assert_eq!(result.peer_store, src_padz.canonicalize().unwrap());
+        assert_eq!(result.copied_count, 1);
 
         let landed = api
             .get_pads(Scope::Project, Default::default(), &[] as &[String])

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -31,11 +31,12 @@
 //! with its canonical [`DisplayIndex`]. This ensures consistent representation
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
-//! Initialization, doctor, purge, import, tag catalog/mutation, and
-//! artifact-producing commands use dedicated outcome types where a generic
-//! result would obscure the operation's facts. Pad mutations that still use [`CmdResult`] attach
-//! presentation-free [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI,
-//! web, etc.) decides how to render every result.
+//! Initialization, doctor, purge, import, cross-store transfer, tag
+//! catalog/mutation, and artifact-producing commands use dedicated outcome
+//! types where a generic result would obscure the operation's facts. Pad
+//! mutations that still use [`CmdResult`] attach presentation-free
+//! [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides
+//! how to render every result.
 //!
 //! ## Testing Strategy
 //!

--- a/crates/padzapp/src/commands/transfer.rs
+++ b/crates/padzapp/src/commands/transfer.rs
@@ -4,16 +4,17 @@
 //! 1. Resolve selectors against the source store to UUIDs.
 //! 2. Open a destination [`FileStore`] at the target path (smart-resolved to
 //!    `.padz/` via [`resolve_target_dir`]).
-//! 3. For each pad, read from source, apply metadata defensively to a fresh
-//!    `Pad` on the destination side, save. `parent_id`s that point outside
-//!    the move set are orphaned.
+//! 3. For each pad, read from source and save the same live [`Pad`] on the
+//!    destination side. `parent_id`s that point outside the move set are
+//!    orphaned.
 //! 4. Merge referenced tag registry entries into the destination (no
 //!    overwriting existing entries).
 //! 5. For migrate: delete each successfully copied pad from the source.
 //!
-//! The "content copy" is treated as the critical path: if it fails, we
-//! report the pad as failed and skip it. Metadata field failures are
-//! per-pad warnings — the file still lands.
+//! The report is presentation-free and retains every partial-success fact in
+//! pipeline order. Copy failures distinguish source reads from destination
+//! writes; destination enumeration, parent orphaning, tag-registry merging,
+//! and migrate cleanup remain independently observable.
 //!
 //! ## Path resolution
 //!
@@ -27,7 +28,6 @@
 //! This means `padz clone --to /tmp/work` works whether the user points at
 //! `/tmp/work`, `/tmp/work/.padz`, or a subdirectory of the project.
 
-use crate::commands::{CmdMessage, CmdResult};
 use crate::config::PadzConfig;
 use crate::error::{PadzError, Result};
 use crate::index::{DisplayIndex, PadSelector};
@@ -37,6 +37,7 @@ use crate::store::fs::FileStore;
 use crate::store::{Bucket, DataStore};
 use crate::tags::TagEntry;
 use clapfig::{Clapfig, SearchMode, SearchPath};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -44,7 +45,8 @@ use uuid::Uuid;
 use super::helpers::{indexed_pads, resolve_selectors, TitleBucket};
 
 /// Whether the source keeps or loses the pads after a transfer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TransferMode {
     /// Clone: copy to destination, keep in source.
     Clone,
@@ -52,13 +54,86 @@ pub enum TransferMode {
     Migrate,
 }
 
-impl TransferMode {
-    fn verb(self) -> &'static str {
-        match self {
-            TransferMode::Clone => "Cloned",
-            TransferMode::Migrate => "Migrated",
-        }
-    }
+/// Whether the external peer is receiving pads or providing them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirection {
+    To,
+    From,
+}
+
+/// The selector request resolved against the source store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferSelection {
+    AllNonDeleted,
+    Explicit { selectors: Vec<String> },
+}
+
+/// Invocation facts that are independent of the two participating stores.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferRequest {
+    pub operation: TransferMode,
+    pub direction: TransferDirection,
+    pub peer_store: PathBuf,
+    pub requested_selection: TransferSelection,
+}
+
+/// Overall semantic state of a cross-store transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferStatus {
+    Empty,
+    FullSuccess,
+    PartialSuccess,
+    NoCopies,
+}
+
+/// The phase that prevented one requested pad from reaching the destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopyFailureCategory {
+    SourceRead,
+    DestinationWrite,
+}
+
+/// Ordered warning/failure facts produced by the transfer pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransferDiagnostic {
+    DestinationBucketEnumerationFailed {
+        bucket: Bucket,
+        detail: String,
+    },
+    ParentOrphaned {
+        pad_id: Uuid,
+        parent_id: Uuid,
+    },
+    CopyFailed {
+        pad_id: Uuid,
+        category: CopyFailureCategory,
+        detail: String,
+    },
+    TagRegistryMergeFailed {
+        detail: String,
+    },
+    SourceDeleteFailed {
+        pad_id: Uuid,
+        detail: String,
+    },
+}
+
+/// Complete presentation-free result of clone/migrate across two stores.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferReport {
+    pub status: TransferStatus,
+    pub operation: TransferMode,
+    pub direction: TransferDirection,
+    pub peer_store: PathBuf,
+    pub requested_selection: TransferSelection,
+    pub copied_pad_ids: Vec<Uuid>,
+    pub copied_count: usize,
+    pub diagnostics: Vec<TransferDiagnostic>,
 }
 
 /// Resolve a user-supplied path into the `.padz/` directory at or above it.
@@ -159,19 +234,22 @@ pub fn open_target_store(padz_dir: &Path) -> Result<FileStore> {
 /// - `dest`: the store we write pads to
 /// - `dest_scope`: Project or Global on the dest side
 /// - `selectors`: pad selectors, resolved against the source
-/// - `summary_path`: human-readable destination location (used in the
-///   trailing success message; usually a path, can be anything)
-/// - `mode`: Clone (keep source) or Migrate (delete source on success)
+/// - `request`: operation, direction, resolved peer, and requested selection
 pub fn run<Src: DataStore, Dst: DataStore>(
     source: &mut Src,
     source_scope: Scope,
     dest: &mut Dst,
     dest_scope: Scope,
     selectors: &[PadSelector],
-    summary_path: &Path,
-    mode: TransferMode,
-) -> Result<CmdResult> {
-    let mut result = CmdResult::default();
+    request: TransferRequest,
+) -> Result<TransferReport> {
+    let TransferRequest {
+        operation,
+        direction,
+        peer_store,
+        requested_selection,
+    } = request;
+    let mut diagnostics = Vec::new();
 
     // 1. Resolve selectors on the source. Empty selectors mean "all non-
     //    deleted pads" (active + archived), matching `padz export`'s default
@@ -182,8 +260,16 @@ pub fn run<Src: DataStore, Dst: DataStore>(
         resolve_selectors(source, source_scope, selectors, false, TitleBucket::Any)?
     };
     if resolved.is_empty() {
-        result.add_message(CmdMessage::info("No pads to transfer."));
-        return Ok(result);
+        return Ok(TransferReport {
+            status: TransferStatus::Empty,
+            operation,
+            direction,
+            peer_store,
+            requested_selection,
+            copied_pad_ids: Vec::new(),
+            copied_count: 0,
+            diagnostics,
+        });
     }
 
     // 2. Build the move set. Pads whose parent lives outside the move set
@@ -192,11 +278,7 @@ pub fn run<Src: DataStore, Dst: DataStore>(
     //    silently swallowed — an incomplete `dest_ids` set can incorrectly
     //    orphan parent relationships.
     let move_set: HashSet<Uuid> = resolved.iter().map(|(_, uuid)| *uuid).collect();
-    let mut dest_ids_warnings = Vec::new();
-    let dest_ids = collect_all_ids(dest, dest_scope, &mut dest_ids_warnings);
-    for w in dest_ids_warnings {
-        result.add_message(w);
-    }
+    let dest_ids = collect_all_ids(dest, dest_scope, &mut diagnostics);
     let known_ids: HashSet<Uuid> = move_set.union(&dest_ids).copied().collect();
 
     // 3. Transfer pad-by-pad. `copy_one_pad` returns the source pad's tags so
@@ -206,23 +288,27 @@ pub fn run<Src: DataStore, Dst: DataStore>(
 
     for (_, id) in &resolved {
         match copy_one_pad(source, source_scope, dest, dest_scope, *id, &known_ids) {
-            Ok(CopyOutcome { mut warnings, tags }) => {
+            Ok(CopyOutcome {
+                orphaned_parent,
+                tags,
+            }) => {
                 copied.push(*id);
                 for t in tags {
                     referenced_tags.insert(t);
                 }
-                result.messages.append(&mut warnings);
+                if let Some(parent_id) = orphaned_parent {
+                    diagnostics.push(TransferDiagnostic::ParentOrphaned {
+                        pad_id: *id,
+                        parent_id,
+                    });
+                }
             }
-            Err(e) => {
-                result.add_message(CmdMessage::warning(format!(
-                    "Failed to {} pad {}: {}",
-                    match mode {
-                        TransferMode::Clone => "clone",
-                        TransferMode::Migrate => "migrate",
-                    },
-                    id,
-                    e
-                )));
+            Err(failure) => {
+                diagnostics.push(TransferDiagnostic::CopyFailed {
+                    pad_id: *id,
+                    category: failure.category,
+                    detail: failure.detail,
+                });
             }
         }
     }
@@ -231,46 +317,48 @@ pub fn run<Src: DataStore, Dst: DataStore>(
     if !copied.is_empty() {
         if let Err(e) = merge_tag_registry(source, source_scope, dest, dest_scope, &referenced_tags)
         {
-            result.add_message(CmdMessage::warning(format!(
-                "Tag registry merge failed: {}",
-                e
-            )));
+            diagnostics.push(TransferDiagnostic::TagRegistryMergeFailed {
+                detail: e.to_string(),
+            });
         }
     }
 
     // 5. For migrate: delete copies from source.
-    if mode == TransferMode::Migrate {
+    if operation == TransferMode::Migrate {
         for id in &copied {
             if let Err(e) = delete_from_source(source, source_scope, *id) {
-                result.add_message(CmdMessage::warning(format!(
-                    "Copied but failed to remove from source, pad {}: {}",
-                    id, e
-                )));
+                diagnostics.push(TransferDiagnostic::SourceDeleteFailed {
+                    pad_id: *id,
+                    detail: e.to_string(),
+                });
             }
         }
     }
 
-    if copied.is_empty() {
-        result.add_message(CmdMessage::warning(format!(
-            "No pads were {} to {}",
-            mode.verb().to_lowercase(),
-            summary_path.display()
-        )));
+    let status = if copied.is_empty() {
+        TransferStatus::NoCopies
+    } else if diagnostics.is_empty() {
+        TransferStatus::FullSuccess
     } else {
-        result.add_message(CmdMessage::success(format!(
-            "{} {} pad(s) to {}",
-            mode.verb(),
-            copied.len(),
-            summary_path.display()
-        )));
-    }
-    Ok(result)
+        TransferStatus::PartialSuccess
+    };
+    let copied_count = copied.len();
+    Ok(TransferReport {
+        status,
+        operation,
+        direction,
+        peer_store,
+        requested_selection,
+        copied_pad_ids: copied,
+        copied_count,
+        diagnostics,
+    })
 }
 
 fn collect_all_ids<S: DataStore>(
     store: &S,
     scope: Scope,
-    warnings: &mut Vec<CmdMessage>,
+    diagnostics: &mut Vec<TransferDiagnostic>,
 ) -> HashSet<Uuid> {
     let mut ids = HashSet::new();
     for bucket in [Bucket::Active, Bucket::Archived, Bucket::Deleted] {
@@ -281,11 +369,10 @@ fn collect_all_ids<S: DataStore>(
                 }
             }
             Err(e) => {
-                warnings.push(CmdMessage::warning(format!(
-                    "Could not enumerate destination bucket {:?}: {}. \
-Parent relationships that cross this bucket may be orphaned.",
-                    bucket, e
-                )));
+                diagnostics.push(TransferDiagnostic::DestinationBucketEnumerationFailed {
+                    bucket,
+                    detail: e.to_string(),
+                });
             }
         }
     }
@@ -313,12 +400,16 @@ fn default_non_deleted_ids<S: DataStore>(
     Ok(out)
 }
 
-/// Result of a successful per-pad copy: carries warnings from defensive
-/// metadata application plus the source pad's tags (so the caller can
-/// merge the tag registry without another source read).
+/// Result of a successful per-pad copy, retaining any removed parent plus the
+/// source pad's tags so the caller can merge the registry without another read.
 struct CopyOutcome {
-    warnings: Vec<CmdMessage>,
+    orphaned_parent: Option<Uuid>,
     tags: Vec<String>,
+}
+
+struct CopyFailure {
+    category: CopyFailureCategory,
+    detail: String,
 }
 
 /// Read a pad from whichever bucket it lives in on the source side. Returns
@@ -328,10 +419,18 @@ fn read_source_pad_any_bucket<S: DataStore>(
     scope: Scope,
     id: Uuid,
 ) -> Result<(Pad, Bucket)> {
+    let mut storage_failure = None;
     for bucket in [Bucket::Active, Bucket::Archived, Bucket::Deleted] {
-        if let Ok(pad) = source.get_pad(&id, scope, bucket) {
-            return Ok((pad, bucket));
+        match source.get_pad(&id, scope, bucket) {
+            Ok(pad) => return Ok((pad, bucket)),
+            Err(PadzError::PadNotFound(_)) => {}
+            Err(error) => {
+                storage_failure.get_or_insert(error);
+            }
         }
+    }
+    if let Some(error) = storage_failure {
+        return Err(error);
     }
     Err(PadzError::Api(format!(
         "Pad {} not found in any bucket",
@@ -361,25 +460,32 @@ fn copy_one_pad<Src: DataStore, Dst: DataStore>(
     dest_scope: Scope,
     id: Uuid,
     known_ids: &HashSet<Uuid>,
-) -> Result<CopyOutcome> {
-    let (mut pad, bucket) = read_source_pad_any_bucket(source, source_scope, id)?;
+) -> std::result::Result<CopyOutcome, CopyFailure> {
+    let (mut pad, bucket) =
+        read_source_pad_any_bucket(source, source_scope, id).map_err(|error| CopyFailure {
+            category: CopyFailureCategory::SourceRead,
+            detail: error.to_string(),
+        })?;
     let tags = pad.metadata.tags.clone();
 
-    let mut warnings = Vec::new();
+    let mut orphaned_parent = None;
     if let Some(pid) = pad.metadata.parent_id {
         if !known_ids.contains(&pid) {
             pad.metadata.parent_id = None;
-            warnings.push(CmdMessage::info(format!(
-                "Pad {}: parent not in move set, orphaned to root",
-                id
-            )));
+            orphaned_parent = Some(pid);
         }
     }
 
     dest.save_pad(&pad, dest_scope, bucket)
-        .map_err(|e| PadzError::Api(format!("Writing pad {} to destination failed: {}", id, e)))?;
+        .map_err(|error| CopyFailure {
+            category: CopyFailureCategory::DestinationWrite,
+            detail: format!("Writing pad {} to destination failed: {}", id, error),
+        })?;
 
-    Ok(CopyOutcome { warnings, tags })
+    Ok(CopyOutcome {
+        orphaned_parent,
+        tags,
+    })
 }
 
 fn delete_from_source<S: DataStore>(source: &mut S, scope: Scope, id: Uuid) -> Result<()> {
@@ -408,10 +514,9 @@ fn merge_tag_registry<Src: DataStore, Dst: DataStore>(
     if referenced.is_empty() {
         return Ok(());
     }
-    let source_tags = source.load_tags(source_scope).unwrap_or_default();
+    let source_tags = source.load_tags(source_scope)?;
     let existing: HashMap<String, TagEntry> = dest
-        .load_tags(dest_scope)
-        .unwrap_or_default()
+        .load_tags(dest_scope)?
         .into_iter()
         .map(|t| (t.name.clone(), t))
         .collect();
@@ -433,7 +538,7 @@ fn merge_tag_registry<Src: DataStore, Dst: DataStore>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::{create, MessageLevel};
+    use crate::commands::create;
     use crate::index::{DisplayIndex, PadSelector};
     use crate::store::bucketed::BucketedStore;
     use crate::store::mem_backend::MemBackend;
@@ -447,6 +552,125 @@ mod tests {
         )
     }
 
+    struct FaultStore {
+        inner: BucketedStore<MemBackend>,
+        fail_get: bool,
+        fail_list: Option<Bucket>,
+        fail_delete: bool,
+        fail_save_tags: bool,
+    }
+
+    impl FaultStore {
+        fn new() -> Self {
+            Self {
+                inner: store(),
+                fail_get: false,
+                fail_list: None,
+                fail_delete: false,
+                fail_save_tags: false,
+            }
+        }
+
+        fn fault(label: &str) -> PadzError {
+            PadzError::Store(format!("simulated {label} failure"))
+        }
+    }
+
+    impl DataStore for FaultStore {
+        fn save_pad(&mut self, pad: &Pad, scope: Scope, bucket: Bucket) -> Result<()> {
+            self.inner.save_pad(pad, scope, bucket)
+        }
+
+        fn get_pad(&self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<Pad> {
+            if self.fail_get {
+                Err(Self::fault("source read"))
+            } else {
+                self.inner.get_pad(id, scope, bucket)
+            }
+        }
+
+        fn list_pads(&self, scope: Scope, bucket: Bucket) -> Result<Vec<Pad>> {
+            if self.fail_list == Some(bucket) {
+                Err(Self::fault("bucket enumeration"))
+            } else {
+                self.inner.list_pads(scope, bucket)
+            }
+        }
+
+        fn delete_pad(&mut self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<()> {
+            if self.fail_delete {
+                Err(Self::fault("source delete"))
+            } else {
+                self.inner.delete_pad(id, scope, bucket)
+            }
+        }
+
+        fn move_pad(&mut self, id: &Uuid, scope: Scope, from: Bucket, to: Bucket) -> Result<Pad> {
+            self.inner.move_pad(id, scope, from, to)
+        }
+
+        fn move_pads(
+            &mut self,
+            ids: &[Uuid],
+            scope: Scope,
+            from: Bucket,
+            to: Bucket,
+        ) -> Result<Vec<Pad>> {
+            self.inner.move_pads(ids, scope, from, to)
+        }
+
+        fn get_pad_path(&self, id: &Uuid, scope: Scope, bucket: Bucket) -> Result<PathBuf> {
+            self.inner.get_pad_path(id, scope, bucket)
+        }
+
+        fn doctor(&mut self, scope: Scope) -> Result<crate::store::DoctorReport> {
+            self.inner.doctor(scope)
+        }
+
+        fn load_tags(&self, scope: Scope) -> Result<Vec<TagEntry>> {
+            self.inner.load_tags(scope)
+        }
+
+        fn save_tags(&mut self, scope: Scope, tags: &[TagEntry]) -> Result<()> {
+            if self.fail_save_tags {
+                Err(Self::fault("tag registry merge"))
+            } else {
+                self.inner.save_tags(scope, tags)
+            }
+        }
+    }
+
+    fn run_test<Src: DataStore, Dst: DataStore>(
+        source: &mut Src,
+        source_scope: Scope,
+        dest: &mut Dst,
+        dest_scope: Scope,
+        selectors: &[PadSelector],
+        peer_store: &Path,
+        mode: TransferMode,
+    ) -> Result<TransferReport> {
+        let requested_selection = if selectors.is_empty() {
+            TransferSelection::AllNonDeleted
+        } else {
+            TransferSelection::Explicit {
+                selectors: selectors.iter().map(ToString::to_string).collect(),
+            }
+        };
+        super::run(
+            source,
+            source_scope,
+            dest,
+            dest_scope,
+            selectors,
+            TransferRequest {
+                operation: mode,
+                direction: TransferDirection::To,
+                peer_store: peer_store.to_path_buf(),
+                requested_selection,
+            },
+        )
+    }
+
     /// For unit tests we need a destination store that is `&mut dyn DataStore`.
     /// The production `run` takes a `FileStore` directly, so test the inner
     /// pipeline (copy_one_pad + delete_from_source) using two in-memory stores.
@@ -457,7 +681,8 @@ mod tests {
         id: Uuid,
         known: &HashSet<Uuid>,
     ) -> Result<()> {
-        copy_one_pad(src, scope, dst, Scope::Project, id, known)?;
+        copy_one_pad(src, scope, dst, Scope::Project, id, known)
+            .map_err(|failure| PadzError::Api(failure.detail))?;
         Ok(())
     }
 
@@ -604,21 +829,14 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_mode_verb() {
-        // Direct check on the only entry point that uses verb().
-        assert_eq!(TransferMode::Clone.verb(), "Cloned");
-        assert_eq!(TransferMode::Migrate.verb(), "Migrated");
-    }
-
-    #[test]
-    fn test_run_no_pads_returns_info_message() {
+    fn test_run_no_pads_returns_explicit_empty_report() {
         // Empty source + explicit selectors that can't resolve to anything.
         let mut src = store();
         let mut dst = store();
         // An empty source with empty selectors triggers the "no pads" branch
         // through `default_non_deleted_ids` (which returns an empty Vec).
         let summary = std::path::PathBuf::from("/tmp/nowhere");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -629,14 +847,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("No pads to transfer")),
-            "expected info message about no pads; got {:?}",
-            result.messages
-        );
+        assert_eq!(result.status, TransferStatus::Empty);
+        assert_eq!(result.operation, TransferMode::Clone);
+        assert_eq!(result.direction, TransferDirection::To);
+        assert_eq!(result.peer_store, summary);
+        assert_eq!(result.requested_selection, TransferSelection::AllNonDeleted);
+        assert!(result.copied_pad_ids.is_empty());
+        assert_eq!(result.copied_count, 0);
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -647,7 +865,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -658,13 +876,10 @@ mod tests {
         )
         .unwrap();
 
-        let success_message = result
-            .messages
-            .iter()
-            .find(|m| matches!(m.level, MessageLevel::Success))
-            .expect("clone should emit a success message");
-        assert!(success_message.content.contains("Cloned 2 pad(s)"));
-        assert!(success_message.content.contains("/tmp/dest"));
+        assert_eq!(result.status, TransferStatus::FullSuccess);
+        assert_eq!(result.copied_count, 2);
+        assert_eq!(result.copied_pad_ids.len(), 2);
+        assert!(result.diagnostics.is_empty());
 
         // Both pads on destination, both still on source.
         assert_eq!(
@@ -684,7 +899,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -695,14 +910,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("Migrated 1 pad(s)")),
-            "expected Migrated success message; got {:?}",
-            result.messages
-        );
+        assert_eq!(result.status, TransferStatus::FullSuccess);
+        assert_eq!(result.operation, TransferMode::Migrate);
+        assert_eq!(result.copied_count, 1);
 
         // Migrate clears the source.
         assert!(src
@@ -747,7 +957,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        run(
+        run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -784,7 +994,7 @@ mod tests {
         // The newest pad gets index 1 (which is "Second"). Asking for "1"
         // should clone exactly one pad: the most recently created.
         let selectors = vec![PadSelector::Path(vec![DisplayIndex::Regular(1)])];
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -795,10 +1005,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Cloned 1 pad(s)")));
+        assert_eq!(result.status, TransferStatus::FullSuccess);
+        assert_eq!(
+            result.requested_selection,
+            TransferSelection::Explicit {
+                selectors: vec!["1".to_string()]
+            }
+        );
+        assert_eq!(result.copied_count, 1);
         let dst_pads = dst.list_pads(Scope::Project, Bucket::Active).unwrap();
         assert_eq!(dst_pads.len(), 1);
         assert_eq!(dst_pads[0].metadata.title, "Second");
@@ -824,7 +1038,7 @@ mod tests {
 
         let mut dst = store();
         let summary = std::path::PathBuf::from("/tmp/dest");
-        run(
+        run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -870,7 +1084,7 @@ mod tests {
         let mut dst = BucketedStore::new(dst_active, dst_archived, dst_deleted, dst_tags);
 
         let summary = std::path::PathBuf::from("/tmp/dest");
-        let result = run(
+        let result = run_test(
             &mut src,
             Scope::Project,
             &mut dst,
@@ -881,25 +1095,214 @@ mod tests {
         )
         .unwrap();
 
-        // Per-pad warning naming the failed action.
-        assert!(
-            result.messages.iter().any(|m| {
-                matches!(m.level, MessageLevel::Warning)
-                    && m.content.contains("Failed to clone pad")
-            }),
-            "expected per-pad clone failure warning; got {:?}",
-            result.messages
-        );
+        assert_eq!(result.status, TransferStatus::NoCopies);
+        assert!(result.copied_pad_ids.is_empty());
+        assert!(matches!(
+            result.diagnostics.as_slice(),
+            [TransferDiagnostic::CopyFailed {
+                category: CopyFailureCategory::DestinationWrite,
+                detail,
+                ..
+            }] if detail.contains("Writing pad") && detail.contains("Simulated write error")
+        ));
+    }
 
-        // And the trailing "no pads were cloned" message.
-        assert!(
-            result
-                .messages
-                .iter()
-                .any(|m| m.content.contains("No pads were cloned")),
-            "expected 'No pads were cloned' trailer; got {:?}",
-            result.messages
+    #[test]
+    fn test_run_reports_source_read_failure_category() {
+        let mut src = FaultStore::new();
+        create::run(
+            &mut src,
+            Scope::Project,
+            "Unreadable".into(),
+            "".into(),
+            None,
+        )
+        .unwrap();
+        src.fail_get = true;
+        let mut dst = store();
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::NoCopies);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::CopyFailed {
+                category: CopyFailureCategory::SourceRead,
+                detail,
+                ..
+            }] if detail.contains("simulated source read failure")
+        ));
+    }
+
+    #[test]
+    fn test_run_reports_parent_orphaning_as_partial_success() {
+        let mut src = store();
+        create::run(&mut src, Scope::Project, "Parent".into(), "".into(), None).unwrap();
+        create::run(
+            &mut src,
+            Scope::Project,
+            "Child".into(),
+            "".into(),
+            Some(PadSelector::Path(vec![DisplayIndex::Regular(1)])),
+        )
+        .unwrap();
+        let pads = src.list_pads(Scope::Project, Bucket::Active).unwrap();
+        let parent = pads
+            .iter()
+            .find(|pad| pad.metadata.title == "Parent")
+            .unwrap();
+        let child = pads
+            .iter()
+            .find(|pad| pad.metadata.title == "Child")
+            .unwrap();
+        let parent_id = parent.metadata.id;
+        let child_id = child.metadata.id;
+        let selectors = vec![PadSelector::Path(vec![
+            DisplayIndex::Regular(1),
+            DisplayIndex::Regular(1),
+        ])];
+        let mut dst = store();
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &selectors,
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_pad_ids, vec![child_id]);
+        assert_eq!(
+            report.diagnostics,
+            vec![TransferDiagnostic::ParentOrphaned {
+                pad_id: child_id,
+                parent_id,
+            }]
         );
+        assert_eq!(
+            dst.get_pad(&child_id, Scope::Project, Bucket::Active)
+                .unwrap()
+                .metadata
+                .parent_id,
+            None
+        );
+    }
+
+    #[test]
+    fn test_run_reports_destination_bucket_enumeration_failure() {
+        let mut src = store();
+        create::run(&mut src, Scope::Project, "Alpha".into(), "".into(), None).unwrap();
+        let mut dst = FaultStore::new();
+        dst.fail_list = Some(Bucket::Archived);
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_count, 1);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::DestinationBucketEnumerationFailed {
+                bucket: Bucket::Archived,
+                detail,
+            }] if detail.contains("simulated bucket enumeration failure")
+        ));
+    }
+
+    #[test]
+    fn test_run_reports_tag_registry_merge_failure_without_losing_copy() {
+        let mut src = store();
+        create::run(&mut src, Scope::Project, "Tagged".into(), "".into(), None).unwrap();
+        let mut pad = src
+            .list_pads(Scope::Project, Bucket::Active)
+            .unwrap()
+            .remove(0);
+        pad.metadata.tags = vec!["work".into()];
+        src.save_pad(&pad, Scope::Project, Bucket::Active).unwrap();
+        src.save_tags(Scope::Project, &[TagEntry::new("work".into())])
+            .unwrap();
+        let mut dst = FaultStore::new();
+        dst.fail_save_tags = true;
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Clone,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_pad_ids, vec![pad.metadata.id]);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::TagRegistryMergeFailed { detail }]
+                if detail.contains("simulated tag registry merge failure")
+        ));
+        assert!(dst
+            .get_pad(&pad.metadata.id, Scope::Project, Bucket::Active)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_migrate_delete_failure_is_partial_and_keeps_both_copies() {
+        let mut src = FaultStore::new();
+        create::run(&mut src, Scope::Project, "Stuck".into(), "".into(), None).unwrap();
+        let id = src.list_pads(Scope::Project, Bucket::Active).unwrap()[0]
+            .metadata
+            .id;
+        src.fail_delete = true;
+        let mut dst = store();
+        let peer = PathBuf::from("/tmp/dest");
+
+        let report = run_test(
+            &mut src,
+            Scope::Project,
+            &mut dst,
+            Scope::Project,
+            &[],
+            &peer,
+            TransferMode::Migrate,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, TransferStatus::PartialSuccess);
+        assert_eq!(report.copied_pad_ids, vec![id]);
+        assert!(matches!(
+            report.diagnostics.as_slice(),
+            [TransferDiagnostic::SourceDeleteFailed { pad_id, detail }]
+                if *pad_id == id && detail.contains("simulated source delete failure")
+        ));
+        assert!(src.get_pad(&id, Scope::Project, Bucket::Active).is_ok());
+        assert!(dst.get_pad(&id, Scope::Project, Bucket::Active).is_ok());
     }
 
     #[test]
@@ -928,7 +1331,7 @@ mod tests {
         dst.save_tags(Scope::Project, &[dst_tag.clone()]).unwrap();
 
         let summary = std::path::PathBuf::from("/tmp/dest");
-        run(
+        run_test(
             &mut src,
             Scope::Project,
             &mut dst,


### PR DESCRIPTION
## Context

for #217

Why this approach: WS05 extends the semantic-result pattern established by #207 and integrated through #224, #226, #227, and #228. padzapp now returns one ordered cross-store transfer report with operation, direction, resolved peer store, requested selection, copied pad IDs/count, and explicit empty, full-success, partial-success, or no-copy status. Typed diagnostics retain destination bucket enumeration failures, parent orphaning, categorized per-pad copy failures, tag-registry merge failure, and migrate source-delete failure in pipeline order. A migrate whose destination copy landed but source cleanup failed is always partial success and retains both copies in the report and tests.

Thin CLI adapters project those facts into a dedicated structured DTO, while transfer.jinja preserves the established human wording, ordering, pluralization, paths, and info/warning/success styles. Structured transfer output intentionally changes from a prose-only messages array to factual fields and typed diagnostics. The external clone-success JSON fixture pins the schema, TestHarness proves JSON/YAML/XML/CSV serialization plus human text/style compatibility, and the unreleased changelog documents the transition.

Standout v7.9.0 was verified against the named local source tree at ~/h/standout before implementation. It remains the newest coherent tag and was already pinned across the epic base, so no dependency diff was necessary.

Out of scope: #218-#223, dependency changes, selector/storage/hierarchy/bucket/tag/path redesign, and broad wording or visual redesign. Do not move human sentences back into padzapp or handlers, collapse partial success into full success, reorder diagnostics, or drop failures after a successful copy.

Verification:
- env RUSTC_WRAPPER= pixi run test — 883 passed, 1 skipped
- commit and push hooks — all 12 lint checks passed

Governing-doc self-check: reviewed every acceptance criterion and compatibility/non-goal boundary in epic #208 and issue #217, the semantic ownership pattern from #207, and integrated workstreams #224, #226, #227, and #228. No separate ADR/spec list was supplied in the implementer brief; this mandatory brief-slot gap is recorded here rather than guessed.