### PR TITLE
STD02-WS06: Epic: Complete Remaining Standout Ownership Work - Workstream: Typed UUID Selections

### DIFF
--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -1105,7 +1105,7 @@ pub fn path(
     }))
 }
 
-/// Returns the UUID of each selected pad.
+/// Maps each selected domain UUID into the CLI's stable textual UUID result.
 #[handler]
 pub fn uuid(
     #[ctx] ctx: &CommandContext,
@@ -1115,7 +1115,7 @@ pub fn uuid(
     let result = state.with_api(|api| api.pad_uuids(state.scope, &indexes).map_err(to_anyhow))?;
 
     Ok(Output::Render(UuidResult {
-        uuids: result.messages.iter().map(|m| m.content.clone()).collect(),
+        uuids: result.into_iter().map(|uuid| uuid.to_string()).collect(),
     }))
 }
 

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -1095,5 +1095,6 @@ pub struct PathResult {
 /// UUIDs of the selected pads, one per selector match.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UuidResult {
+    /// Canonical UUID strings in selector order, with ranges in display order.
     pub uuids: Vec<String>,
 }

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -699,20 +699,34 @@ fn path_maps_selectors_to_one_filesystem_path_each() {
 }
 
 #[test]
-fn uuid_maps_selectors_to_one_uuid_each() {
+fn uuid_maps_single_multiple_and_range_selectors_in_order() {
     let fx = Fixture::new();
     let state = fx.app_state();
-    fx.seed_pad(&state, "first", "");
+    let first = state
+        .with_api(|api| api.create_pad(state.scope, "first".into(), "".into(), None))
+        .unwrap()
+        .affected_pads[0]
+        .pad
+        .metadata
+        .id;
+    let second = state
+        .with_api(|api| api.create_pad(state.scope, "second".into(), "".into(), None))
+        .unwrap()
+        .affected_pads[0]
+        .pad
+        .metadata
+        .id;
     let ctx = support::ctx_with_state(state);
 
-    let result: UuidResult = rendered(handlers::uuid(&ctx, vec!["1".to_string()]));
+    let single: UuidResult = rendered(handlers::uuid(&ctx, vec!["1".to_string()]));
+    assert_eq!(single.uuids, vec![second.to_string()]);
 
-    assert_eq!(result.uuids.len(), 1);
-    assert!(
-        uuid::Uuid::parse_str(&result.uuids[0]).is_ok(),
-        "uuid handler should return a parseable uuid, got {:?}",
-        result.uuids[0]
-    );
+    let multiple: UuidResult =
+        rendered(handlers::uuid(&ctx, vec!["2".to_string(), "1".to_string()]));
+    assert_eq!(multiple.uuids, vec![first.to_string(), second.to_string()],);
+
+    let range: UuidResult = rendered(handlers::uuid(&ctx, vec!["1-2".to_string()]));
+    assert_eq!(range.uuids, vec![second.to_string(), first.to_string()]);
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -2025,8 +2025,145 @@ fn term_debug_marks_a_deleted_pad_with_its_own_styles() {
 }
 
 // =============================================================================
+// UUID selections — selector ordering, human rendering, and structured data
+// =============================================================================
+
+#[test]
+#[serial]
+fn uuid_renders_single_multiple_and_range_selections_in_order() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "first", "");
+    fx.seed_pad(&state, "second", "");
+    fx.seed_pad(&state, "third", "");
+    drop(state);
+
+    let mut ids = Vec::new();
+    for selector in ["1", "2", "3"] {
+        let (app, cmd) = fx.read_app();
+        let result = TestHarness::new().no_color().text_output().run(
+            &app,
+            cmd,
+            fx.argv(&["uuid", selector]),
+        );
+        result.assert_success();
+        let lines: Vec<&str> = result.stdout().lines().collect();
+        assert_eq!(lines.len(), 1, "{selector}: one UUID per line");
+        uuid::Uuid::parse_str(lines[0])
+            .unwrap_or_else(|e| panic!("{selector}: invalid UUID {:?}: {e}", lines[0]));
+        ids.push(lines[0].to_string());
+    }
+
+    let (app, cmd) = fx.read_app();
+    let multiple =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["uuid", "3", "1"]));
+    multiple.assert_success();
+    assert_eq!(
+        multiple.stdout().lines().collect::<Vec<_>>(),
+        vec![ids[2].as_str(), ids[0].as_str()],
+        "multiple selectors must retain selector order"
+    );
+    drop(multiple);
+
+    let (app, cmd) = fx.read_app();
+    let range =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["uuid", "1-3"]));
+    range.assert_success();
+    assert_eq!(
+        range.stdout().lines().collect::<Vec<_>>(),
+        ids.iter().map(String::as_str).collect::<Vec<_>>(),
+        "ranges must expand in canonical display order"
+    );
+}
+
+// =============================================================================
 // Structured output — every mode parses with a real parser for that format
 // =============================================================================
