### PR TITLE
STD02-WS07: Epic: Complete Remaining Standout Ownership Work - Workstream: Semantic CLI Copy and Empty-Input Outcomes

### DIFF
--- a/CHANGELOG/unreleased-semantic-copy-create-outcomes.md
+++ b/CHANGELOG/unreleased-semantic-copy-create-outcomes.md
@@ -1,0 +1,9 @@
+- `copy` structured output now reports CLI-owned `root_pad_count` and ordered
+  `titles` facts instead of a prose-only `messages` result. Nested descendants
+  remain in the single ordered clipboard payload but do not increase the selected
+  root count. Human wording and clipboard bytes remain compatible.
+- Empty piped-input and editor creates now return `{ "kind": "aborted",
+  "reason": "empty_content" }` in structured modes instead of an empty generic
+  modification plus an English warning message. Human `Aborted: empty content`
+  wording and successful exit behavior remain unchanged; no pad, editor fallback,
+  or clipboard write occurs for an empty pipe.

--- a/crates/padz/src/cli/clipboard.rs
+++ b/crates/padz/src/cli/clipboard.rs
@@ -2,8 +2,9 @@
 //!
 //! A user-environment concern owned by the CLI: each supported platform shells
 //! out to its clipboard *write* tool (`pbcopy`, `xclip`/`xsel`, `clip`); any
-//! other platform is an error. The library never touches the clipboard —
-//! handlers hand pad text to these functions at the CLI boundary.
+//! other platform is an error. The library never touches the clipboard — the
+//! CLI injects a [`ClipboardWriter`] into application state and handlers hand it
+//! semantic pad text at that boundary.
 //!
 //! Write-only by design: padz copies pad text *to* the clipboard after a pad is
 //! saved or viewed, and never reads it back to pre-fill one. There is no
@@ -12,6 +13,25 @@
 
 use padzapp::error::{PadzError, Result};
 use std::process::Command;
+
+/// A CLI-owned destination for semantic clipboard payloads.
+///
+/// The production implementation writes to the platform clipboard. Keeping the
+/// dependency behind this one-method interface lets in-process CLI tests observe
+/// write count and ordering without making rendered output the clipboard source.
+pub trait ClipboardWriter {
+    fn write(&self, text: &str) -> Result<()>;
+}
+
+/// The real platform clipboard used by ordinary Padz invocations.
+#[derive(Debug, Default)]
+pub struct SystemClipboardWriter;
+
+impl ClipboardWriter for SystemClipboardWriter {
+    fn write(&self, text: &str) -> Result<()> {
+        copy_to_clipboard(text)
+    }
+}
 
 /// Copies text to the system clipboard in an OS-specific way.
 /// - macOS: uses pbcopy

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -14,10 +14,10 @@
 // Allow non_snake_case for macro-generated __handler wrapper functions
 #![allow(non_snake_case)]
 
-use crate::cli::clipboard::{copy_to_clipboard, format_for_clipboard};
+use crate::cli::clipboard::{format_for_clipboard, ClipboardWriter, SystemClipboardWriter};
 use crate::cli::errors::to_anyhow;
 use crate::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
-use padzapp::api::{CmdMessage, PadFilter, PadStatusFilter, PadzApi, TodoStatus};
+use padzapp::api::{PadFilter, PadStatusFilter, PadzApi, TodoStatus};
 use padzapp::commands::{CmdOutcome, CmdResult, NestingMode, UpdateKind};
 use padzapp::config::PadzMode;
 use padzapp::error::PadzError;
@@ -26,12 +26,14 @@ use padzapp::store::fs::FileStore;
 use standout::cli::{Artifact, CommandContext, CommandContextInput, Output};
 use standout_macros::handler;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 use super::result::{
+    CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateAbortResult, CreateResult,
     DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
-    MessagesResult, ModificationRequest, ModificationResult, PadContent, PadContentResult,
-    PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
-    TransferResult, UuidResult,
+    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
+    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferResult,
+    UuidResult,
 };
 
 // =============================================================================
