### PR TITLE
STD03: Epic: Finish Smallest-Seam Test Migration - Workstream: Direct Format Tests

### DIFF
--- a/crates/padz/tests/format_e2e.rs
+++ b/crates/padz/tests/format_e2e.rs
@@ -6,7 +6,7 @@
 //!
 //! **`padz config set format`, which `cli::run` handles before dispatch.**
 //!
-//! Most of this suite turns on the config *write* path: `config` is intercepted
+//! This suite turns on the config *write/load* path: `config` is intercepted
 //! by `run` and handed to clapfig, never reaching a handler, so
 //! `App::run_to_string` — where `TestHarness` starts — cannot reach it. The
 //! tests that flip `format` in config and then observe the next create honor it
@@ -14,22 +14,8 @@
 //! `test_config_set_format_does_not_rename_existing_pads`,
 //! `test_config_with_stale_keys_still_loads_format`) need that round trip.
 //!
-//! ## Honest classification: not all of it needs a process
-//!
-//! The cases that only assert "`create --format md` writes a `.md` file"
-//! (`test_create_uses_default_txt_format`, `test_create_with_format_override_creates_md`,
-//! `test_format_override_does_not_affect_subsequent_creates`,
-//! `test_format_alias_markdown_creates_md`, `test_format_alias_text_creates_txt`,
-//! `test_mixed_formats_list_and_view_work`) do **not** need a real process: the
-//! format reaches `padzapp` as an argument and the on-disk filename is a
-//! `padzapp` fact, so they belong in `padzapp`'s own tests, with the CLI's
-//! `--format`-to-argument mapping proven in `handlers_direct.rs`.
-//!
-//! They are left here deliberately rather than migrated blind: moving them is a
-//! `padzapp`-side change, and this workstream's rule is to move one
-//! representative behavior at a time and delete the redundant assertion, not to
-//! bulk-rewrite a suite against an API the mover hasn't read. Tracked as
-//! follow-up; see this workstream's PR.
+//! Direct format behavior lives in `padzapp/tests/format_behavior.rs`; typed
+//! handler forwarding of `format` lives in `handlers_direct.rs`.
 
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
@@ -62,150 +48,9 @@ fn setup_project(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
 }
 
 #[test]