+
+#[test]
+#[serial]
+fn uuid_preserves_its_array_contract_in_every_structured_mode() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "structured UUID", "");
+    drop(state);
+
+    let (app, cmd) = fx.read_app();
+    let text = TestHarness::new()
+        .no_color()
+        .text_output()
+        .run(&app, cmd, fx.argv(&["uuid", "1"]));
+    text.assert_success();
+    let expected = text.stdout().trim().to_string();
+    uuid::Uuid::parse_str(&expected).expect("human output should contain a full UUID");
+    drop(text);
+
+    for mode in ["json", "yaml", "xml", "csv"] {
+        let (app, cmd) = fx.read_app();
+        let result =
+            TestHarness::new()
+                .no_color()
+                .run(&app, cmd, fx.argv(&["uuid", "1", "--output", mode]));
+        result.assert_success();
+
+        let actual = match mode {
+            "json" => {
+                let value: serde_json::Value = serde_json::from_str(result.stdout())
+                    .unwrap_or_else(|e| panic!("not JSON: {e}\n{}", result.stdout()));
+                value["uuids"][0].as_str().expect("uuids[0]").to_string()
+            }
+            "yaml" => {
+                let value: serde_json::Value = serde_yaml::from_str(result.stdout())
+                    .unwrap_or_else(|e| panic!("not YAML: {e}\n{}", result.stdout()));
+                value["uuids"][0].as_str().expect("uuids[0]").to_string()
+            }
+            "xml" => {
+                let mut reader = quick_xml::Reader::from_str(result.stdout());
+                let mut in_uuid = false;
+                let mut uuid = None;
+                loop {
+                    match reader.read_event() {
+                        Ok(quick_xml::events::Event::Start(e)) => {
+                            in_uuid = e.name().as_ref() == b"uuids";
+                        }
+                        Ok(quick_xml::events::Event::Text(e)) if in_uuid => {
+                            uuid = Some(e.unescape().expect("UUID XML text").into_owned());
+                        }
+                        Ok(quick_xml::events::Event::End(e)) if e.name().as_ref() == b"uuids" => {
+                            in_uuid = false;
+                        }
+                        Ok(quick_xml::events::Event::Eof) => break,
+                        Ok(_) => {}
+                        Err(e) => panic!("not XML: {e}\n{}", result.stdout()),
+                    }
+                }
+                uuid.expect("XML uuids element")
+            }
+            "csv" => {
+                let mut reader = csv::Reader::from_reader(result.stdout().as_bytes());
+                assert_eq!(
+                    reader.headers().expect("CSV header").get(0),
+                    Some("uuids.0")
+                );
+                reader
+                    .records()
+                    .next()
+                    .expect("CSV row")
+                    .expect("valid CSV row")[0]
+                    .to_string()
+            }
+            other => unreachable!("unhandled mode {other}"),
+        };
+
+        assert_eq!(actual, expected, "{mode} UUID array changed");
+    }
+}
 
 #[test]
 #[serial]

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -2125,12 +2125,13 @@ fn uuid_preserves_its_array_contract_in_every_structured_mode() {
             }
             "xml" => {
                 let mut reader = quick_xml::Reader::from_str(result.stdout());
+                reader.config_mut().trim_text(true);
                 let mut in_uuid = false;
                 let mut uuid = None;
                 loop {
                     match reader.read_event() {
-                        Ok(quick_xml::events::Event::Start(e)) => {
-                            in_uuid = e.name().as_ref() == b"uuids";
+                        Ok(quick_xml::events::Event::Start(e)) if e.name().as_ref() == b"uuids" => {
+                            in_uuid = true;
                         }
                         Ok(quick_xml::events::Event::Text(e)) if in_uuid => {
                             uuid = Some(e.unescape().expect("UUID XML text").into_owned());

--- a/crates/padzapp/src/api/util.rs
+++ b/crates/padzapp/src/api/util.rs
@@ -24,11 +24,9 @@ impl<S: DataStore> PadzApi<S> {
         commands::paths::run(&self.store, scope, &selectors)
     }
 
-    pub fn pad_uuids<I: AsRef<str>>(
-        &self,
-        scope: Scope,
-        indexes: &[I],
-    ) -> Result<commands::CmdResult> {
+    /// Resolves selectors to UUIDs in selector order, with ranges expanded in
+    /// canonical display order.
+    pub fn pad_uuids<I: AsRef<str>>(&self, scope: Scope, indexes: &[I]) -> Result<Vec<uuid::Uuid>> {
         let selectors = parse_selectors(indexes)?;
         commands::uuid::run(&self.store, scope, &selectors)
     }
@@ -104,6 +102,29 @@ mod tests {
 
         assert_eq!(paths.project, Some(PathBuf::from("/tmp/test")));
         assert_eq!(paths.global, PathBuf::from("/tmp/global"));
+    }
+
+    #[test]
+    fn test_api_pad_uuids_returns_values_in_selector_order() {
+        let mut api = make_api();
+        let first = api
+            .create_pad(Scope::Project, "first".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let second = api
+            .create_pad(Scope::Project, "second".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+
+        let uuids = api.pad_uuids(Scope::Project, &["2", "1"]).unwrap();
+
+        assert_eq!(uuids, vec![first, second]);
     }
 
     #[test]

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -32,9 +32,9 @@
 //! throughout the API—clients always receive pads with their resolved indexes.
 //!
 //! Initialization, doctor, purge, import, cross-store transfer, tag
-//! catalog/mutation, and artifact-producing commands use dedicated outcome
-//! types where a generic result would obscure the operation's facts. Pad
-//! mutations that still use [`CmdResult`] attach presentation-free
+//! catalog/mutation, UUID selection, and artifact-producing commands return
+//! direct values or dedicated outcome types where a generic result would obscure
+//! the operation's facts. Pad mutations that still use [`CmdResult`] attach presentation-free
 //! [`CmdOutcome`] and [`CmdNotice`] facts. The UI layer (CLI, web, etc.) decides
 //! how to render every result.
 //!
@@ -61,6 +61,7 @@
 //! - [`export`]: Export pads to archive
 //! - [`import`]: Import pads from files
 //! - [`paths`]: Get filesystem paths to pads
+//! - [`uuid`]: Resolve selected pads to durable UUID values
 //! - [`init`]: Initialize scope directories
 //! - [`doctor`]: Verify and fix data consistency
 //! - [`tags`]: List and mutate the tag registry

--- a/crates/padzapp/src/commands/uuid.rs
+++ b/crates/padzapp/src/commands/uuid.rs
@@ -1,22 +1,21 @@
-use crate::commands::CmdResult;
+//! Resolve pad selectors to their durable UUIDs.
+//!
+//! Selector parsing and canonical display ordering remain application concerns;
+//! presentation clients decide how to render or serialize the resolved values.
+
 use crate::error::Result;
 use crate::index::PadSelector;
 use crate::model::Scope;
 use crate::store::DataStore;
+use uuid::Uuid;
 
 use super::helpers::{resolve_selectors, TitleBucket};
 
-pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<CmdResult> {
+/// Return the selected UUIDs in selector order, expanding ranges in canonical
+/// display order.
+pub fn run<S: DataStore>(store: &S, scope: Scope, selectors: &[PadSelector]) -> Result<Vec<Uuid>> {
     let resolved = resolve_selectors(store, scope, selectors, false, TitleBucket::Active)?;
-    let mut result = CmdResult::default();
-
-    for (_, uuid) in resolved {
-        result
-            .messages
-            .push(super::CmdMessage::info(uuid.to_string()));
-    }
-
-    Ok(result)
+    Ok(resolved.into_iter().map(|(_, uuid)| uuid).collect())
 }
 
 #[cfg(test)]
@@ -47,8 +46,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].content, expected_uuid.to_string());
+        assert_eq!(result, vec![expected_uuid]);
     }
 
     #[test]
@@ -59,20 +57,30 @@ mod tests {
             MemBackend::new(),
             MemBackend::new(),
         );
-        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
-        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
+        let first = create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let second = create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
 
         let result = run(
             &store,
             Scope::Project,
             &[
-                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
                 PadSelector::Path(vec![DisplayIndex::Regular(2)]),
+                PadSelector::Path(vec![DisplayIndex::Regular(1)]),
             ],
         )
         .unwrap();
 
-        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result, vec![first, second]);
     }
 
     #[test]
@@ -83,9 +91,24 @@ mod tests {
             MemBackend::new(),
             MemBackend::new(),
         );
-        create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None).unwrap();
-        create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None).unwrap();
-        create::run(&mut store, Scope::Project, "Pad C".into(), "".into(), None).unwrap();
+        let first = create::run(&mut store, Scope::Project, "Pad A".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let second = create::run(&mut store, Scope::Project, "Pad B".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
+        let third = create::run(&mut store, Scope::Project, "Pad C".into(), "".into(), None)
+            .unwrap()
+            .affected_pads[0]
+            .pad
+            .metadata
+            .id;
 
         let result = run(
             &store,
@@ -97,6 +120,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.messages.len(), 3);
+        assert_eq!(result, vec![third, second, first]);
     }
 }


### PR DESCRIPTION
for #218

## Context

The reusable UUID operation now returns Vec<Uuid> directly in the order produced by the existing selector resolver. The CLI handler is only an adapter: it converts those domain UUID values into the unchanged UuidResult string fields used by human and structured rendering. This removes the UUID-as-CmdMessage round trip without changing selector parsing, display indexing, range expansion, templates, or serialization shape.

The implementation was self-checked against #208, #218, the merged #207 ownership slice, and the integrated STD02 WS01-WS05 work. No separate ADR or spec governs this slice. Core, public API, direct-handler, and serial TestHarness tests pin single, multiple, range, selector-order, canonical range-order, human one-per-line output, and the existing JSON/YAML/XML/CSV uuids array contract.

Out of scope are #219 and later workstreams, dependency updates, selector or storage redesign, output rewording, and broader CmdMessage migration. In particular, do not change UuidResult from canonical UUID strings or fold path handling into this change; those would expand the public schema or workstream boundary. The existing subprocess structured-output matrix remains as its stdout smoke boundary.

## Verification

- env RUSTC_WRAPPER= pixi run test - 886 passed, 1 skipped
- pre-commit lint hook - 12 checks passed
- pre-push lint hook - 12 checks passed