@@ -42,14 +44,17 @@ use super::result::{
 #[derive(Clone)]
 pub struct ImportExtensions(pub Vec<String>);
 
-/// Shared application state injected via app_state
-/// Contains the API instance wrapped in RefCell for interior mutability
+/// Shared application state injected via app_state.
+///
+/// Contains the API instance wrapped in `RefCell` for interior mutability and
+/// the CLI-owned clipboard destination used for best-effort final writes.
 ///
 /// State is deliberately free of `OutputMode`: handlers return one typed result
 /// regardless of `--output`, and the output mode is resolved at the app-execution
 /// boundary (see [`super::commands`]).
 pub struct AppState {
     api: RefCell<PadzApi<FileStore>>,
+    clipboard: Rc<dyn ClipboardWriter>,
     pub scope: Scope,
     pub import_extensions: ImportExtensions,
     pub mode: PadzMode,
@@ -67,11 +72,27 @@ impl AppState {
     ) -> Self {
         Self {
             api: RefCell::new(api),
+            clipboard: Rc::new(SystemClipboardWriter),
             scope,
             import_extensions: ImportExtensions(import_extensions),
             mode,
             local_padz_dir,
         }
+    }
+
+    /// Replace the platform clipboard destination.
+    ///
+    /// Production assembly keeps the default system writer. In-process CLI tests
+    /// supply a recording writer so they can prove one ordered write from semantic
+    /// pad data without invoking an OS clipboard command.
+    pub fn with_clipboard_writer(mut self, clipboard: Rc<dyn ClipboardWriter>) -> Self {
+        self.clipboard = clipboard;
+        self
+    }
+
+    /// Best-effort clipboard write, preserving Padz's established failure semantics.
+    fn copy_to_clipboard(&self, text: &str) {
+        let _ = self.clipboard.write(text);
     }
 
     /// Whether todo status icons are part of this invocation's request.
@@ -455,7 +476,7 @@ impl<'a> ScopedApi<'a> {
         // clipboard source.
         let clipboard_text = view_clipboard_text(&view);
         if !clipboard_text.is_empty() {
-            let _ = copy_to_clipboard(&clipboard_text);
+            self.state.copy_to_clipboard(&clipboard_text);
         }
 
         Ok(Output::Render(view))
@@ -467,7 +488,7 @@ impl<'a> ScopedApi<'a> {
         &self,
         indexes: &[String],
         nesting: NestingMode,
-    ) -> Result<Output<MessagesResult>, anyhow::Error> {
+    ) -> Result<Output<CopyResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.view_pads(scope, indexes, nesting))?;
 
         let indent_per_level: usize = match nesting {
@@ -501,28 +522,23 @@ impl<'a> ScopedApi<'a> {
             }
         }
 
-        let _ = copy_to_clipboard(&clipboard_text);
+        self.state.copy_to_clipboard(&clipboard_text);
 
-        // Report using only the root-level (depth 0) pad titles
-        let root_titles: Vec<&str> = result
+        // Report using only the root-level (depth 0) pad titles. These are the
+        // selected roots; descendants belong in the nested payload but are not
+        // additional selections.
+        let titles: Vec<String> = result
             .listed_pads
             .iter()
             .enumerate()
             .filter(|(i, _)| result.listed_depths.get(*i).copied().unwrap_or(0) == 0)
-            .map(|(_, dp)| dp.pad.metadata.title.as_str())
+            .map(|(_, dp)| dp.pad.metadata.title.clone())
             .collect();
-        let count = root_titles.len();
-        let label = if count == 1 { "pad" } else { "pads" };
-        let msg = format!(
-            "Copied {} {} to clipboard: {}",
-            count,
-            label,
-            root_titles.join(", ")
-        );
 
-        Ok(Output::Render(MessagesResult::new(vec![CmdMessage::info(
-            msg,
-        )])))
+        Ok(Output::Render(CopyResult {
+            root_pad_count: titles.len(),
+            titles,
+        }))
     }
 }
 
@@ -561,10 +577,10 @@ fn parse_nesting_mode(flat: bool, _tree: bool, indented: bool) -> NestingMode {
 }
 
 /// Helper to copy pad content to clipboard (from content string)
