### PR TITLE
STD03: Epic: Finish Smallest-Seam Test Migration - Workstream: Presentation Prose Audit

### DIFF
--- a/CHANGELOG/unreleased-presentation-prose-audit.md
+++ b/CHANGELOG/unreleased-presentation-prose-audit.md
@@ -1,0 +1,6 @@
+- Retire the unused generic `CmdMessage` presentation pipeline. Reusable command
+  results and CLI projections no longer serialize always-empty `messages` arrays;
+  generic pad modifications now serialize a typed semantic `action` token such as
+  `pin` instead of a human past-tense verb such as `Pinned`. This intentional
+  structured-schema cleanup is fixture-tested. Human wording, pluralization,
+  ordering, styles, and terminal layout remain unchanged in CLI templates.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -31,9 +31,9 @@ use std::rc::Rc;
 use super::result::{
     CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateAbortResult, CreateResult,
     DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
-    ModificationRequest, ModificationResult, PadContent, PadContentResult, PadListResult,
-    PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferResult,
-    UuidResult,
+    ModificationActionResult, ModificationRequest, ModificationResult, PadContent,
+    PadContentResult, PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult,
+    TaggingResult, TransferResult, UuidResult,
 };
 
 // =============================================================================
@@ -161,7 +161,7 @@ impl<'a> ScopedApi<'a> {
     /// When `force_show_status` is true, status icons are requested regardless of mode.
     fn modification(
         &self,
-        action: &str,
+        action: ModificationActionResult,
         result: CmdResult,
         force_show_status: bool,
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
@@ -177,14 +177,13 @@ impl<'a> ScopedApi<'a> {
     /// Used by the handlers that assemble a `CmdResult` themselves (create, edit).
     fn modification_result(
         &self,
-        action: &str,
+        action: ModificationActionResult,
         result: CmdResult,
         force_show_status: bool,
     ) -> ModificationResult {
         ModificationResult {
-            action: action.to_string(),
+            action,
             pads: result.affected_pads,
-            messages: result.messages,
             notices: result.notices.into_iter().map(Into::into).collect(),
             outcomes: result.outcomes.into_iter().map(Into::into).collect(),
             request: ModificationRequest {
@@ -200,7 +199,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.pin_pads(scope, indexes))?;
-        self.modification("Pinned", result, false)
+        self.modification(ModificationActionResult::Pin, result, false)
     }
 
     pub fn unpin_pads(
@@ -208,7 +207,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.unpin_pads(scope, indexes))?;
-        self.modification("Unpinned", result, false)
+        self.modification(ModificationActionResult::Unpin, result, false)
     }
 
     pub fn delete_pads(
@@ -216,12 +215,12 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_pads(scope, indexes))?;
-        self.modification("Deleted", result, false)
+        self.modification(ModificationActionResult::Delete, result, false)
     }
 
     pub fn delete_completed_pads(&self) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_completed_pads(scope))?;
-        self.modification("Deleted", result, false)
+        self.modification(ModificationActionResult::Delete, result, false)
     }
 
     pub fn restore_pads(
@@ -229,7 +228,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.restore_pads(scope, indexes))?;
-        self.modification("Restored", result, false)
+        self.modification(ModificationActionResult::Restore, result, false)
     }
 
     pub fn archive_pads(
@@ -237,7 +236,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.archive_pads(scope, indexes))?;
-        self.modification("Archived", result, false)
+        self.modification(ModificationActionResult::Archive, result, false)
     }
 
     pub fn unarchive_pads(
@@ -245,7 +244,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.unarchive_pads(scope, indexes))?;
-        self.modification("Unarchived", result, false)
+        self.modification(ModificationActionResult::Unarchive, result, false)
     }
 
     pub fn complete_pads(
@@ -253,7 +252,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.complete_pads(scope, indexes))?;
-        self.modification("Completed", result, true)
+        self.modification(ModificationActionResult::Complete, result, true)
     }
 
     pub fn reopen_pads(
@@ -261,7 +260,7 @@ impl<'a> ScopedApi<'a> {
         indexes: &[String],
     ) -> Result<Output<ModificationResult>, anyhow::Error> {
         let result = self.call(|api, scope| api.reopen_pads(scope, indexes))?;
-        self.modification("Reopened", result, true)
+        self.modification(ModificationActionResult::Reopen, result, true)
     }
 
     pub fn move_pads(
@@ -280,7 +279,7 @@ impl<'a> ScopedApi<'a> {
             let (sources, dest) = indexes.split_at(indexes.len() - 1);
             self.call(|api, scope| api.move_pads(scope, sources, Some(dest[0].as_str())))?
         };
-        self.modification("Moved", result, false)
+        self.modification(ModificationActionResult::Move, result, false)
     }
 
     // --- Maintenance outcomes ---
@@ -427,7 +426,6 @@ impl<'a> ScopedApi<'a> {
         let result = self.call(|api, scope| api.get_pads(scope, filter, ids))?;
         Ok(Output::Render(PadListResult {
             pads: result.listed_pads,
-            messages: result.messages,
             request: ListRequest {
                 peek,
                 uuid: show_uuid,
@@ -769,7 +767,7 @@ pub fn create(
     };
 
     Ok(Output::Render(CreateResult::Created(
-        api(ctx).modification_result("Created", result, false),
+        api(ctx).modification_result(ModificationActionResult::Create, result, false),
     )))
 }
 
@@ -957,18 +955,22 @@ pub fn edit(
         RequestContent::Direct(raw) => {
             let result = update(raw)?;
             state.copy_to_clipboard(raw);
-            return Ok(Output::Render(
-                api(ctx).modification_result("Updated", result, false),
-            ));
+            return Ok(Output::Render(api(ctx).modification_result(
+                ModificationActionResult::Update,
+                result,
+                false,
+            )));
         }
 
         // Piped content is copied in the pad's title/body shape.
         RequestContent::Piped(raw) => {
             let result = update(raw)?;
             copy_content_to_clipboard(state, raw);
-            return Ok(Output::Render(
-                api(ctx).modification_result("Updated", result, false),
-            ));
+            return Ok(Output::Render(api(ctx).modification_result(
+                ModificationActionResult::Update,
+                result,
+                false,
+            )));
         }
 
         // An empty pipe aborts the edit outright — unlike create, which reports
@@ -1027,9 +1029,11 @@ pub fn edit(
                 }],
                 ..Default::default()
             };
-            Ok(Output::Render(
-                api(ctx).modification_result("Updated", result, false),
-            ))
+            Ok(Output::Render(api(ctx).modification_result(
+                ModificationActionResult::Update,
+                result,
+                false,
+            )))
         }
         None => {
             // User emptied the file
@@ -1625,7 +1629,7 @@ mod tests {
 
         let result = rendered(pin(&app.ctx, vec!["1".into()]).unwrap());
 
-        assert_eq!(result.action, "Pinned");
+        assert_eq!(result.action, ModificationActionResult::Pin);
         assert_eq!(result.pads.len(), 1);
         assert_eq!(result.pads[0].pad.metadata.title, "Pin me");
         assert!(result.pads[0].pad.metadata.is_pinned);
@@ -1638,7 +1642,7 @@ mod tests {
 
         let result = rendered(complete(&app.ctx, vec!["1".into()]).unwrap());
 
-        assert_eq!(result.action, "Completed");
+        assert_eq!(result.action, ModificationActionResult::Complete);
         // A command that changes status always shows it, whatever the mode.
         assert!(result.request.status);
     }
@@ -1651,7 +1655,6 @@ mod tests {
         let result = rendered(delete(&app.ctx, vec![], true).unwrap());
 
         assert!(result.pads.is_empty());
-        assert!(result.messages.is_empty());
         assert_eq!(
             result.notices,
             vec![super::super::result::ModificationNoticeResult::NoCompletedPads]
@@ -1720,7 +1723,7 @@ mod tests {
 
         let json = serde_json::to_value(&result).unwrap();
         assert!(json.get("pads").unwrap().is_array());
-        assert!(json.get("messages").unwrap().is_array());
+        assert!(json.get("messages").is_none());
         assert!(json.get("request").unwrap().is_object());
 
         // Terminal-only derivations must not be anywhere in the handler's value.

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -46,13 +46,12 @@
 //! Everything a template can decide, a template decides.
 
 use super::result::{
-    ModificationNoticeResult, ModificationResult, MutationOutcomeResult, MutationStatusResult,
-    PadListResult, TaggingResult, UpdateKindResult,
+    ModificationActionResult, ModificationNoticeResult, ModificationResult, MutationOutcomeResult,
+    MutationStatusResult, PadListResult, TaggingResult, UpdateKindResult,
 };
 use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
 use minijinja::Value;
-use padzapp::api::CmdMessage;
 use padzapp::index::{DisplayIndex, DisplayPad, SearchMatch};
 use padzapp::model::TodoStatus;
 use padzapp::peek::{format_as_peek, PeekResult};
@@ -208,18 +207,15 @@ pub struct ListView {
     pub deleted_help: bool,
     /// The grouped command help, shown when the store is empty. Rendered by clap.
     pub help_text: String,
-    pub messages: Vec<CmdMessage>,
 }
 
 /// Template-ready view for a modification.
 #[derive(Debug, Clone, Serialize)]
 pub struct ModificationView {
-    /// Past-tense verb for the change ("Created", "Pinned"). The template builds the
-    /// sentence around it, including the pluralization.
-    pub action: String,
+    /// Semantic operation token. The template owns the human verb.
+    pub action: ModificationActionResult,
     pub rows: Vec<PadRow>,
     pub show_status: bool,
-    pub messages: Vec<CmdMessage>,
     /// Presentation-ready projections of semantic core notices.
     pub notices: Vec<ModificationNoticeView>,
     /// Presentation-ready projections of semantic successful outcomes.
@@ -316,7 +312,6 @@ pub fn build_list_view(result: &PadListResult) -> ListView {
         } else {
             String::new()
         },
-        messages: result.messages.clone(),
     }
 }
 
@@ -330,14 +325,13 @@ pub fn build_modification_view(result: &ModificationResult) -> ModificationView 
         ..Default::default()
     };
     ModificationView {
-        action: result.action.clone(),
+        action: result.action,
         rows: result
             .pads
             .iter()
             .map(|dp| row(dp, 0, SectionKind::of(&dp.index), &opts))
             .collect(),
         show_status: result.request.status,
-        messages: result.messages.clone(),
         notices: result.notices.iter().map(modification_notice).collect(),
         outcomes: result
             .outcomes
@@ -526,11 +520,7 @@ mod tests {
     }
 
     fn list(pads: Vec<DisplayPad>, request: ListRequest) -> PadListResult {
-        PadListResult {
-            pads,
-            messages: vec![],
-            request,
-        }
+        PadListResult { pads, request }
     }
 
     // =========================================================================
@@ -728,20 +718,19 @@ mod tests {
     #[test]
     fn a_modification_reports_affected_pads_flat() {
         let result = ModificationResult {
-            action: "Pinned".to_string(),
+            action: ModificationActionResult::Pin,
             pads: vec![dp(
                 pad("root"),
                 DisplayIndex::Pinned(1),
                 vec![dp(pad("child"), DisplayIndex::Regular(1), vec![])],
             )],
-            messages: vec![],
             notices: vec![],
             outcomes: vec![],
             request: ModificationRequest { status: true },
         };
         let view = build_modification_view(&result);
 
-        assert_eq!(view.action, "Pinned");
+        assert_eq!(view.action, ModificationActionResult::Pin);
         assert_eq!(view.rows.len(), 1, "children are not redrawn");
         assert_eq!(view.rows[0].depth, 0);
         assert!(view.show_status);

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -10,7 +10,7 @@
 //!
 //! These are CLI-only adapter types: they exist purely to establish the shell's
 //! result contract, so they live in the binary rather than in `padzapp`. The data
-//! they carry (`DisplayPad`, `CmdMessage`, semantic tag/transfer outcomes) is
+//! they carry (`DisplayPad` and semantic mutation/tag/transfer outcomes) is
 //! reusable domain data and stays in `padzapp`.
 //!
 //! ## Presentation is not in here
@@ -26,7 +26,6 @@
 //! icons), not how to draw it. It is a mode-independent fact about the invocation, so
 //! it is part of the result and visible in structured output.
 
-use padzapp::api::CmdMessage;
 use padzapp::commands::{CmdNotice, CmdOutcome, NestingMode, UpdateKind};
 use padzapp::index::{DisplayIndex, DisplayPad};
 use padzapp::model::TodoStatus;
@@ -69,7 +68,6 @@ pub struct ModificationRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PadListResult {
     pub pads: Vec<DisplayPad>,
-    pub messages: Vec<CmdMessage>,
     pub request: ListRequest,
 }
 
@@ -79,9 +77,8 @@ pub struct PadListResult {
 /// `pads` are the pads it affected.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModificationResult {
-    pub action: String,
+    pub action: ModificationActionResult,
     pub pads: Vec<DisplayPad>,
-    pub messages: Vec<CmdMessage>,
     /// Machine-readable facts emitted by the core; templates own their prose.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub notices: Vec<ModificationNoticeResult>,
@@ -89,6 +86,26 @@ pub struct ModificationResult {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub outcomes: Vec<MutationOutcomeResult>,
     pub request: ModificationRequest,
+}
+
+/// The operation performed by a generic pad modification command.
+///
+/// This is a machine-readable token, not the human past-tense verb. The
+/// modification template owns wording such as "Pinned" and "Moved".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModificationActionResult {
+    Create,
+    Pin,
+    Unpin,
+    Delete,
+    Restore,
+    Archive,
+    Unarchive,
+    Complete,
+    Reopen,
+    Move,
+    Update,
 }
 
 /// CLI projection of a semantic mutation no-op.
@@ -839,21 +856,6 @@ impl From<padzapp::commands::transfer::TransferDiagnostic> for TransferDiagnosti
                 detail,
             },
         }
-    }
-}
-
-/// A command whose whole result is user-facing messages.
-///
-/// Rendered by `messages.jinja`, which reads `CmdMessage` directly — no view
-/// derivation, so no view builder is registered for this shape.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MessagesResult {
-    pub messages: Vec<CmdMessage>,
-}
-
-impl MessagesResult {
-    pub fn new(messages: Vec<CmdMessage>) -> Self {
-        Self { messages }
     }
 }
 

--- a/crates/padz/src/cli/templates/list.jinja
+++ b/crates/padz/src/cli/templates/list.jinja
@@ -36,8 +36,3 @@
 {%- if view.deleted_help -%}
 {%- include "_deleted_help.jinja" -%}
 {%- endif -%}
-{#- Trailing messages (info, warnings, errors from the API). A message's semantic -#}
-{#- style is its level, which CmdMessage serializes lowercase to match the theme. -#}
-{%- for msg in view.messages -%}
-{{ msg.content | style_as(msg.level) }}{{ "" | nl }}
-{%- endfor -%}

--- a/crates/padz/src/cli/templates/messages.jinja
+++ b/crates/padz/src/cli/templates/messages.jinja
@@ -1,6 +1,0 @@
-{#- Commands whose whole result is user-facing messages (MessagesResult). -#}
-{#- A message's semantic style is its level, which CmdMessage serializes lowercase -#}
-{#- ("info", "success", "warning", "error") to match the theme's class names. -#}
-{% for msg in messages -%}
-{{ msg.content | style_as(msg.level) }}
-{% endfor %}

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -8,19 +8,27 @@
 {%- set show_status = view.show_status -%}
 {%- set peek_mode = false -%}
 {%- set count = view.rows | length -%}
+{%- set verb = {
+    "create": "Created",
+    "pin": "Pinned",
+    "unpin": "Unpinned",
+    "delete": "Deleted",
+    "restore": "Restored",
+    "archive": "Archived",
+    "unarchive": "Unarchived",
+    "complete": "Completed",
+    "reopen": "Reopened",
+    "move": "Moved",
+    "update": "Updated"
+}[view.action] -%}
 
-{#- "Created 1 pad...", "Deleted 3 pads..." — the handler supplies only the verb. -#}
+{#- Human verbs and pluralization are presentation policy owned here. -#}
 {%- if count > 0 -%}
-[info]{{ view.action }} {{ count }} {{ "pad" if count == 1 else "pads" }}...[/info]{{ "" | nl }}
+[info]{{ verb }} {{ count }} {{ "pad" if count == 1 else "pads" }}...[/info]{{ "" | nl }}
 {%- endif -%}
 
 {%- for pad in view.rows -%}
 {%- include "_pad_line.jinja" -%}
-{%- endfor -%}
-
-{#- Trailing messages (info, warnings, errors). -#}
-{%- for msg in view.messages -%}
-{{ msg.content | style_as(msg.level) }}{{ "" | nl }}
 {%- endfor -%}
 
 {#- Semantic successful outcomes: wording stays here; refresh updates deliberately -#}

--- a/crates/padz/tests/fixtures/presentation_seams/modification-pin.json
+++ b/crates/padz/tests/fixtures/presentation_seams/modification-pin.json
@@ -1,0 +1,4 @@
+{
+  "action": "pin",
+  "top_level_keys": ["action", "pads", "request"]
+}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -29,11 +29,11 @@ use padz::cli::result::{
     CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateResult, DoctorResult,
     ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
     ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
-    MetadataWarningReasonResult, ModificationNoticeResult, ModificationResult,
-    MutationOutcomeResult, MutationStatusResult, PadContentResult, PadListResult, PathResult,
-    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferDirectionResult,
-    TransferOperationResult, TransferResult, TransferSelectionResult, TransferStatusResult,
-    UpdateKindResult, UuidResult,
+    MetadataWarningReasonResult, ModificationActionResult, ModificationNoticeResult,
+    ModificationResult, MutationOutcomeResult, MutationStatusResult, PadContentResult,
+    PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
+    TransferDirectionResult, TransferOperationResult, TransferResult, TransferSelectionResult,
+    TransferStatusResult, UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -384,28 +384,28 @@ fn copy_keeps_nested_content_in_the_payload_but_counts_only_the_root() {
 }
 
 // =============================================================================
-// Modification family — the action verb each maps to
+// Modification family — the semantic action each maps to
 // =============================================================================
 
 /// Every modification handler's contract is the same shape: act on the selected
-/// pads and report a past-tense action. Checking the family in one table is what
-/// keeps a new verb from being added without a test.
+/// pads and report a semantic action. Checking the family in one table is what
+/// keeps a new action from being added without a test.
 #[test]
-fn modification_handlers_report_their_action_verb() {
+fn modification_handlers_report_their_semantic_action() {
     type Call =
         fn(&standout_dispatch::CommandContext) -> Result<Output<ModificationResult>, anyhow::Error>;
 
-    let cases: Vec<(&str, &str, Call)> = vec![
-        ("pin", "Pinned", |ctx| {
+    let cases: Vec<(&str, ModificationActionResult, Call)> = vec![
+        ("pin", ModificationActionResult::Pin, |ctx| {
             handlers::pin(ctx, vec!["1".to_string()])
         }),
-        ("delete", "Deleted", |ctx| {
+        ("delete", ModificationActionResult::Delete, |ctx| {
             handlers::delete(ctx, vec!["1".to_string()], false)
         }),
-        ("archive", "Archived", |ctx| {
+        ("archive", ModificationActionResult::Archive, |ctx| {
             handlers::archive(ctx, vec!["1".to_string()])
         }),
-        ("complete", "Completed", |ctx| {
+        ("complete", ModificationActionResult::Complete, |ctx| {
             handlers::complete(ctx, vec!["1".to_string()])
         }),
     ];
@@ -473,7 +473,6 @@ fn repeated_pin_maps_the_core_notice_without_parsing_prose() {
             path: vec![padzapp::index::DisplayIndex::Pinned(1)]
         }]
     );
-    assert!(result.messages.is_empty());
 }
 
 #[test]
@@ -486,7 +485,7 @@ fn unpin_reverses_pin_and_reports_its_own_verb() {
     rendered(handlers::pin(&ctx, vec!["1".to_string()]));
     let result = rendered(handlers::unpin(&ctx, vec!["p1".to_string()]));
 
-    assert_eq!(result.action, "Unpinned");
+    assert_eq!(result.action, ModificationActionResult::Unpin);
     assert!(!result.pads[0].pad.metadata.is_pinned);
 }
 
@@ -500,7 +499,7 @@ fn restore_maps_a_deleted_selector_back_to_active() {
     rendered(handlers::delete(&ctx, vec!["1".to_string()], false));
     let result = rendered(handlers::restore(&ctx, vec!["d1".to_string()]));
 
-    assert_eq!(result.action, "Restored");
+    assert_eq!(result.action, ModificationActionResult::Restore);
     assert_eq!(result.pads[0].pad.metadata.title, "gone");
 }
 
@@ -536,7 +535,7 @@ fn move_to_root_needs_only_the_sources() {
     ));
     let result = rendered(handlers::move_pads(&ctx, vec!["1.1".to_string()], true));
 
-    assert_eq!(result.action, "Moved");
+    assert_eq!(result.action, ModificationActionResult::Move);
     assert!(
         result.pads[0].pad.metadata.parent_id.is_none(),
         "--root detaches the pad from its parent"
@@ -611,7 +610,6 @@ fn empty_delete_completed_maps_the_core_no_op() {
     let result = rendered(handlers::delete(&ctx, vec![], true));
 
     assert!(result.pads.is_empty());
-    assert!(result.messages.is_empty());
     assert_eq!(
         result.notices,
         vec![ModificationNoticeResult::NoCompletedPads]
@@ -1085,7 +1083,7 @@ fn create_with_direct_content_splits_title_from_body() {
 
     let result = created(handlers::create(&ctx, None, None, vec![]));
 
-    assert_eq!(result.action, "Created");
+    assert_eq!(result.action, ModificationActionResult::Create);
     assert_eq!(result.pads[0].pad.metadata.title, "the title");
     assert!(result.pads[0].pad.content.contains("the body"));
 }

--- a/crates/padz/tests/harness.rs
+++ b/crates/padz/tests/harness.rs
@@ -744,7 +744,7 @@ fn nested_edit_preserves_text_and_exposes_update_facts() {
     let fixture: serde_json::Value =
         serde_json::from_str(include_str!("fixtures/semantic_outcomes/edit-content.json")).unwrap();
     assert_eq!(value["outcomes"], fixture);
-    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+    assert!(value.get("messages").is_none());
 }
 
 #[test]
@@ -776,7 +776,7 @@ fn same_parent_move_preserves_text_and_exposes_the_nested_no_op() {
     let fixture: serde_json::Value =
         serde_json::from_str(include_str!("fixtures/semantic_outcomes/move-no-op.json")).unwrap();
     assert_eq!(value["notices"], fixture);
-    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+    assert!(value.get("messages").is_none());
 }
 
 #[test]
@@ -898,7 +898,7 @@ fn empty_delete_completed_preserves_text_and_exposes_a_typed_no_op() {
     ))
     .unwrap();
     assert_eq!(value["notices"], fixture);
-    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+    assert!(value.get("messages").is_none());
 }
 
 // =============================================================================
@@ -1903,7 +1903,7 @@ fn semantic_pin_notice_is_machine_readable() {
     assert_eq!(value["notices"][0]["kind"], "already_pinned");
     assert_eq!(value["notices"][0]["path"][0]["type"], "Pinned");
     assert_eq!(value["notices"][0]["path"][0]["value"], 1);
-    assert!(value["messages"].as_array().is_some_and(Vec::is_empty));
+    assert!(value.get("messages").is_none());
 }
 
 #[test]

--- a/crates/padz/tests/presentation_seams.rs
+++ b/crates/padz/tests/presentation_seams.rs
@@ -1,0 +1,73 @@
+//! Closing proof for the reusable-result/presentation seam.
+//!
+//! The core and typed-handler interfaces expose semantic facts. Standout's
+//! template path owns the human sentence. This file keeps that cross-seam proof
+//! isolated from the broad format matrix migrated by STD03-WS09.
+
+mod support;
+
+use padz::cli::handlers;
+use padz::cli::result::{ModificationActionResult, ModificationResult};
+use standout::cli::Output;
+use standout_test::{serial, TestHarness};
+use support::Fixture;
+
+fn rendered(out: Result<Output<ModificationResult>, anyhow::Error>) -> ModificationResult {
+    match out.expect("handler returned an error") {
+        Output::Render(value) => value,
+        other => panic!("expected rendered modification result, got {other:?}"),
+    }
+}
+
+#[test]
+fn typed_pin_handler_exposes_a_semantic_action_without_generic_messages() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    let ctx = support::ctx_with_state(state);
+
+    let result = rendered(handlers::pin(&ctx, vec!["1".to_string()]));
+
+    assert_eq!(result.action, ModificationActionResult::Pin);
+    assert_eq!(result.pads.len(), 1);
+    assert!(result.notices.is_empty());
+    assert!(result.outcomes.is_empty());
+
+    let value = serde_json::to_value(result).unwrap();
+    let mut top_level_keys: Vec<_> = value
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    top_level_keys.sort_unstable();
+    let actual = serde_json::json!({
+        "action": value["action"],
+        "top_level_keys": top_level_keys,
+    });
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "fixtures/presentation_seams/modification-pin.json"
+    ))
+    .unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+#[serial]
+fn pin_template_owns_the_compatible_human_sentence() {
+    let fx = Fixture::new();
+    let state = fx.app_state();
+    fx.seed_pad(&state, "target", "");
+    drop(state);
+    let (app, command) = fx.read_app();
+
+    let result = TestHarness::new().no_color().run(
+        &app,
+        command,
+        fx.argv(&["pin", "1", "--output", "text"]),
+    );
+
+    result.assert_success();
+    result.assert_stdout_contains("Pinned 1 pad...");
+    result.assert_stdout_contains("p1. target");
+}

--- a/crates/padz/tests/structured_output_e2e.rs
+++ b/crates/padz/tests/structured_output_e2e.rs
@@ -307,7 +307,7 @@ fn structured_output_excludes_template_only_view_fields() {
     top.sort_unstable();
 
     // The result contract: data + invocation facts, nothing view-derived.
-    assert_eq!(top, vec!["messages", "pads", "request"]);
+    assert_eq!(top, vec!["pads", "request"]);
 
     for forbidden in ["rows", "time_ago", "status_icon", "left_pin", "columns"] {
         assert!(

--- a/crates/padz/tests/theme.rs
+++ b/crates/padz/tests/theme.rs
@@ -49,7 +49,7 @@ const REQUIRED: &[&str] = &[
     "line-number",
     // tags
     "tag",
-    // messages — these match CmdMessage's lowercase level names
+    // semantic message styles used by CLI-owned templates
     "error",
     "warning",
     "success",

--- a/crates/padzapp/src/api/mod.rs
+++ b/crates/padzapp/src/api/mod.rs
@@ -87,7 +87,7 @@ pub use commands::init::InitializationOutcome;
 pub use commands::purge::{PurgeOutcome, PurgeSelection};
 pub use commands::tagging::{TaggingOutcome, TaggingResult};
 pub use commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
-pub use commands::{CmdMessage, CmdResult, MessageLevel, PadUpdate, PadzPaths};
+pub use commands::{CmdResult, PadUpdate, PadzPaths};
 
 #[cfg(test)]
 mod tests {

--- a/crates/padzapp/src/api/status.rs
+++ b/crates/padzapp/src/api/status.rs
@@ -114,7 +114,6 @@ mod tests {
 
         let result = api.move_pads(Scope::Project, &["1"], Some("2")).unwrap();
 
-        assert!(result.messages.is_empty());
         assert_eq!(result.affected_pads.len(), 1);
         assert_eq!(result.affected_pads[0].pad.metadata.title, "B");
 
@@ -136,7 +135,6 @@ mod tests {
             .unwrap();
 
         let result = api.move_pads(Scope::Project, &["1.1"], None).unwrap();
-        assert!(result.messages.is_empty());
         assert_eq!(result.affected_pads.len(), 1);
 
         let pads = api

--- a/crates/padzapp/src/commands/create.rs
+++ b/crates/padzapp/src/commands/create.rs
@@ -194,9 +194,6 @@ mod tests {
             result.affected_pads[0].index,
             DisplayIndex::Regular(1)
         ));
-
-        // No messages - CLI handles unified rendering
-        assert!(result.messages.is_empty());
     }
 
     #[test]

--- a/crates/padzapp/src/commands/delete.rs
+++ b/crates/padzapp/src/commands/delete.rs
@@ -370,7 +370,6 @@ mod tests {
 
         let result = run_completed(&mut store, Scope::Project).unwrap();
         assert!(result.affected_pads.is_empty());
-        assert!(result.messages.is_empty());
         assert_eq!(result.notices, vec![CmdNotice::NoCompletedPads]);
 
         // Pad should still be active

--- a/crates/padzapp/src/commands/mod.rs
+++ b/crates/padzapp/src/commands/mod.rs
@@ -24,7 +24,6 @@
 //! Most commands return [`CmdResult`], not strings. This struct carries:
 //! - `affected_pads`: Pads that were modified (as `DisplayPad` with post-operation index)
 //! - `listed_pads`: Pads to display (as `DisplayPad` with current index)
-//! - `messages`: Structured messages with levels (info, success, warning, error)
 //! - `pad_paths`: File paths (for `path` command)
 //!
 //! Both `affected_pads` and `listed_pads` use [`DisplayPad`], which pairs a [`Pad`]
@@ -89,8 +88,8 @@ pub enum NestingMode {
 
 /// A semantic, presentation-free fact a command wants the caller to surface.
 ///
-/// Unlike [`CmdMessage`], notices carry no authored prose. CLI clients can render
-/// them for people while structured clients can branch on `kind` and fields.
+/// CLI clients can render notices for people while structured clients branch on
+/// `kind` and fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CmdNotice {
@@ -200,51 +199,6 @@ impl PadzPaths {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum MessageLevel {
-    Info,
-    Success,
-    Warning,
-    Error,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CmdMessage {
-    pub level: MessageLevel,
-    pub content: String,
-}
-
-impl CmdMessage {
-    pub fn info(content: impl Into<String>) -> Self {
-        Self {
-            level: MessageLevel::Info,
-            content: content.into(),
-        }
-    }
-
-    pub fn success(content: impl Into<String>) -> Self {
-        Self {
-            level: MessageLevel::Success,
-            content: content.into(),
-        }
-    }
-
-    pub fn warning(content: impl Into<String>) -> Self {
-        Self {
-            level: MessageLevel::Warning,
-            content: content.into(),
-        }
-    }
-
-    pub fn error(content: impl Into<String>) -> Self {
-        Self {
-            level: MessageLevel::Error,
-            content: content.into(),
-        }
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct CmdResult {
     pub affected_pads: Vec<DisplayPad>,
@@ -253,7 +207,6 @@ pub struct CmdResult {
     /// Empty means all pads are at depth 0.
     pub listed_depths: Vec<usize>,
     pub pad_paths: Vec<PathBuf>,
-    pub messages: Vec<CmdMessage>,
     /// Semantic notices that clients render or inspect without parsing English.
     pub notices: Vec<CmdNotice>,
     /// Semantic successful outcomes that clients inspect without parsing English.
@@ -263,10 +216,6 @@ pub struct CmdResult {
 }
 
 impl CmdResult {
-    pub fn add_message(&mut self, message: CmdMessage) {
-        self.messages.push(message);
-    }
-
     pub fn with_affected_pads(mut self, pads: Vec<DisplayPad>) -> Self {
         self.affected_pads = pads;
         self
@@ -280,46 +229,6 @@ impl CmdResult {
     pub fn with_pad_paths(mut self, paths: Vec<PathBuf>) -> Self {
         self.pad_paths = paths;
         self
-    }
-}
-
-/// Result from commands that modify pads.
-///
-/// Provides structured output for unified CLI rendering:
-/// - `affected_pads`: The pads that were modified (rendered as a list)
-/// - `trailing_messages`: Info/warning messages shown after the pad list
-///
-/// The CLI layer generates the start message (e.g., "Completing 2 pads...")
-/// based on the action and affected_pads count.
-#[derive(Debug, Default)]
-pub struct ModificationResult {
-    /// Pads that were modified by the operation
-    pub affected_pads: Vec<DisplayPad>,
-    /// Messages shown after the pad list (info, warnings, errors)
-    pub trailing_messages: Vec<CmdMessage>,
-}
-
-impl ModificationResult {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_pads(mut self, pads: Vec<DisplayPad>) -> Self {
-        self.affected_pads = pads;
-        self
-    }
-
-    pub fn add_info(&mut self, content: impl Into<String>) {
-        self.trailing_messages.push(CmdMessage::info(content));
-    }
-
-    /// Convert to CmdResult for backward compatibility
-    pub fn into_cmd_result(self) -> CmdResult {
-        CmdResult {
-            affected_pads: self.affected_pads,
-            messages: self.trailing_messages,
-            ..Default::default()
-        }
     }
 }
 

--- a/crates/padzapp/src/commands/move_pads.rs
+++ b/crates/padzapp/src/commands/move_pads.rs
@@ -304,7 +304,6 @@ mod tests {
         .unwrap();
 
         assert!(result.affected_pads.is_empty());
-        assert!(result.messages.is_empty());
         assert_eq!(
             result.notices,
             vec![CmdNotice::AlreadyAtDestination { path }]

--- a/crates/padzapp/src/commands/pinning.rs
+++ b/crates/padzapp/src/commands/pinning.rs
@@ -213,7 +213,6 @@ mod tests {
                 path: vec![DisplayIndex::Pinned(1)]
             }]
         );
-        assert!(result.messages.is_empty());
     }
 
     #[test]
@@ -240,7 +239,6 @@ mod tests {
                 path: vec![DisplayIndex::Regular(1)]
             }]
         );
-        assert!(result.messages.is_empty());
     }
 
     #[test]

--- a/crates/padzapp/src/commands/restore.rs
+++ b/crates/padzapp/src/commands/restore.rs
@@ -129,9 +129,6 @@ mod tests {
         )
         .unwrap();
 
-        // No messages - CLI handles unified rendering
-        assert!(result.messages.is_empty());
-
         // Verify affected_pads contains the restored pad
         assert_eq!(result.affected_pads.len(), 1);
         assert_eq!(result.affected_pads[0].pad.metadata.title, "Title");
@@ -197,8 +194,6 @@ mod tests {
         )
         .unwrap();
 
-        // No messages - CLI handles unified rendering
-        assert!(result.messages.is_empty());
         // Should have 2 affected pads
         assert_eq!(result.affected_pads.len(), 2);
 
@@ -352,8 +347,6 @@ mod tests {
         )
         .unwrap();
 
-        // No messages - CLI handles unified rendering
-        assert!(result.messages.is_empty());
         // Should have 2 affected pads
         assert_eq!(result.affected_pads.len(), 2);
         let count = store
@@ -382,7 +375,6 @@ mod tests {
         .unwrap();
 
         // Pad was skipped (not in Deleted bucket), so no affected pads
-        assert!(result.messages.is_empty());
         assert_eq!(result.affected_pads.len(), 0);
 
         // Pad is still active

--- a/crates/padzapp/src/commands/status.rs
+++ b/crates/padzapp/src/commands/status.rs
@@ -111,8 +111,6 @@ mod tests {
         let sel = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
         let result = complete(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        // No messages for successful completion - CLI handles unified rendering
-        assert!(result.messages.is_empty());
         // Should have affected pad
         assert_eq!(result.affected_pads.len(), 1);
 
@@ -137,8 +135,6 @@ mod tests {
         // Then reopen it
         let result = reopen(&mut store, Scope::Project, slice::from_ref(&sel)).unwrap();
 
-        // No messages for successful reopen - CLI handles unified rendering
-        assert!(result.messages.is_empty());
         // Should have affected pad
         assert_eq!(result.affected_pads.len(), 1);
 
@@ -169,7 +165,6 @@ mod tests {
                 status: TodoStatus::Done,
             }]
         );
-        assert!(result.messages.is_empty());
     }
 
     #[test]
@@ -194,7 +189,6 @@ mod tests {
                 status: TodoStatus::Planned,
             }]
         );
-        assert!(result.messages.is_empty());
     }
 
     #[test]
@@ -263,8 +257,6 @@ mod tests {
 
         let result = complete(&mut store, Scope::Project, &selectors).unwrap();
 
-        // No messages for successful completion - CLI handles unified rendering
-        assert!(result.messages.is_empty());
         // Should have 2 affected pads
         assert_eq!(result.affected_pads.len(), 2);
 

--- a/crates/padzapp/src/commands/transfer.rs
+++ b/crates/padzapp/src/commands/transfer.rs
@@ -479,7 +479,9 @@ fn copy_one_pad<Src: DataStore, Dst: DataStore>(
     dest.save_pad(&pad, dest_scope, bucket)
         .map_err(|error| CopyFailure {
             category: CopyFailureCategory::DestinationWrite,
-            detail: format!("Writing pad {} to destination failed: {}", id, error),
+            // The report already carries the pad id and failure category. Keep
+            // only the causal store diagnostic here; clients own the sentence.
+            detail: error.to_string(),
         })?;
 
     Ok(CopyOutcome {
@@ -1103,7 +1105,7 @@ mod tests {
                 category: CopyFailureCategory::DestinationWrite,
                 detail,
                 ..
-            }] if detail.contains("Writing pad") && detail.contains("Simulated write error")
+            }] if detail.contains("Simulated write error") && !detail.contains("Writing pad")
         ));
     }
 

--- a/crates/padzapp/src/commands/update.rs
+++ b/crates/padzapp/src/commands/update.rs
@@ -183,7 +183,6 @@ mod tests {
             MemBackend::new(),
         );
         let result = run(&mut store, Scope::Project, &[]).unwrap();
-        assert!(result.messages.is_empty());
         assert!(result.affected_pads.is_empty());
     }
 
@@ -251,7 +250,6 @@ mod tests {
         let res = run(&mut store, Scope::Project, &updates).unwrap();
 
         // Check semantic results without parsing presentation prose.
-        assert!(res.messages.is_empty());
         assert_eq!(res.outcomes.len(), 2);
         assert!(res.outcomes.iter().any(|outcome| matches!(
             outcome,
@@ -392,7 +390,6 @@ mod tests {
         );
         let result = run(&mut store, Scope::Project, &[update]).unwrap();
 
-        assert!(result.messages.is_empty());
         assert_eq!(
             result.outcomes,
             vec![CmdOutcome::Updated {

--- a/crates/padzapp/tests/presentation_contract.rs
+++ b/crates/padzapp/tests/presentation_contract.rs
@@ -1,0 +1,63 @@
+//! Core-level proof that command results expose facts, not presentation prose.
+
+use padzapp::commands::{create, pinning, CmdNotice};
+use padzapp::index::{DisplayIndex, PadSelector};
+use padzapp::model::Scope;
+use padzapp::store::bucketed::BucketedStore;
+use padzapp::store::mem_backend::MemBackend;
+
+fn store() -> BucketedStore<MemBackend> {
+    BucketedStore::new(
+        MemBackend::new(),
+        MemBackend::new(),
+        MemBackend::new(),
+        MemBackend::new(),
+    )
+}
+
+#[test]
+fn repeated_pin_exposes_the_no_op_as_typed_facts() {
+    let mut store = store();
+    create::run(&mut store, Scope::Project, "target".into(), "".into(), None).unwrap();
+    let regular = PadSelector::Path(vec![DisplayIndex::Regular(1)]);
+    pinning::pin(&mut store, Scope::Project, &[regular]).unwrap();
+
+    let pinned = PadSelector::Path(vec![DisplayIndex::Pinned(1)]);
+    let result = pinning::pin(&mut store, Scope::Project, &[pinned]).unwrap();
+
+    assert_eq!(
+        result.notices,
+        vec![CmdNotice::AlreadyPinned {
+            path: vec![DisplayIndex::Pinned(1)],
+        }]
+    );
+}
+
+#[test]
+fn reusable_source_has_no_generic_message_interface() {
+    let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut stack = vec![source_root];
+    let mut offenders = Vec::new();
+
+    while let Some(path) = stack.pop() {
+        for entry in std::fs::read_dir(path).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                let source = std::fs::read_to_string(&path).unwrap();
+                for forbidden in ["CmdMessage", "MessageLevel", "trailing_messages"] {
+                    if source.contains(forbidden) {
+                        offenders.push(format!("{} contains {forbidden}", path.display()));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "generic presentation plumbing returned to padzapp: {offenders:#?}"
+    );
+}

--- a/docs/presentation-prose-audit.md
+++ b/docs/presentation-prose-audit.md
@@ -1,0 +1,60 @@
+# Reusable result presentation-prose audit
+
+This is the closing STD03-WS10 inventory after the command-family semantic
+outcome migrations. The reusable `padzapp` interface reports user data, typed
+outcomes, and typed diagnostics. The `padz` CLI owns wording, pluralization,
+ordering, glyphs, indentation, semantic style tags, and blank-line layout.
+
+## Result inventory
+
+The repository-wide search found no live `CmdMessage` producer. The remaining
+`CmdMessage`, `MessageLevel`, `messages`, and `trailing_messages` surfaces were
+empty pass-through plumbing, so they were removed from `CmdResult`, CLI result
+DTOs, render views, templates, and exports. The unused `MessagesResult`, core
+`ModificationResult`, and `messages.jinja` adapters were removed by the same
+deletion test: deleting them removed interface complexity without moving any
+behavior into callers.
+
+Generic pad modifications now carry `ModificationActionResult`, affected pads,
+typed notices, typed outcomes, and request facts. The action is a stable semantic
+token (`pin`, `delete`, `update`, and so on); `modification_result.jinja` owns the
+human past-tense verb and pluralization. Transfer write failures retain only the
+causal store diagnostic in `detail`; the already-typed pad id/category and the
+template supply the sentence around it.
+
+There are no layout-only empty strings in reusable results. Empty strings found
+under `padzapp/src` are content values, parser buffers, or test data. Template
+layout continues to use MiniJinja newline operations in `padz`.
+
+## Retained domain-diagnostic text
+
+The following authored text is intentionally retained. These are failed-operation
+diagnostics, not successful command-result presentation. Replacing the causal
+detail with a success/no-op enum would discard information needed to correct the
+request or diagnose storage and decoding failures.
+
+| Source | Diagnostic content | Why it remains in the reusable module |
+| --- | --- | --- |
+| `commands/helpers/selector_resolve.rs`, `commands/get/selector_filter.rs`, `error.rs`, `index.rs` | Invalid, missing, range, UUID, and ambiguous-title errors | Selector validity and candidate identity are domain rules. `AmbiguousTitle` already exposes typed term/count/candidates; `Display` is the diagnostic fallback for non-structured error transport. |
+| `commands/init.rs`, `init.rs`, `store/fs_backend.rs`, `commands/mod.rs` | Missing/unusable stores, invalid links, migration failures, and unavailable scopes | These explain why the storage interface cannot satisfy an operation and include causal paths or underlying I/O errors. They are not layout or success prose. |
+| `commands/purge.rs`, `commands/move_pads.rs`, `commands/create.rs`, `commands/update.rs` | Destructive-operation safety requirements and invalid mutation preconditions | Counts, selectors, and required flags are needed to make a refused mutation actionable. No command result exists on these error paths. |
+| `commands/tags.rs`, `commands/tagging.rs`, `tags/validation.rs` | Tag-name validation and missing/duplicate tag errors | The invalid value and violated domain invariant are the diagnostic payload. Successful/no-op tag results are typed separately. |
+| `commands/io/import.rs`, `commands/io/export.rs`, `commands/metadata_apply.rs` | Decode, archive-entry, serialization, metadata, and registry-merge causes | Status/reason/category fields are typed; retained strings are lower-level parser, I/O, or store causes that cannot be enumerated without losing useful detail. |
+| `commands/transfer.rs`, `api/transfer.rs` | Store/path preconditions and causal partial-failure details | Transfer status, operation, direction, pad id, bucket, and failure category are typed. `detail` contains only the underlying store/link cause; the CLI template owns surrounding prose. |
+
+User-authored titles/content, filesystem paths, selector strings, format names,
+and suggested artifact filenames are data, not authored presentation sentences.
+
+## Mechanical verification
+
+The closing search is:
+
+```text
+rg -n 'CmdMessage|MessageLevel|trailing_messages|messages\.jinja' \
+  crates/padzapp/src crates/padz/src
+```
+
+It returns no matches. `crates/padzapp/tests/presentation_contract.rs` keeps that
+generic-interface absence and a typed core no-op under test. The direct-handler
+fixture pins the structured action token and top-level keys; the serial
+`TestHarness` proof pins the compatible human sentence at the rendering seam.


### PR DESCRIPTION
## Context

for #222

### Why

STD02 completed the command-family semantic migrations, but the closing repository-wide audit found the obsolete generic message interface still crossing the reusable core, CLI result DTOs, render views, templates, and structured schemas despite having zero live producers. Generic modification results also carried human past-tense verbs.

### Approach

- Removed CmdMessage, MessageLevel, the always-empty message vectors, the unused core and CLI generic message helpers, and messages.jinja.
- Added typed ModificationActionResult tokens and moved past-tense wording/pluralization entirely into modification_result.jinja.
- Reduced transfer destination-write detail to its causal store diagnostic because typed fields already carry the pad id and failure category.
- Added a repository-wide audit document plus core, direct-handler fixture, and serial TestHarness proofs.
- Fixture-tested and changelogged the intentional structured-schema cleanup: no empty messages keys and semantic action tokens such as pin instead of Pinned.

### Exceptions

Retained core-authored text is limited to failed-operation domain diagnostics: selector/precondition violations, store/link/migration failures, tag validation, destructive-operation safety, and lower-level import/export/transfer causes. The audit documents each source class and why typed result facts cannot replace that causal detail without information loss. User content, paths, selectors, format names, and artifact filenames are data rather than presentation prose.

### Out of scope

No command, argument, storage, selector, ordering, input, artifact, or human-output behavior changes. No subprocess-suite migration or format-matrix relocation belongs to this workstream.

## Verification

- pixi run test: 901 passed, 1 skipped
- pixi run lint: all 12 checks passed
- repository search: zero CmdMessage, MessageLevel, trailing_messages, or messages.jinja sites under reusable/CLI source

## Integration overlap

WS08/WS09 may also edit crates/padz/tests/handlers_direct.rs, crates/padz/tests/harness.rs, and crates/padz/tests/structured_output_e2e.rs while moving tests. WS10 changes there are narrow old-schema assertions/action-token expectations. The new focused proofs are isolated in crates/padz/tests/presentation_seams.rs and crates/padzapp/tests/presentation_contract.rs; rebase/order WS10 after WS08/WS09 if those files conflict.