-fn test_create_uses_default_txt_format() {
-    let temp = TempDir::new().unwrap();
-    let (project, global_dir) = setup_project(&temp);
-
-    // Create a pad (default format = txt)
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "hello"])
-        .assert()
-        .success();
-
-    // Check that a .txt file was created in .padz/active/
-    let active_dir = project.join(".padz").join("active");
-    let entries: Vec<_> = fs::read_dir(&active_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("pad-") && name.ends_with(".txt")
-        })
-        .collect();
-
-    assert_eq!(entries.len(), 1, "Expected one .txt pad file");
-}
-
-#[test]
-fn test_create_with_format_override_creates_md() {
-    let temp = TempDir::new().unwrap();
-    let (project, global_dir) = setup_project(&temp);
-
-    // Create a pad with --format md
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "--format", "md", "markdown pad"])
-        .assert()
-        .success();
-
-    // Check that a .md file was created
-    let active_dir = project.join(".padz").join("active");
-    let entries: Vec<_> = fs::read_dir(&active_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("pad-") && name.ends_with(".md")
-        })
-        .collect();
-
-    assert_eq!(entries.len(), 1, "Expected one .md pad file");
-}
-
-#[test]
-fn test_format_override_does_not_affect_subsequent_creates() {
-    let temp = TempDir::new().unwrap();
-    let (project, global_dir) = setup_project(&temp);
-
-    // Create first pad with --format md
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "--format", "md", "md pad"])
-        .assert()
-        .success();
-
-    // Create second pad without format (should use default .txt)
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "txt pad"])
-        .assert()
-        .success();
-
-    let active_dir = project.join(".padz").join("active");
-    let md_count = fs::read_dir(&active_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("pad-") && name.ends_with(".md")
-        })
-        .count();
-    let txt_count = fs::read_dir(&active_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("pad-") && name.ends_with(".txt")
-        })
-        .count();
-
-    assert_eq!(md_count, 1, "Expected one .md file");
-    assert_eq!(txt_count, 1, "Expected one .txt file");
-}
-
-#[test]
-fn test_mixed_formats_list_and_view_work() {
-    let temp = TempDir::new().unwrap();
-    let (project, global_dir) = setup_project(&temp);
-
-    // Create pads with different formats
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "--format", "md", "markdown note"])
-        .assert()
-        .success();
-
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "plain text note"])
-        .assert()
-        .success();
-
-    // List should show both
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["list", "--output", "json"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("markdown note"))
-        .stdout(predicate::str::contains("plain text note"));
-
-    // View each should work
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["view", "1", "--output", "json"])
-        .assert()
-        .success();
-
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["view", "2", "--output", "json"])
-        .assert()
-        .success();
-}
-
-#[test]
 fn test_config_set_format_affects_new_pads() {
+    // Process-only boundary: `config set` writes through clapfig before dispatch,
+    // and a later invocation must reload that persisted value into AppState.
     let temp = TempDir::new().unwrap();
     let (project, global_dir) = setup_project(&temp);
 
@@ -240,6 +85,8 @@ fn test_config_set_format_affects_new_pads() {
 
 #[test]
 fn test_config_set_format_does_not_rename_existing_pads() {
+    // Process-only boundary: a pre-dispatch `config set` must persist for later
+    // invocations without rewriting files created by an earlier invocation.
     let temp = TempDir::new().unwrap();
     let (project, global_dir) = setup_project(&temp);
 
@@ -286,73 +133,9 @@ fn test_config_set_format_does_not_rename_existing_pads() {
 }
 
 #[test]
-fn test_format_alias_markdown_creates_md() {
-    let temp = TempDir::new().unwrap();
-    let (project, global_dir) = setup_project(&temp);
-
-    // Create with "markdown" alias
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args([
-            "create",
-            "--no-editor",
-            "--format",
-            "markdown",
-            "alias test",
-        ])
-        .assert()
-        .success();
-
-    let active_dir = project.join(".padz").join("active");
-    let md_count = fs::read_dir(&active_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("pad-") && name.ends_with(".md")
-        })
-        .count();
-
-    assert_eq!(md_count, 1, "\"markdown\" alias should create .md file");
-}
-
-#[test]
-fn test_format_alias_text_creates_txt() {
-    let temp = TempDir::new().unwrap();
-    let (project, global_dir) = setup_project(&temp);
-
-    // Set format to md first
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["config", "set", "format", "md"])
-        .assert()
-        .success();
-
-    // Create with "text" alias (should override config and create .txt)
-    padz_cmd()
-        .env("PADZ_GLOBAL_DATA", global_dir.as_os_str())
-        .current_dir(&project)
-        .args(["create", "--no-editor", "--format", "text", "text alias"])
-        .assert()
-        .success();
-
-    let active_dir = project.join(".padz").join("active");
-    let txt_count = fs::read_dir(&active_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            name.starts_with("pad-") && name.ends_with(".txt")
-        })
-        .count();
-
-    assert_eq!(txt_count, 1, "\"text\" alias should create .txt file");
-}
-
-#[test]
 fn test_config_with_stale_keys_still_loads_format() {
+    // Process-only boundary: startup configuration loading happens before
+    // dispatch and must tolerate stale keys while hydrating the active format.
     let temp = TempDir::new().unwrap();
     let (project, global_dir) = setup_project(&temp);
 

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -1091,6 +1091,43 @@ fn create_with_direct_content_splits_title_from_body() {
 }
 
 #[test]
+fn create_maps_typed_format_values_to_core_format_overrides() {
+    for (format, expected_extension) in [("md", "md"), ("markdown", "md"), ("text", "txt")] {
+        let fx = Fixture::new();
+        if format == "text" {
+            std::fs::write(
+                fx.project().join(".padz").join("padz.toml"),
+                "format = \"md\"\n",
+            )
+            .unwrap();
+        }
+        let ctx = support::ctx_with_input(
+            fx.app_state_for(&["create"]),
+            CREATE_CONTENT,
+            RequestContent::Direct(format!("{format} note\nbody")),
+        );
+
+        let result = created(handlers::create(
+            &ctx,
+            None,
+            Some(format.to_string()),
+            vec![],
+        ));
+        let id = result.pads[0].pad.metadata.id;
+        let expected_path = fx
+            .project()
+            .join(".padz")
+            .join("active")
+            .join(format!("pad-{id}.{expected_extension}"));
+
+        assert!(
+            expected_path.exists(),
+            "typed format {format:?} should reach the core as .{expected_extension}"
+        );
+    }
+}
+
+#[test]
 fn create_with_an_empty_pipe_aborts_without_creating_a_pad() {
     let fx = Fixture::new();
     let state = fx.app_state_for(&["create"]);

--- a/crates/padzapp/tests/format_behavior.rs
+++ b/crates/padzapp/tests/format_behavior.rs
@@ -135,11 +135,16 @@ fn mixed_format_pads_are_listable_and_viewable() {
     titles.sort_unstable();
     assert_eq!(titles, ["markdown note", "plain text note"]);
 
-    for selector in ["1", "2"] {
+    for listed_pad in &listed.listed_pads {
+        let selector = listed_pad.index.to_string();
         let viewed = fx
             .api
-            .view_pads(Scope::Project, &[selector], NestingMode::Flat)
+            .view_pads(Scope::Project, &[selector.as_str()], NestingMode::Flat)
             .unwrap();
         assert_eq!(viewed.listed_pads.len(), 1);
+        assert_eq!(
+            viewed.listed_pads[0].pad.metadata.title, listed_pad.pad.metadata.title,
+            "selector {selector} should resolve to its listed pad"
+        );
     }
 }

--- a/crates/padzapp/tests/format_behavior.rs
+++ b/crates/padzapp/tests/format_behavior.rs
@@ -1,0 +1,145 @@
+//! File-format behavior at the core/store seam.
+//!
+//! These tests use the public API with a real [`FileStore`]: format selection is
+//! a core argument here, while the resulting filename and mixed-extension lookup
+//! are filesystem-store behavior. Neither requires spawning the CLI binary.
+
+use padzapp::api::{PadFilter, PadzApi, PadzPaths};
+use padzapp::commands::NestingMode;
+use padzapp::model::Scope;
+use padzapp::store::fs::FileStore;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+struct Fixture {
+    _temp: TempDir,
+    api: PadzApi<FileStore>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_default_format("txt")
+    }
+
+    fn with_default_format(format: &str) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project").join(".padz");
+        let global = temp.path().join("global");
+        let store = FileStore::new_fs(Some(project.clone()), global.clone()).with_format(format);
+        let paths = PadzPaths {
+            project: Some(project),
+            global,
+            home: None,
+        };
+
+        Self {
+            _temp: temp,
+            api: PadzApi::new(store, paths),
+        }
+    }
+
+    fn create(&mut self, title: &str) -> PathBuf {
+        self.api
+            .create_pad(Scope::Project, title.to_string(), "body".to_string(), None)
+            .unwrap()
+            .pad_paths
+            .remove(0)
+    }
+
+    fn create_with_format(&mut self, title: &str, format: &str) -> PathBuf {
+        self.api
+            .create_pad_with_format(
+                Scope::Project,
+                title.to_string(),
+                "body".to_string(),
+                None,
+                format,
+            )
+            .unwrap()
+            .pad_paths
+            .remove(0)
+    }
+}
+
+fn assert_extension(path: &Path, expected: &str) {
+    assert_eq!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some(expected)
+    );
+    assert!(
+        path.exists(),
+        "created pad should exist at {}",
+        path.display()
+    );
+}
+
+#[test]
+fn default_create_stores_a_txt_file() {
+    let mut fx = Fixture::new();
+
+    let path = fx.create("plain note");
+
+    assert_extension(&path, "txt");
+}
+
+#[test]
+fn explicit_md_format_stores_a_markdown_file() {
+    let mut fx = Fixture::new();
+
+    let path = fx.create_with_format("markdown note", "md");
+
+    assert_extension(&path, "md");
+}
+
+#[test]
+fn an_explicit_format_override_does_not_persist() {
+    let mut fx = Fixture::new();
+
+    let overridden = fx.create_with_format("markdown note", "md");
+    let following = fx.create("plain note");
+
+    assert_extension(&overridden, "md");
+    assert_extension(&following, "txt");
+}
+
+#[test]
+fn markdown_and_text_aliases_select_the_canonical_extensions() {
+    let mut markdown_fx = Fixture::new();
+    let mut text_fx = Fixture::with_default_format("md");
+
+    let markdown = markdown_fx.create_with_format("markdown alias", "markdown");
+    let text = text_fx.create_with_format("text alias", "text");
+
+    assert_extension(&markdown, "md");
+    assert_extension(&text, "txt");
+}
+
+#[test]
+fn mixed_format_pads_are_listable_and_viewable() {
+    let mut fx = Fixture::new();
+    let markdown = fx.create_with_format("markdown note", "md");
+    let text = fx.create("plain text note");
+
+    assert_extension(&markdown, "md");
+    assert_extension(&text, "txt");
+
+    let listed = fx
+        .api
+        .get_pads(Scope::Project, PadFilter::default(), &[] as &[String])
+        .unwrap();
+    let mut titles: Vec<_> = listed
+        .listed_pads
+        .iter()
+        .map(|pad| pad.pad.metadata.title.as_str())
+        .collect();
+    titles.sort_unstable();
+    assert_eq!(titles, ["markdown note", "plain text note"]);
+
+    for selector in ["1", "2"] {
+        let viewed = fx
+            .api
+            .view_pads(Scope::Project, &[selector], NestingMode::Flat)
+            .unwrap();
+        assert_eq!(viewed.listed_pads.len(), 1);
+    }
+}


### PR DESCRIPTION
## Context

Why: issue #220 identified six direct format behaviors whose subprocess tests obscured whether failures belonged to CLI dispatch or core storage.

Approach: STD03-WS08 adds public PadzApi plus FileStore tests for default txt, explicit md, temporary overrides, aliases, and mixed-store list/view behavior. A direct typed-handler test proves format values are forwarded to the core, including text overriding a configured md default. The six redundant process assertions were removed only after those equivalents existed.

Out of scope: the three pre-dispatch configuration write/load round trips remain subprocess tests and now state the boundary they protect. No production behavior changed.

for #220