-fn copy_content_to_clipboard(content: &str) {
+fn copy_content_to_clipboard(state: &AppState, content: &str) {
     if let Some((title, body)) = extract_title_and_body(content) {
         let clipboard_text = format_for_clipboard(&title, &body);
-        let _ = copy_to_clipboard(&clipboard_text);
+        state.copy_to_clipboard(&clipboard_text);
     }
 }
 
@@ -626,14 +642,15 @@ pub(crate) fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<St
 /// decided here: `cli::input`'s chain resolves it before dispatch and this
 /// handler matches on the resulting [`RequestContent`]. The `editor` /
 /// `no_editor` flags are part of that chain's availability rules, so they are
-/// not read here either.
+/// not read here either. Successful creates preserve the modification schema;
+/// empty piped/editor content returns a typed [`CreateResult::Aborted`] outcome.
 #[handler]
 pub fn create(
     #[ctx] ctx: &CommandContext,
     #[arg] inside: Option<String>,
     #[arg] format: Option<String>,
     #[arg] title: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<CreateResult>, anyhow::Error> {
     let state = get_state(ctx);
     let content = ctx.input::<RequestContent>(CREATE_CONTENT)?;
     let title_arg = if title.is_empty() {
@@ -675,7 +692,7 @@ pub fn create(
             state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
             // Copy to clipboard
             let clipboard_text = format_for_clipboard(&title, &body);
-            let _ = copy_to_clipboard(&clipboard_text);
+            state.copy_to_clipboard(&clipboard_text);
             result
         }
 
@@ -693,7 +710,7 @@ pub fn create(
             let parent_id = result.affected_pads[0].pad.metadata.parent_id;
             state.with_api(|api| api.propagate_status(state.scope, parent_id))?;
             // Copy to clipboard
-            copy_content_to_clipboard(raw);
+            copy_content_to_clipboard(state, raw);
             result
         }
 
@@ -730,7 +747,7 @@ pub fn create(
                             .map_err(to_anyhow)
                     })?;
                     // Copy to clipboard
-                    copy_content_to_clipboard(&pad.content);
+                    copy_content_to_clipboard(state, &pad.content);
                     // Build result
                     let display_pad = padzapp::index::DisplayPad {
                         pad,
@@ -751,23 +768,19 @@ pub fn create(
         }
     };
 
-    Ok(Output::Render(
+    Ok(Output::Render(CreateResult::Created(
         api(ctx).modification_result("Created", result, false),
-    ))
+    )))
 }
 
 /// The result of a `create` the user abandoned by supplying no content.
 ///
-/// No pad was created, so there is nothing to report but the warning.
-fn aborted_create() -> ModificationResult {
-    ModificationResult {
-        action: "Created".to_string(),
-        pads: Vec::new(),
-        messages: vec![CmdMessage::warning("Aborted: empty content")],
-        notices: Vec::new(),
-        outcomes: Vec::new(),
-        request: ModificationRequest::default(),
-    }
+/// No pad was created, so the result carries only the semantic abort facts.
+fn aborted_create() -> CreateResult {
+    CreateResult::Aborted(CreateAbortResult {
+        kind: CreateAbortKindResult::Aborted,
+        reason: CreateAbortReasonResult::EmptyContent,
+    })
 }
 
 /// List all pads with optional filtering.
@@ -894,6 +907,7 @@ pub fn view(
     api(ctx).view_pads(&indexes, uuid, nesting)
 }
 
+/// Copy selected pads to one ordered clipboard payload and return root-selection facts.
 #[handler]
 pub fn copy(
     #[ctx] ctx: &CommandContext,
@@ -902,7 +916,7 @@ pub fn copy(
     #[flag] flat: bool,
     #[flag] tree: bool,
     #[flag] indented: bool,
-) -> Result<Output<MessagesResult>, anyhow::Error> {
+) -> Result<Output<CopyResult>, anyhow::Error> {
     let nesting = parse_nesting_mode(flat, tree, indented);
     api(ctx).copy_pads(&indexes, nesting)
 }
@@ -942,7 +956,7 @@ pub fn edit(
         // Quick-edit (todos mode, inline words): the raw text is copied as typed.
         RequestContent::Direct(raw) => {
             let result = update(raw)?;
-            let _ = copy_to_clipboard(raw);
+            state.copy_to_clipboard(raw);
             return Ok(Output::Render(
                 api(ctx).modification_result("Updated", result, false),
             ));
@@ -951,7 +965,7 @@ pub fn edit(
         // Piped content is copied in the pad's title/body shape.
         RequestContent::Piped(raw) => {
             let result = update(raw)?;
-            copy_content_to_clipboard(raw);
+            copy_content_to_clipboard(state, raw);
             return Ok(Output::Render(
                 api(ctx).modification_result("Updated", result, false),
             ));
@@ -995,7 +1009,7 @@ pub fn edit(
     // Refresh pad from disk (re-reads content, updates title)
     match state.with_api(|api| api.refresh_pad(state.scope, &pad_id).map_err(to_anyhow))? {
         Some(pad) => {
-            copy_content_to_clipboard(&pad.content);
+            copy_content_to_clipboard(state, &pad.content);
             let title = pad.metadata.title.clone();
 
             let display_pad = padzapp::index::DisplayPad {

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -857,6 +857,50 @@ impl MessagesResult {
     }
 }
 
+/// Semantic facts reported after copying pads to the system clipboard.
+///
+/// Only selected roots contribute to the count and titles. Descendants remain in
+/// the clipboard payload according to the requested nesting mode, but they are not
+/// additional user selections.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CopyResult {
+    pub root_pad_count: usize,
+    pub titles: Vec<String>,
+}
+
+/// The typed outcome of `create`.
+///
+/// `Created` deliberately serializes exactly like the existing
+/// [`ModificationResult`] so successful-create automation remains compatible.
+/// `Aborted` replaces the former prose-only warning with semantic facts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CreateResult {
+    Created(ModificationResult),
+    Aborted(CreateAbortResult),
+}
+
+/// Why a create invocation stopped without creating a pad.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateAbortResult {
+    pub kind: CreateAbortKindResult,
+    pub reason: CreateAbortReasonResult,
+}
+
+/// The top-level outcome class for a create abort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CreateAbortKindResult {
+    Aborted,
+}
+
+/// The semantic reason a create invocation aborted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CreateAbortReasonResult {
+    EmptyContent,
+}
+
 /// CLI projection of explicit store initialization and link maintenance.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -501,7 +501,7 @@ pub enum Commands {
         indented: bool,
     },
 
-    /// Copy one or more pads to the clipboard (without printing)
+    /// Copy one or more pads to the clipboard without printing their contents
     #[command(alias = "cp", display_order = 10)]
     #[dispatch(pure, template = "copy")]
     Copy {

--- a/crates/padz/src/cli/setup.rs
+++ b/crates/padz/src/cli/setup.rs
@@ -503,7 +503,7 @@ pub enum Commands {
 
     /// Copy one or more pads to the clipboard (without printing)
     #[command(alias = "cp", display_order = 10)]
-    #[dispatch(pure, template = "messages")]
+    #[dispatch(pure, template = "copy")]
     Copy {
         /// Indexes of the pads (e.g. 1 p1 d1)
         #[arg(required = true, num_args = 1.., add = all_pads_completer())]

--- a/crates/padz/src/cli/templates/copy.jinja
+++ b/crates/padz/src/cli/templates/copy.jinja
@@ -1,0 +1,2 @@
+{#- Copy reports selected-root facts; descendants belong only to the payload. -#}
+[info]Copied {{ root_pad_count }} {{ "pad" if root_pad_count == 1 else "pads" }} to clipboard: {{ titles | join(", ") }}[/info]

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -1,5 +1,9 @@
 {#- Unified rendering for modification commands. `modification_view` is derived at -#}
 {#- render time from the handler's ModificationResult; see cli::render. -#}
+{#- An empty piped/editor create is a typed abort, not a modification. -#}
+{%- if kind == "aborted" and reason == "empty_content" -%}
+[warning]Aborted: empty content[/warning]{{ "" | nl }}
+{%- else -%}
 {%- set view = modification_view -%}
 {%- set show_status = view.show_status -%}
 {%- set peek_mode = false -%}
@@ -43,3 +47,4 @@
 [info]No completed pads to delete.[/info]{{ "" | nl }}
 {%- endif -%}
 {%- endfor -%}
+{%- endif -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/copy-multiple.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/copy-multiple.json
@@ -1,0 +1,4 @@
+{
+  "root_pad_count": 2,
+  "titles": ["second", "first"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/copy-nested.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/copy-nested.json
@@ -1,0 +1,4 @@
+{
+  "root_pad_count": 1,
+  "titles": ["parent"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/copy-singleton.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/copy-singleton.json
@@ -1,0 +1,4 @@
+{
+  "root_pad_count": 1,
+  "titles": ["single"]
+}

--- a/crates/padz/tests/fixtures/semantic_outcomes/create-aborted.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/create-aborted.json
@@ -1,0 +1,4 @@
+{
+  "kind": "aborted",
+  "reason": "empty_content"
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -1085,6 +1085,23 @@ fn create_with_an_empty_pipe_aborts_without_creating_a_pad() {
     };
     assert_eq!(abort.kind, CreateAbortKindResult::Aborted);
     assert_eq!(abort.reason, CreateAbortReasonResult::EmptyContent);
+
+    let listed = rendered(handlers::list(
+        &ctx,
+        vec![],
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        vec![],
+        false,
+        false,
+    ));
+    assert!(listed.pads.is_empty());
 }
 
 #[test]

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -26,7 +26,8 @@ mod support;
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
 use padz::cli::result::{
-    DoctorResult, ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
+    CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateResult, DoctorResult,
+    ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
     ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
     MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
     MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
@@ -60,6 +61,16 @@ fn titles(result: &PadListResult) -> Vec<String> {
         .iter()
         .map(|p| p.pad.metadata.title.clone())
         .collect()
+}
+
+/// Unwraps the successful modification arm of create without changing its public
+/// serialized shape.
+#[track_caller]
+fn created(out: Result<Output<CreateResult>, anyhow::Error>) -> ModificationResult {
+    match rendered(out) {
+        CreateResult::Created(result) => result,
+        CreateResult::Aborted(abort) => panic!("expected created pad, got {abort:?}"),
+    }
 }
 
 // =============================================================================
@@ -289,6 +300,86 @@ fn view_of_an_unknown_selector_is_an_error_not_an_empty_result() {
         err.to_string().to_lowercase().contains("99")
             || err.to_string().to_lowercase().contains("not found"),
         "error should name the bad selector, got: {err}"
+    );
+}
+
+// =============================================================================
+// Content family — copy
+// =============================================================================
+
+#[test]
+fn copy_maps_a_single_root_to_typed_facts_and_one_semantic_write() {
+    let fx = Fixture::new();
+    let (state, clipboard) = fx.app_state_with_recording_clipboard_for(&["copy", "1"]);
+    fx.seed_pad(&state, "single", "body");
+    let ctx = support::ctx_with_state(state);
+
+    let result: CopyResult = rendered(handlers::copy(
+        &ctx,
+        vec!["1".to_string()],
+        false,
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(
+        result,
+        CopyResult {
+            root_pad_count: 1,
+            titles: vec!["single".to_string()],
+        }
+    );
+    assert_eq!(clipboard.writes(), vec!["single\n\nbody"]);
+}
+
+#[test]
+fn copy_maps_multiple_roots_in_display_order() {
+    let fx = Fixture::new();
+    let (state, clipboard) = fx.app_state_with_recording_clipboard_for(&["copy", "1", "2"]);
+    fx.seed_pad(&state, "first", "one");
+    fx.seed_pad(&state, "second", "two");
+    let ctx = support::ctx_with_state(state);
+
+    let result: CopyResult = rendered(handlers::copy(
+        &ctx,
+        vec!["1".to_string(), "2".to_string()],
+        false,
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(result.root_pad_count, 2);
+    assert_eq!(result.titles, vec!["second", "first"]);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["second\n\ntwo\n---\n\nfirst\n\none"]
+    );
+}
+
+#[test]
+fn copy_keeps_nested_content_in_the_payload_but_counts_only_the_root() {
+    let fx = Fixture::new();
+    let (state, clipboard) = fx.app_state_with_recording_clipboard_for(&["copy", "1"]);
+    fx.seed_pad(&state, "parent", "parent body");
+    fx.seed_child(&state, "1", "child", "child body");
+    let ctx = support::ctx_with_state(state);
+
+    let result: CopyResult = rendered(handlers::copy(
+        &ctx,
+        vec!["1".to_string()],
+        false,
+        false,
+        false,
+        false,
+    ));
+
+    assert_eq!(result.root_pad_count, 1);
+    assert_eq!(result.titles, vec!["parent"]);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["parent\n\nparent body\n\nchild\n\nchild body"]
     );
 }
 
@@ -974,7 +1065,7 @@ fn create_with_direct_content_splits_title_from_body() {
         RequestContent::Direct("the title\nthe body".to_string()),
     );
 
-    let result = rendered(handlers::create(&ctx, None, None, vec![]));
+    let result = created(handlers::create(&ctx, None, None, vec![]));
 
     assert_eq!(result.action, "Created");
     assert_eq!(result.pads[0].pad.metadata.title, "the title");
@@ -989,18 +1080,11 @@ fn create_with_an_empty_pipe_aborts_without_creating_a_pad() {
 
     let result = rendered(handlers::create(&ctx, None, None, vec![]));
 
-    assert!(
-        result.pads.is_empty(),
-        "an aborted create must report no pads"
-    );
-    assert!(
-        result
-            .messages
-            .iter()
-            .any(|m| m.content.to_lowercase().contains("aborted")),
-        "the abort must be visible to the user, got: {:?}",
-        result.messages
-    );
+    let CreateResult::Aborted(abort) = result else {
+        panic!("expected a semantic create abort")
+    };
+    assert_eq!(abort.kind, CreateAbortKindResult::Aborted);
+    assert_eq!(abort.reason, CreateAbortReasonResult::EmptyContent);
 }
 
 #[test]
@@ -1012,7 +1096,7 @@ fn create_piped_content_takes_its_title_from_the_first_line() {
         RequestContent::Piped("piped title\npiped body".to_string()),
     );
 
-    let result = rendered(handlers::create(&ctx, None, None, vec![]));
+    let result = created(handlers::create(&ctx, None, None, vec![]));
 
     assert_eq!(result.pads[0].pad.metadata.title, "piped title");
 }
@@ -1026,7 +1110,7 @@ fn create_prefers_the_title_argument_over_the_piped_title() {
         RequestContent::Piped("piped title\npiped body".to_string()),
     );
 
-    let result = rendered(handlers::create(
+    let result = created(handlers::create(
         &ctx,
         None,
         None,

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -108,19 +108,6 @@ fn shape_of(v: &serde_json::Value) -> Shape {
     shape
 }
 
-/// The message strings a JSON result carries.
-fn messages(json: &str) -> Vec<String> {
-    let v: serde_json::Value = serde_json::from_str(json).unwrap();
-    v["messages"]
-        .as_array()
-        .map(|ms| {
-            ms.iter()
-                .map(|m| m["content"].as_str().unwrap_or_default().to_string())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 // =============================================================================
 // Command wiring — argv reaches the right handler with the right arguments
 // =============================================================================
@@ -217,10 +204,12 @@ fn a_naked_invocation_with_an_empty_pipe_aborts_create() {
         .run(&app, cmd, fx.argv(&["--output", "json"]));
 
     result.assert_success();
-    assert_eq!(pads(result.stdout()), Vec::<(String, String)>::new());
-    assert!(messages(result.stdout())
-        .iter()
-        .any(|message| message.contains("Aborted: empty content")));
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -1246,6 +1235,112 @@ fn uuid_flag_reaches_the_view_handler() {
 }
 
 // =============================================================================
+// Copy — semantic result plus application-owned clipboard destination
+// =============================================================================
+
+#[test]
+#[serial]
+fn singleton_copy_reports_typed_facts_and_writes_once() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "single", "body");
+    drop(state);
+
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["copy", "1"]);
+    let result = TestHarness::new().run(&app, cmd, fx.argv(&["copy", "1", "--output", "json"]));
+
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/copy-singleton.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(clipboard.writes(), vec!["single\n\nbody"]);
+}
+
+#[test]
+#[serial]
+fn multiple_copy_preserves_root_order_in_facts_and_one_payload() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "first", "one");
+    fx.seed_pad(&state, "second", "two");
+    drop(state);
+
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["copy", "1", "2"]);
+    let result =
+        TestHarness::new().run(&app, cmd, fx.argv(&["copy", "1", "2", "--output", "json"]));
+
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/copy-multiple.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["second\n\ntwo\n---\n\nfirst\n\none"]
+    );
+}
+
+#[test]
+#[serial]
+fn nested_copy_keeps_descendants_in_one_payload_but_reports_one_root() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "parent", "parent body");
+    fx.seed_child(&state, "1", "child", "child body");
+    drop(state);
+
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["copy", "1"]);
+    let result = TestHarness::new().run(&app, cmd, fx.argv(&["copy", "1", "--output", "json"]));
+
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/semantic_outcomes/copy-nested.json")).unwrap();
+    assert_eq!(actual, expected);
+    assert_eq!(
+        clipboard.writes(),
+        vec!["parent\n\nparent body\n\nchild\n\nchild body"]
+    );
+}
+
+#[test]
+#[serial]
+fn copy_template_preserves_human_wording_and_pluralization() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "single", "body");
+    drop(state);
+
+    let (app, cmd, _clipboard) = fx.app_with_recording_clipboard(&["copy", "1"]);
+    TestHarness::new()
+        .no_color()
+        .text_output()
+        .run(&app, cmd, fx.argv(&["copy", "1"]))
+        .assert_stdout_contains("Copied 1 pad to clipboard: single");
+
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "first", "one");
+    fx.seed_pad(&state, "second", "two");
+    drop(state);
+
+    let (app, cmd, _clipboard) = fx.app_with_recording_clipboard(&["copy", "1", "2"]);
+    let result =
+        TestHarness::new()
+            .no_color()
+            .text_output()
+            .run(&app, cmd, fx.argv(&["copy", "1", "2"]));
+
+    result.assert_success();
+    result.assert_stdout_contains("Copied 2 pads to clipboard: second, first");
+}
+
+// =============================================================================
 // Input chain — the pre-dispatch hooks, driven through real argv and stdin
 // =============================================================================
 //
@@ -1361,22 +1456,23 @@ fn title_arg_overrides_the_piped_title() {
 #[serial]
 fn empty_pipe_aborts_and_creates_no_pad() {
     let fx = Fixture::new();
-    let (app, cmd) = fx.app(&["create"]);
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["create"]);
 
-    let result = TestHarness::new().no_color().piped_stdin("").run(
-        &app,
-        cmd,
-        fx.argv(&["create", "--output", "json"]),
-    );
+    let result = TestHarness::new()
+        .no_color()
+        .piped_stdin("")
+        .env("EDITOR", "/usr/bin/false")
+        .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
 
-    assert_eq!(pads(result.stdout()), vec![]);
-    assert!(
-        messages(result.stdout())
-            .iter()
-            .any(|m| m.contains("Aborted: empty content")),
-        "expected an abort warning, got: {}",
-        result.stdout()
-    );
+    result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert!(clipboard.writes().is_empty());
     drop(result);
 
     // The store must stay empty — the abort is not a create that rendered oddly.
@@ -1392,18 +1488,22 @@ fn empty_pipe_aborts_and_creates_no_pad() {
 #[serial]
 fn whitespace_only_pipe_aborts() {
     let fx = Fixture::new();
-    let (app, cmd) = fx.app(&["create"]);
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["create"]);
 
-    let result = TestHarness::new().no_color().piped_stdin("   \n  \n").run(
-        &app,
-        cmd,
-        fx.argv(&["create", "--output", "json"]),
-    );
+    let result = TestHarness::new()
+        .no_color()
+        .piped_stdin("   \n  \n")
+        .env("EDITOR", "/usr/bin/false")
+        .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
 
-    assert_eq!(pads(result.stdout()), vec![]);
-    assert!(messages(result.stdout())
-        .iter()
-        .any(|m| m.contains("Aborted: empty content")));
+    result.assert_success();
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert!(clipboard.writes().is_empty());
 }
 
 #[test]
@@ -1589,7 +1689,7 @@ fn a_terminal_stdin_routes_create_to_the_editor() {
     let result = TestHarness::new()
         .no_color()
         .interactive_stdin()
-        .env("EDITOR", "/bin/false")
+        .env("EDITOR", "/usr/bin/false")
         .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
 
     assert!(
@@ -1615,6 +1715,55 @@ fn a_terminal_stdin_routes_create_to_the_editor() {
         vec![],
         "a failed editor create must roll the pad back"
     );
+}
+
+#[test]
+#[serial]
+fn an_editor_save_with_empty_content_returns_the_typed_abort() {
+    let fx = Fixture::new();
+    let (app, cmd, clipboard) = fx.app_with_recording_clipboard(&["create"]);
+
+    // `/usr/bin/true` accepts the scratch pad path and exits successfully without
+    // writing it, exactly like leaving the editor buffer empty and saving.
+    let result = TestHarness::new()
+        .no_color()
+        .interactive_stdin()
+        .env("EDITOR", "/usr/bin/true")
+        .run(&app, cmd, fx.argv(&["create", "--output", "json"]));
+
+    result.assert_success();
+    result.assert_exit_status(ExitStatus::SUCCESS);
+    let actual: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/semantic_outcomes/create-aborted.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+    assert!(clipboard.writes().is_empty());
+    drop(result);
+
+    let (app, cmd) = fx.read_app();
+    let listed =
+        TestHarness::new()
+            .no_color()
+            .run(&app, cmd, fx.argv(&["list", "--output", "json"]));
+    assert_eq!(pads(listed.stdout()), vec![]);
+}
+
+#[test]
+#[serial]
+fn an_empty_create_abort_preserves_human_wording() {
+    let fx = Fixture::new();
+    let (app, cmd) = fx.app(&["create"]);
+
+    let result = TestHarness::new().no_color().piped_stdin("").run(
+        &app,
+        cmd,
+        fx.argv(&["create", "--output", "text"]),
+    );
+
+    result.assert_success();
+    result.assert_stdout_contains("Aborted: empty content");
 }
 
 // =============================================================================

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -210,6 +210,11 @@ fn a_naked_invocation_with_an_empty_pipe_aborts_create() {
     ))
     .unwrap();
     assert_eq!(actual, expected);
+    drop(result);
+
+    let (app, cmd) = fx.read_app();
+    let listed = TestHarness::new().run(&app, cmd, fx.argv(&["list", "--output", "json"]));
+    assert_eq!(pads(listed.stdout()), vec![]);
 }
 
 #[test]
@@ -1504,6 +1509,11 @@ fn whitespace_only_pipe_aborts() {
     .unwrap();
     assert_eq!(actual, expected);
     assert!(clipboard.writes().is_empty());
+    drop(result);
+
+    let (app, cmd) = fx.read_app();
+    let listed = TestHarness::new().run(&app, cmd, fx.argv(&["list", "--output", "json"]));
+    assert_eq!(pads(listed.stdout()), vec![]);
 }
 
 #[test]

--- a/crates/padz/tests/support/mod.rs
+++ b/crates/padz/tests/support/mod.rs
@@ -17,6 +17,7 @@
 #![allow(dead_code)] // Each test binary uses its own subset of these helpers.
 
 use clap::Parser;
+use padz::cli::clipboard::ClipboardWriter;
 use padz::cli::commands::{build_app_state, build_dispatch_app};
 use padz::cli::handlers::AppState;
 use padz::cli::input::RequestContent;
@@ -25,6 +26,7 @@ use padzapp::init::{create_bucket_layout, PadzEnv};
 use standout::cli::App;
 use standout::input::{InputSourceKind, Inputs, ResolvedInput};
 use standout_dispatch::{CommandContext, Extensions};
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use tempfile::TempDir;
@@ -37,6 +39,29 @@ pub struct Fixture {
     temp: TempDir,
     project: PathBuf,
     env: PadzEnv,
+}
+
+/// A CLI clipboard destination that records every complete payload.
+///
+/// Copy tests inspect the vector to prove both write count and byte ordering. It
+/// implements Padz's application-owned write seam because Standout's harness
+/// clipboard override is intentionally an input reader, not an output sink.
+#[derive(Clone, Default)]
+pub struct RecordingClipboard {
+    writes: Rc<RefCell<Vec<String>>>,
+}
+
+impl RecordingClipboard {
+    pub fn writes(&self) -> Vec<String> {
+        self.writes.borrow().clone()
+    }
+}
+
+impl ClipboardWriter for RecordingClipboard {
+    fn write(&self, text: &str) -> padzapp::error::Result<()> {
+        self.writes.borrow_mut().push(text.to_string());
+        Ok(())
+    }
 }
 
 impl Fixture {
@@ -130,6 +155,18 @@ impl Fixture {
         build_app_state(&cli, &self.env, &self.project).expect("failed to build app state")
     }
 
+    /// App state with an observable CLI clipboard destination.
+    pub fn app_state_with_recording_clipboard_for(
+        &self,
+        args: &[&str],
+    ) -> (AppState, RecordingClipboard) {
+        let clipboard = RecordingClipboard::default();
+        let state = self
+            .app_state_for(args)
+            .with_clipboard_writer(Rc::new(clipboard.clone()));
+        (state, clipboard)
+    }
+
     /// The real dispatch app (templates, styles, dispatch table) bound to this
     /// fixture's store, paired with the clap command — the two arguments
     /// `TestHarness::run` wants.
@@ -141,6 +178,15 @@ impl Fixture {
             build_dispatch_app(self.app_state_for(args)),
             build_command(),
         )
+    }
+
+    /// The real dispatch app with an observable CLI clipboard destination.
+    pub fn app_with_recording_clipboard(
+        &self,
+        args: &[&str],
+    ) -> (App, clap::Command, RecordingClipboard) {
+        let (state, clipboard) = self.app_state_with_recording_clipboard_for(args);
+        (build_dispatch_app(state), build_command(), clipboard)
     }
 
     /// The dispatch app for an ordinary read/modify command. See [`app_state`](Self::app_state).


### PR DESCRIPTION
## Context

for #219

This workstream replaces the last shell-authored copy and empty-create prose with CLI-owned semantic outcomes. Copy now returns ordered selected-root facts while one application-owned clipboard writer receives the complete payload built directly from semantic pad data. Empty piped and editor creates return an aborted/empty_content result while preserving successful exit behavior, no pad creation, and the existing human warning.

Standout 7.9 TestHarness can inject a clipboard reader but cannot observe application writes. Standout's clipboard pipe consumes rendered output, which would violate this issue's semantic-source boundary. The narrow CLI-owned ClipboardWriter dependency therefore uses the platform writer in production and a recording writer in tests; padzapp remains CLI-free.

Successful create structured output retains the existing top-level modification shape through an untagged created arm. The intentional structured replacements are documented in the changelog and JSON fixtures: copy exposes root_pad_count plus ordered titles, and empty create exposes kind aborted plus reason empty_content. Human wording, nesting, clipboard bytes, ordering, input precedence, and exit behavior remain compatible.

Self-checked against #208, #219, merged #207, and the integrated STD02 WS01-WS06 result patterns. This workstream has no governing ADR or spec.

Out of scope: #220-#223, dependency changes, export/input redesign, core changes, and broader presentation cleanup. Do not route clipboard data through rendered or structured output, and do not move shell input or clipboard facts into padzapp.

## Test evidence

- env RUSTC_WRAPPER= pixi run test — 895 passed, 1 skipped
- direct typed-handler suite — 45 passed
- serial TestHarness suite — 80 passed
- pre-commit and pre-push hooks — lint gate passed all 12 checks