### PR TITLE
STD04-WS01: Epic: Collapse CLI Presentation Tiers - Workstream: Listing + rendering pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "standout",
  "standout-dispatch",
  "standout-macros",
+ "standout-render",
  "standout-test",
  "tempfile",
  "terminal_size",
@@ -1947,8 +1948,8 @@ dependencies = [
 
 [[package]]
 name = "standout"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,16 +1973,16 @@ dependencies = [
 
 [[package]]
 name = "standout-bbparser"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "console 0.16.4",
 ]
 
 [[package]]
 name = "standout-dispatch"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "anyhow",
  "clap",
@@ -1992,8 +1993,8 @@ dependencies = [
 
 [[package]]
 name = "standout-input"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "clap",
  "once_cell",
@@ -2005,8 +2006,8 @@ dependencies = [
 
 [[package]]
 name = "standout-macros"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2015,8 +2016,8 @@ dependencies = [
 
 [[package]]
 name = "standout-pipe"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "thiserror 2.0.17",
  "wait-timeout",
@@ -2024,8 +2025,8 @@ dependencies = [
 
 [[package]]
 name = "standout-render"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "console 0.16.4",
  "cssparser",
@@ -2047,8 +2048,8 @@ dependencies = [
 
 [[package]]
 name = "standout-seeker"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "regex",
  "thiserror 2.0.17",
@@ -2056,8 +2057,8 @@ dependencies = [
 
 [[package]]
 name = "standout-test"
-version = "7.9.0"
-source = "git+https://github.com/arthur-debert/standout?tag=v7.9.0#8cb11f920ac921837a115286e41eb3050ac4c244"
+version = "7.9.1"
+source = "git+https://github.com/arthur-debert/standout?tag=v7.9.1#75ed3112e69645904dc35412322c670d7f498c4b"
 dependencies = [
  "clap",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/arthur-debert/padz"
 
-# Resolve the standout family from the v7.9.0 git tag instead of crates.io.
+# Resolve the standout family from the v7.9.1 git tag instead of crates.io.
 #
 # WHY THIS PATCH EXISTS — it keeps the git-only test harness and the published
 # runtime crates in one dependency graph.
@@ -17,7 +17,7 @@ repository = "https://github.com/arthur-debert/padz"
 # newest *published* standout-test is 7.5.1, which does not compile against
 # standout 7.x: 7.6 made `RunResult` `#[non_exhaustive]` and added the `Error`
 # variant, and 7.5.1 matches it exhaustively. The fixed standout-test exists —
-# version 7.9.0 in the upstream repo — but carries `publish = false`, so it can
+# version 7.9.1 in the upstream repo — but carries `publish = false`, so it can
 # only be reached as a git dependency. And a git standout-test resolves its own
 # `standout` through a workspace *path* dep, which Cargo treats as a crate
 # distinct from crates.io's standout: the two `App` types then don't unify and
@@ -30,18 +30,18 @@ repository = "https://github.com/arthur-debert/padz"
 #
 # `[patch]` is workspace-local: it is not published and never reaches consumers
 # of the `padz` crate. Its three direct Standout dependencies are published at
-# 7.9.0 and downstream consumers resolve those ordinary requirements from
+# 7.9.1 and downstream consumers resolve those ordinary requirements from
 # crates.io; only the dev-only `standout-test` remains git-only.
 #
 # REMOVE THIS once a compatible standout-test is published to crates.io; it then goes
 # back to a plain dev-dependency version requirement in crates/padz/Cargo.toml.
 # Tracked upstream at arthur-debert/standout.
 [patch.crates-io]
-standout = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-bbparser = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-dispatch = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-input = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-macros = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-pipe = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-render = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
-standout-seeker = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-bbparser = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-dispatch = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-input = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-macros = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-pipe = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-render = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
+standout-seeker = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }

--- a/crates/padz/Cargo.toml
+++ b/crates/padz/Cargo.toml
@@ -30,9 +30,15 @@ console = "0.15"
 directories = "6.0.0"
 dark-light = "0.2"
 once_cell = "1.19"
-standout = "7.9.0"
-standout-macros = "7.9.0"
-standout-dispatch = "7.9.0"
+standout = "7.9.1"
+standout-macros = "7.9.1"
+standout-dispatch = "7.9.1"
+# Standout's render layer, needed directly for `set_terminal_width_detector`:
+# padz installs its own terminal-width policy (read `$COLUMNS`, clamp, pay back
+# the ⏲ column) so 7.9.1's `tabular()` width cascade resolves to the width the
+# listing templates expect. `standout` re-exports most of this crate but not the
+# environment detectors, so it is named here (same reason `minijinja` is).
+standout-render = "7.9.1"
 # Standout's template engine. Needed directly to type the context providers in
 # cli::render, whose values standout hands to MiniJinja.
 minijinja = "2"
@@ -57,20 +63,20 @@ unicode-width = "0.2.2"
 # builder that restores them on drop. Re-exports `serial_test`, which every
 # harness test needs: those seams are process-global.
 #
-# Pinned to the v7.9.0 git tag rather than a crates.io version ON PURPOSE. The
+# Pinned to the v7.9.1 git tag rather than a crates.io version ON PURPOSE. The
 # newest *published* standout-test is 7.5.1, and it does not compile against the
-# standout 7.9.0 this crate uses: 7.6 made `RunResult` `#[non_exhaustive]` and
+# standout 7.9.1 this crate uses: 7.6 made `RunResult` `#[non_exhaustive]` and
 # added the `Error` variant, while 7.5.1 matches `RunResult` exhaustively. Its
 # `standout = "^7.5.1"` requirement claims that unification is fine, so Cargo
 # resolves it happily and then fails to build — the incompatibility is real but
-# invisible to semver. The v7.9.0 tag (matching our standout exactly) handles
+# invisible to semver. The v7.9.1 tag (matching our standout exactly) handles
 # `Error` and matches non-exhaustively; it is unpublished only because the crate
 # carries `publish = false` upstream. Tracked at arthur-debert/standout; swap this
 # back to a plain version requirement once a compatible release is on crates.io.
 #
 # Safe for `cargo publish`: a dev-dependency with no `version` key is stripped
 # from the packaged manifest, so this git source never reaches consumers.
-standout-test = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.0" }
+standout-test = { git = "https://github.com/arthur-debert/standout", tag = "v7.9.1" }
 # Direct, even though standout-test re-exports `serial`: the macro it re-exports
 # expands to `::serial_test` paths, so the crate has to be nameable here for
 # `#[serial]` to resolve. Same major as standout-test's own requirement, so the

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -18,19 +18,19 @@
 
 use super::handlers::AppState;
 use super::render::{
-    list_view_provider, modification_view_provider, tagging_view_provider, terminal_provider,
-    LIST_VIEW, MODIFICATION_VIEW, TAGGING_VIEW, TERMINAL,
+    modification_view_provider, peek_filter, tagging_view_provider, terminal_provider,
+    timeago_filter, MODIFICATION_VIEW, TAGGING_VIEW, TERMINAL,
 };
 use super::setup::{
-    build_command, invocation_default_command, parse_cli, Cli, Commands, CompletionAction,
-    CompletionShell, ConfigSubcommand,
+    build_command, get_grouped_help, invocation_default_command, parse_cli, Cli, Commands,
+    CompletionAction, CompletionShell, ConfigSubcommand,
 };
 use clapfig::{Clapfig, ConfigAction, SearchMode, SearchPath};
 use padzapp::config::PadzConfig;
 use padzapp::error::Result;
 use padzapp::init::initialize;
 use standout::cli::{App, RunResult};
-use standout::{embed_styles, embed_templates};
+use standout::{embed_styles, embed_templates, MiniJinjaEngine};
 
 pub fn run() -> Result<()> {
     // parse_cli() uses standout's App which handles
@@ -64,10 +64,14 @@ pub fn run() -> Result<()> {
 
 /// Build the dispatch-ready App with templates, styles, command configuration, and app state
 ///
-/// The two `context_fn` registrations are the render-time seam: handlers return typed,
-/// mode-independent results, and these providers derive the template-ready view from
-/// the serialized result. Standout resolves context providers only when it renders a
-/// template, so structured output never sees the derived presentation fields.
+/// Two render-time seams keep presentation out of structured output. The `context_fn`
+/// registrations derive the modification/tagging template views from the serialized
+/// result — Standout resolves them only on the template path. The custom MiniJinja
+/// engine adds the listing family's filters (`timeago`, `peek`) and the empty-store
+/// `grouped_help()` helper, which are likewise render-only: structured modes bypass the
+/// engine entirely, so a JSON consumer never sees a relative timestamp, a preview, or a
+/// help blob. The `list`/`search`/`peek` templates render straight from the core
+/// `DisplayPad` tree, so no list-view provider is needed.
 ///
 /// Public because it is the whole app-under-test: `TestHarness` tests pair it with
 /// [`build_command`] to drive argv through render in process, against the same
@@ -85,13 +89,13 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
 
     App::builder()
         .app_state(app_state)
+        .template_engine(Box::new(listing_engine()))
         .default_command_with(invocation_default_command)
         .templates(embed_templates!("src/cli/templates"))
         .template_ext(".jinja")
         .styles(embed_styles!("src/styles"))
         .default_theme("default")
         .context_fn(TERMINAL, terminal_provider)
-        .context_fn(LIST_VIEW, list_view_provider)
         .context_fn(MODIFICATION_VIEW, modification_view_provider)
         .context_fn(TAGGING_VIEW, tagging_view_provider)
         .commands(Commands::dispatch_config())
@@ -116,6 +120,29 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
         .expect("Failed to configure open input")
         .build()
         .expect("Failed to build app")
+}
+
+/// The MiniJinja engine the listing family renders through.
+///
+/// Standout's default engine already carries the framework filters (`col`, `tabular`,
+/// `nl`, …); this adds the three render-only seams the `list`/`search`/`peek` templates
+/// need and that MiniJinja cannot derive for itself:
+///
+/// - `timeago` — clock arithmetic against `Utc::now()` (`created_at | timeago`).
+/// - `peek` — the body preview, delegating to `padzapp::peek` (`content | peek`).
+/// - `grouped_help()` — the clap-rendered command help shown only on an empty store.
+///
+/// All three run exclusively on the template path, so structured output never sees a
+/// relative timestamp, a preview, or the help blob. Registering them here (rather than
+/// via a context provider) is what lets the templates read the core `DisplayPad` tree
+/// directly instead of a flattened row mirror.
+fn listing_engine() -> MiniJinjaEngine {
+    let mut engine = MiniJinjaEngine::new();
+    let env = engine.environment_mut();
+    env.add_filter("timeago", timeago_filter);
+    env.add_filter("peek", peek_filter);
+    env.add_function("grouped_help", get_grouped_help);
+    engine
 }
 
 /// Handle the result of a dispatch operation.

--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -33,6 +33,13 @@ use standout::cli::{App, RunResult};
 use standout::{embed_styles, embed_templates, MiniJinjaEngine};
 
 pub fn run() -> Result<()> {
+    // Install padz's terminal-width policy before any rendering. Since 7.9.1 the
+    // framework's `tabular()`/`table()` width cascade resolves against the detector
+    // installed here, so the listing templates get `render::line_width` (`$COLUMNS`,
+    // clamp, ⏲ payback) without naming a width. Set only on the real binary path;
+    // `TestHarness` injects its own width per test.
+    standout_render::set_terminal_width_detector(super::render::detect_width);
+
     // parse_cli() uses standout's App which handles
     // help display (including topics) and errors automatically.
     // It also extracts the output mode from the --output flag.

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -30,10 +30,10 @@ use std::rc::Rc;
 
 use super::result::{
     CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateAbortResult, CreateResult,
-    DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest,
+    DoctorResult, ExportReportResult, ImportResult, InitializationResult, ListRequest, Listing,
     ModificationActionResult, ModificationRequest, ModificationResult, PadContent,
-    PadContentResult, PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult,
-    TaggingResult, TransferResult, UuidResult,
+    PadContentResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
+    TransferResult, UuidResult,
 };
 
 // =============================================================================
@@ -418,13 +418,13 @@ impl<'a> ScopedApi<'a> {
         ids: &[String],
         show_uuid: bool,
         show_status: bool,
-    ) -> Result<Output<PadListResult>, anyhow::Error> {
+    ) -> Result<Output<Listing>, anyhow::Error> {
         let filtered = filter.search_term.is_some()
             || filter.todo_status.is_some()
             || filter.tags.is_some()
             || !ids.is_empty();
         let result = self.call(|api, scope| api.get_pads(scope, filter, ids))?;
-        Ok(Output::Render(PadListResult {
+        Ok(Output::Render(Listing {
             pads: result.listed_pads,
             request: ListRequest {
                 peek,
@@ -800,7 +800,7 @@ pub fn list(
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
     #[flag(name = "show_status")] show_status: bool,
-) -> Result<Output<PadListResult>, anyhow::Error> {
+) -> Result<Output<Listing>, anyhow::Error> {
     let todo_status = if planned {
         Some(TodoStatus::Planned)
     } else if completed {
@@ -843,7 +843,7 @@ pub fn peek(
     #[arg] ids: Vec<String>,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
-) -> Result<Output<PadListResult>, anyhow::Error> {
+) -> Result<Output<Listing>, anyhow::Error> {
     let filter = PadFilter {
         status: PadStatusFilter::Active,
         search_term: None,
@@ -864,7 +864,7 @@ pub fn search(
     #[flag] completed: bool,
     #[arg] tags: Vec<String>,
     #[flag] uuid: bool,
-) -> Result<Output<PadListResult>, anyhow::Error> {
+) -> Result<Output<Listing>, anyhow::Error> {
     let filter = PadFilter {
         status: if all {
             PadStatusFilter::All

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -92,10 +92,19 @@ pub const TERMINAL: &str = "terminal";
 /// We subtract 1 to compensate for `⏲` (U+23F2) which `unicode-width` measures as 1
 /// column but terminals render as 2. Standout's tabular system uses `unicode-width`
 /// internally, so without this adjustment every line would overflow by 1 character.
+/// `⏲` is Unicode *Narrow*, not East-Asian *ambiguous*, so no ambiguous-width policy
+/// pays this back — the `-1` is the only thing that does.
 ///
 /// This reads `$COLUMNS` rather than `RenderContext::terminal_width` on purpose: the
 /// context field is `None` whenever output is piped, which is exactly the case tests
 /// and shell pipelines need to control.
+///
+/// Since standout 7.9.1 this is padz's installed terminal-width detector (see
+/// [`detect_width`] and [`super::commands::run`]): the framework's `tabular()`/`table()`
+/// width cascade resolves against it, so the listing templates call `tabular([...])`
+/// with no `width=` and still get this exact width. It also still backs the `terminal`
+/// context provider that the search-hit and modification/tagging templates read
+/// directly (those do manual width math a table cannot express).
 pub fn line_width() -> usize {
     let raw = std::env::var("COLUMNS")
         .ok()
@@ -103,6 +112,17 @@ pub fn line_width() -> usize {
         .or_else(|| terminal_size::terminal_size().map(|(w, _)| w.0 as usize))
         .unwrap_or(DEFAULT_LINE_WIDTH);
     raw.max(MIN_LINE_WIDTH).saturating_sub(1)
+}
+
+/// padz's terminal-width detector, installed with `set_terminal_width_detector`.
+///
+/// standout 7.9.1's default detector reads the tty via `terminal_size` and does not
+/// consult `$COLUMNS`, so under a pipe it yields `None` and `tabular()` would fall back
+/// to a bare 80 — losing both the `$COLUMNS` control tests rely on and the `⏲` payback.
+/// Installing this makes the framework width cascade resolve to [`line_width`], which is
+/// what keeps piped and tty output byte-identical to before.
+pub fn detect_width() -> Option<usize> {
+    Some(line_width())
 }
 
 // =============================================================================

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -33,9 +33,6 @@
 //! its place:
 //!
 //! - [`line_width`] — reads process state (`$COLUMNS`, the tty) that MiniJinja cannot.
-//! - [`flatten`] — turns the pad *tree* into ordered rows with a depth. MiniJinja has
-//!   no clean recursion over a nested structure, and depth is data, not layout: the
-//!   template still decides what a depth is worth in spaces.
 //! - [`PadRow::section`] — which lifecycle bucket a row's **root** sits in. Templates
 //!   drive section breaks off this; it cannot be read off a row's own index, because a
 //!   pinned root's children are indexed `Regular` (see [`SectionKind`]).
@@ -44,12 +41,25 @@
 //! - [`build_peek`] — delegates to `padzapp::peek`, which owns the preview rules.
 //!
 //! Everything a template can decide, a template decides.
+//!
+//! ## Listing renders straight from the core tree
+//!
+//! The `list`/`search`/`peek` family no longer projects into a flat `*Row` mirror.
+//! `list.jinja` walks the core [`DisplayPad`] tree with a MiniJinja recursive loop
+//! (`{% for pad in pads recursive %}` + `loop.depth0`), so depth and section fall out
+//! of the tree itself. The only Rust that survives on that path is two MiniJinja
+//! filters — [`timeago_filter`] (needs `Utc::now()`) and [`peek_filter`] (wraps
+//! `padzapp::peek::format_as_peek`) — registered on the template engine in
+//! [`super::commands`]. Both are render-path only and never touch structured output.
+//!
+//! The `PadRow`/`SectionKind`/`TimeAgo`/`build_peek` derivations below are still used
+//! by the modification and tagging mirrors (`modification_result.jinja`,
+//! `tagging.jinja`), which have not migrated yet; they retire with those families.
 
 use super::result::{
     ModificationActionResult, ModificationNoticeResult, ModificationResult, MutationOutcomeResult,
-    MutationStatusResult, PadListResult, TaggingResult, UpdateKindResult,
+    MutationStatusResult, TaggingResult, UpdateKindResult,
 };
-use super::setup::get_grouped_help;
 use chrono::{DateTime, Utc};
 use minijinja::Value;
 use padzapp::index::{DisplayIndex, DisplayPad, SearchMatch};
@@ -63,8 +73,6 @@ pub const MIN_LINE_WIDTH: usize = 30;
 /// Default width when no terminal is detected and COLUMNS is unset (e.g. piped output).
 pub const DEFAULT_LINE_WIDTH: usize = 80;
 
-/// The context name `list.jinja` reads its view data from.
-pub const LIST_VIEW: &str = "list_view";
 /// The context name `modification_result.jinja` reads its view data from.
 pub const MODIFICATION_VIEW: &str = "modification_view";
 /// The context name `tagging.jinja` reads its view data from.
@@ -190,25 +198,6 @@ pub struct PadRow {
     pub peek: Option<PeekResult>,
 }
 
-/// Template-ready view for a listing.
-#[derive(Debug, Clone, Serialize)]
-pub struct ListView {
-    pub rows: Vec<PadRow>,
-    /// The listing was narrowed and matched nothing (vs. the store being empty).
-    pub filtered: bool,
-    /// Group rows under lifecycle section headers (`--all`).
-    pub sections: bool,
-    /// Draw todo status icons.
-    pub show_status: bool,
-    /// `--peek` was asked for. Distinct from a row's own `peek`, which is absent when
-    /// a pad has no body: peek *mode* still restyles every title, previewable or not.
-    pub peek: bool,
-    /// Append the deleted-pads help block.
-    pub deleted_help: bool,
-    /// The grouped command help, shown when the store is empty. Rendered by clap.
-    pub help_text: String,
-}
-
 /// Template-ready view for a modification.
 #[derive(Debug, Clone, Serialize)]
 pub struct ModificationView {
@@ -257,16 +246,6 @@ pub fn terminal_provider(_ctx: &RenderContext) -> Value {
     Value::from_serialize(serde_json::json!({ "width": line_width() }))
 }
 
-/// Context provider for `list.jinja`.
-///
-/// Returns `undefined` when the rendered command did not produce a [`PadListResult`].
-pub fn list_view_provider(ctx: &RenderContext) -> Value {
-    match serde_json::from_value::<PadListResult>(ctx.data.clone()) {
-        Ok(result) => Value::from_serialize(build_list_view(&result)),
-        Err(_) => Value::UNDEFINED,
-    }
-}
-
 /// Context provider for `modification_result.jinja`.
 ///
 /// Returns `undefined` when the rendered command did not produce a
@@ -289,31 +268,6 @@ pub fn tagging_view_provider(ctx: &RenderContext) -> Value {
 // =============================================================================
 // View builders
 // =============================================================================
-
-/// Builds the template-ready view for a listing.
-pub fn build_list_view(result: &PadListResult) -> ListView {
-    let opts = &result.request;
-    let mut rows = Vec::new();
-    for dp in &result.pads {
-        flatten(dp, 0, SectionKind::of(&dp.index), opts, &mut rows);
-    }
-    ListView {
-        rows,
-        filtered: opts.filtered,
-        sections: opts.sections,
-        show_status: opts.status,
-        peek: opts.peek,
-        // An empty listing has no deleted pads to explain how to restore, so the
-        // help block would be answering a question nobody asked.
-        deleted_help: opts.deleted_help && !result.pads.is_empty(),
-        // Only paid for when there is nothing else to show.
-        help_text: if result.pads.is_empty() && !opts.filtered {
-            get_grouped_help()
-        } else {
-            String::new()
-        },
-    }
-}
 
 /// Builds the template-ready view for a modification result.
 ///
@@ -437,22 +391,6 @@ fn mutation_outcome(outcome: &MutationOutcomeResult) -> Option<MutationOutcomeVi
     }
 }
 
-/// Recursively flattens a pad and its children into depth-tagged rows.
-///
-/// `section` is the *root's* bucket and is carried down unchanged — see [`SectionKind`].
-fn flatten(
-    dp: &DisplayPad,
-    depth: usize,
-    section: SectionKind,
-    opts: &super::result::ListRequest,
-    out: &mut Vec<PadRow>,
-) {
-    out.push(row(dp, depth, section, opts));
-    for child in &dp.children {
-        flatten(child, depth + 1, section, opts, out);
-    }
-}
-
 /// Builds one row from a pad.
 fn row(
     dp: &DisplayPad,
@@ -488,22 +426,56 @@ fn row(
 /// The preview rules (how many lines, where to elide) belong to `padzapp::peek`; this
 /// only feeds it the body and drops an empty result.
 fn build_peek(dp: &DisplayPad) -> Option<PeekResult> {
-    let body: String = dp
-        .pad
-        .content
-        .lines()
-        .skip(1)
-        .collect::<Vec<_>>()
-        .join("\n");
-    let result = format_as_peek(&body, 3);
+    peek_body(&dp.pad.content)
+}
+
+/// Number of preview lines each `peek` shows at the top and bottom of a body.
+const PEEK_LINES: usize = 3;
+
+/// Builds the peek preview for a pad's raw content, or `None` when there is no body.
+///
+/// The title line is dropped (`.lines().skip(1)`) so the preview shows body only, then
+/// `padzapp::peek` decides how many lines to keep and where to elide. An empty result
+/// (a pad with nothing under its title) previews nothing.
+fn peek_body(content: &str) -> Option<PeekResult> {
+    let body: String = content.lines().skip(1).collect::<Vec<_>>().join("\n");
+    let result = format_as_peek(&body, PEEK_LINES);
     (!result.opening_lines.is_empty()).then_some(result)
+}
+
+// =============================================================================
+// MiniJinja filters (the listing render path)
+// =============================================================================
+
+/// `timeago` filter: turns a serialized `created_at` timestamp into `{value, unit}`.
+///
+/// The input is the RFC3339 string serde produces for `DateTime<Utc>`. The template
+/// composes the label (`"3m ⏲"`); this only does the clock arithmetic, which needs
+/// `Utc::now()` and so cannot live in the template. A value that is not a parseable
+/// timestamp renders as `undefined` rather than aborting the whole listing.
+pub fn timeago_filter(value: &str) -> Value {
+    match DateTime::parse_from_rfc3339(value) {
+        Ok(ts) => Value::from_serialize(TimeAgo::since(ts.with_timezone(&Utc))),
+        Err(_) => Value::UNDEFINED,
+    }
+}
+
+/// `peek` filter: previews a pad's body, or `undefined` when it has none.
+///
+/// Wraps [`peek_body`] so the preview rules stay in `padzapp::peek` and never leak into
+/// structured output — the filter only runs on the template path. `undefined` lets the
+/// template gate the preview block with a plain `{% if pad.pad.content | peek %}`.
+pub fn peek_filter(content: &str) -> Value {
+    match peek_body(content) {
+        Some(result) => Value::from_serialize(result),
+        None => Value::UNDEFINED,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::result::{ListRequest, ModificationRequest};
-    use padzapp::index::MatchSegment;
+    use crate::cli::result::ModificationRequest;
     use padzapp::model::Pad;
 
     fn pad(title: &str) -> Pad {
@@ -519,163 +491,38 @@ mod tests {
         }
     }
 
-    fn list(pads: Vec<DisplayPad>, request: ListRequest) -> PadListResult {
-        PadListResult { pads, request }
-    }
-
     // =========================================================================
-    // flatten / SectionKind
+    // peek / timeago filters (the listing render path)
     // =========================================================================
 
-    /// The whole reason `section` exists rather than reading each row's own index.
-    ///
-    /// `index_pads` gives a pinned root's children `Regular` indexes, so a template
-    /// driving section breaks off the row's own index would split the pinned block
-    /// open at its first child. Every row carries its *root's* bucket instead.
+    /// The `peek` filter drops the title line and previews the body; a pad whose
+    /// content is only its title has nothing to preview and renders `undefined`, which
+    /// is what lets the template gate the block with a plain `{% if ... | peek %}`.
     #[test]
-    fn a_pinned_roots_children_stay_in_the_pinned_section() {
-        let tree = dp(
-            pad("root"),
-            DisplayIndex::Pinned(1),
-            vec![dp(pad("child"), DisplayIndex::Regular(1), vec![])],
-        );
-        let view = build_list_view(&list(vec![tree], ListRequest::default()));
-
-        assert_eq!(view.rows.len(), 2);
-        assert_eq!(view.rows[1].index, DisplayIndex::Regular(1));
+    fn peek_filter_previews_a_body_and_is_undefined_without_one() {
+        let bodied = peek_filter("has body\n\nbody line");
+        assert!(!bodied.is_undefined(), "a pad with a body previews");
         assert_eq!(
-            view.rows[1].section,
-            SectionKind::Pinned,
-            "a child's section is its root's, not its own index's"
+            bodied.get_attr("opening_lines").unwrap().as_str(),
+            Some("body line")
         );
+
+        // Title line only: nothing under the title to preview.
+        assert!(peek_filter("bare").is_undefined());
+        assert!(peek_filter("").is_undefined());
     }
 
+    /// The `timeago` filter parses the RFC3339 string serde emits for `created_at` and
+    /// returns the `{value, unit}` pair; an unparseable value renders `undefined`
+    /// rather than aborting the listing.
     #[test]
-    fn flatten_walks_depth_first_and_tags_each_row_with_its_depth() {
-        let tree = dp(
-            pad("root"),
-            DisplayIndex::Regular(1),
-            vec![dp(
-                pad("child"),
-                DisplayIndex::Regular(1),
-                vec![dp(pad("grandchild"), DisplayIndex::Regular(1), vec![])],
-            )],
-        );
-        let view = build_list_view(&list(vec![tree], ListRequest::default()));
+    fn timeago_filter_parses_a_timestamp_and_rejects_junk() {
+        let long_ago = timeago_filter("2000-01-01T00:00:00Z");
+        assert!(!long_ago.is_undefined());
+        // Decades ago reads in years.
+        assert_eq!(long_ago.get_attr("unit").unwrap().as_str(), Some("y"));
 
-        let seen: Vec<(&str, usize)> = view
-            .rows
-            .iter()
-            .map(|r| (r.title.as_str(), r.depth))
-            .collect();
-        assert_eq!(seen, [("root", 0), ("child", 1), ("grandchild", 2)]);
-    }
-
-    // =========================================================================
-    // Request-driven fields
-    // =========================================================================
-
-    #[test]
-    fn short_uuid_is_present_only_when_asked_for() {
-        let p = pad("p");
-        let full = p.metadata.id.to_string();
-        let tree = dp(p, DisplayIndex::Regular(1), vec![]);
-
-        let off = build_list_view(&list(vec![tree.clone()], ListRequest::default()));
-        assert_eq!(off.rows[0].short_uuid, None);
-
-        let on = build_list_view(&list(
-            vec![tree],
-            ListRequest {
-                uuid: true,
-                ..Default::default()
-            },
-        ));
-        assert_eq!(on.rows[0].short_uuid.as_deref(), Some(&full[..8]));
-    }
-
-    #[test]
-    fn peek_is_absent_without_the_flag_and_when_a_pad_has_no_body() {
-        let bodied = dp(pad("has body"), DisplayIndex::Regular(1), vec![]);
-        // Empty content normalizes to the title line alone — nothing to preview.
-        let bare = dp(
-            Pad::new("bare".to_string(), String::new()),
-            DisplayIndex::Regular(2),
-            vec![],
-        );
-        let request = ListRequest {
-            peek: true,
-            ..Default::default()
-        };
-
-        let off = build_list_view(&list(vec![bodied.clone()], ListRequest::default()));
-        assert!(off.rows[0].peek.is_none(), "no --peek, no preview");
-
-        let on = build_list_view(&list(vec![bodied, bare], request));
-        assert!(on.rows[0].peek.is_some());
-        assert!(on.rows[1].peek.is_none(), "a bodyless pad previews nothing");
-    }
-
-    /// Line 0 is the *title* match, which the pad's own title line already shows;
-    /// repeating it as a hit line would print the title twice.
-    #[test]
-    fn the_title_match_is_not_repeated_as_a_hit_line() {
-        let mut tree = dp(pad("p"), DisplayIndex::Regular(1), vec![]);
-        tree.matches = Some(vec![
-            SearchMatch {
-                line_number: 0,
-                segments: vec![MatchSegment::Plain("title".into())],
-            },
-            SearchMatch {
-                line_number: 3,
-                segments: vec![MatchSegment::Match("body".into())],
-            },
-        ]);
-        let view = build_list_view(&list(vec![tree], ListRequest::default()));
-
-        let lines: Vec<usize> = view.rows[0].matches.iter().map(|m| m.line_number).collect();
-        assert_eq!(lines, [3]);
-    }
-
-    /// The help block explains how to restore deleted pads. With nothing listed
-    /// there is nothing to restore, so it would answer a question nobody asked.
-    #[test]
-    fn the_deleted_help_block_is_suppressed_on_an_empty_listing() {
-        let request = ListRequest {
-            deleted_help: true,
-            ..Default::default()
-        };
-        let empty = build_list_view(&list(vec![], request.clone()));
-        assert!(!empty.deleted_help);
-
-        let populated = build_list_view(&list(
-            vec![dp(pad("p"), DisplayIndex::Deleted(1), vec![])],
-            request,
-        ));
-        assert!(populated.deleted_help);
-    }
-
-    /// The grouped help is only rendered when it will actually be shown — it is
-    /// clap work, and a populated listing never displays it.
-    #[test]
-    fn the_grouped_help_is_built_only_for_an_empty_unfiltered_store() {
-        assert!(!build_list_view(&list(vec![], ListRequest::default()))
-            .help_text
-            .is_empty());
-
-        let filtered = ListRequest {
-            filtered: true,
-            ..Default::default()
-        };
-        assert!(build_list_view(&list(vec![], filtered))
-            .help_text
-            .is_empty());
-
-        let populated = build_list_view(&list(
-            vec![dp(pad("p"), DisplayIndex::Regular(1), vec![])],
-            ListRequest::default(),
-        ));
-        assert!(populated.help_text.is_empty());
+        assert!(timeago_filter("not a timestamp").is_undefined());
     }
 
     // =========================================================================

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 
 /// What the user asked a listing to show.
 ///
-/// Consumed by [`super::render::build_list_view`] to decide which columns and
+/// Rides on [`Listing`] and is read by `list.jinja` to decide which columns and
 /// previews to draw. Mode-independent: `--peek` means "include previews" whether the
 /// output ends up as a table or as JSON.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -60,13 +60,18 @@ pub struct ModificationRequest {
     pub status: bool,
 }
 
-/// Pads matching a listing, in canonical display order.
+/// A listing of pads plus what the user asked to show, rendered straight from the
+/// core tree.
 ///
-/// Produced by `list`, `peek`, and `search`. `pads` keeps the canonical display
-/// identifiers assigned by `index_pads` — including pinned dual indexes and nested
-/// tree indexes — untouched.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PadListResult {
+/// Produced by `list`, `peek`, and `search`. `pads` is the core [`DisplayPad`] tree
+/// exactly as `index_pads` built it — canonical display identifiers (pinned dual
+/// indexes, nested tree indexes) and `children` untouched — and `list.jinja` walks it
+/// with a recursive loop rather than a flattened row mirror. `request` records what to
+/// show (peek/uuid/status flags), not how to draw it, so it rides in structured output
+/// too. Presentation (widths, glyphs, timestamps, the empty-store help) stays in the
+/// template and its filters; nothing here is a rendered string.
+#[derive(Debug, Clone, Serialize)]
+pub struct Listing {
     pub pads: Vec<DisplayPad>,
     pub request: ListRequest,
 }

--- a/crates/padz/src/cli/templates/_list_pad_line.jinja
+++ b/crates/padz/src/cli/templates/_list_pad_line.jinja
@@ -1,7 +1,8 @@
 {#- One listing pad line, rendered straight from a core DisplayPad. -#}
 {#- Reads `pad` (padzapp::index::DisplayPad), `depth` (from the recursive loop's -#}
-{#- `loop.depth0`), plus `show_status`, `peek_mode`, `request` and `terminal` off the -#}
-{#- including template's context. Every width, glyph and style name is decided here. -#}
+{#- `loop.depth0`), plus `show_status`, `peek_mode` and `request` off the including -#}
+{#- template's context. Layout width is resolved by `tabular` itself (no `terminal` -#}
+{#- read); every glyph and style name is decided here. -#}
 {#- Its section styling reads the pad's own `index.type`: a cascade-archived or -#}
 {#- cascade-deleted child carries the same bucket as its root, and a pinned root's -#}
 {#- Regular-indexed child is only ever styled at depth 0, so per-pad index is exact. -#}
@@ -11,8 +12,6 @@
 {#- Widths. An unused status column still costs its width, so zero it when off. -#}
 {%- set col_status = L.COLS.status if show_status else 0 -%}
 {%- set indent_width = depth * L.INDENT -%}
-{%- set fixed = L.COLS.left_pin + col_status + L.COLS.index + L.COLS.time -%}
-{%- set title_width = [terminal.width - fixed - indent_width, 0] | max -%}
 
 {#- Index: "p1.", " 1.", "ar1.", "d1." -#}
 {%- if section == "Pinned" -%}
@@ -57,11 +56,15 @@
 {%- set time = pad.pad.metadata.created_at | timeago -%}
 {%- set time_label = (time.value | string | pad_left(2)) ~ time.unit ~ " " ~ L.CLOCK -%}
 
+{#- No `width=`: `tabular` resolves the total against the terminal width padz -#}
+{#- installs (render::line_width, ⏲ payback included). Nesting is a leading fixed -#}
+{#- column so the content column can `fill` the rest, and the whole row still fits. -#}
 {%- set t = tabular([
+    {"key": "indent", "width": indent_width},
     {"key": "left_pin", "width": L.COLS.left_pin, "style": "pinned"},
     {"key": "status", "width": col_status, "style": "status-icon"},
     {"key": "index", "width": L.COLS.index, "style": index_style},
-    {"key": "content", "width": title_width, "sub_columns": {
+    {"key": "content", "width": "fill", "sub_columns": {
         "columns": [
             {"width": "fill", "overflow": "truncate", "style": title_style},
             {"width": {"min": 0, "max": L.TAGS_MAX}, "align": "right"}
@@ -69,8 +72,7 @@
         "separator": " "
     }},
     {"key": "time", "width": L.COLS.time, "align": "right", "style": "time"}
-], width=terminal.width) -%}
+]) -%}
 
-{{- "" | pad_right(indent_width) -}}
-{{- t.row([left_pin, status_icon, index, [title, ns.tags], time_label]) -}}
+{{- t.row(["", left_pin, status_icon, index, [title, ns.tags], time_label]) -}}
 {{ "" | nl -}}

--- a/crates/padz/src/cli/templates/_list_pad_line.jinja
+++ b/crates/padz/src/cli/templates/_list_pad_line.jinja
@@ -1,0 +1,76 @@
+{#- One listing pad line, rendered straight from a core DisplayPad. -#}
+{#- Reads `pad` (padzapp::index::DisplayPad), `depth` (from the recursive loop's -#}
+{#- `loop.depth0`), plus `show_status`, `peek_mode`, `request` and `terminal` off the -#}
+{#- including template's context. Every width, glyph and style name is decided here. -#}
+{#- Its section styling reads the pad's own `index.type`: a cascade-archived or -#}
+{#- cascade-deleted child carries the same bucket as its root, and a pinned root's -#}
+{#- Regular-indexed child is only ever styled at depth 0, so per-pad index is exact. -#}
+{%- import "_layout.jinja" as L -%}
+{%- set section = pad.index.type -%}
+
+{#- Widths. An unused status column still costs its width, so zero it when off. -#}
+{%- set col_status = L.COLS.status if show_status else 0 -%}
+{%- set indent_width = depth * L.INDENT -%}
+{%- set fixed = L.COLS.left_pin + col_status + L.COLS.index + L.COLS.time -%}
+{%- set title_width = [terminal.width - fixed - indent_width, 0] | max -%}
+
+{#- Index: "p1.", " 1.", "ar1.", "d1." -#}
+{%- if section == "Pinned" -%}
+  {%- set index = "p" ~ pad.index.value ~ "." -%}
+{%- elif section == "Archived" -%}
+  {%- set index = "ar" ~ pad.index.value ~ "." -%}
+{%- elif section == "Deleted" -%}
+  {%- set index = "d" ~ pad.index.value ~ "." -%}
+{%- else -%}
+  {%- set index = (pad.index.value | string | pad_left(2)) ~ "." -%}
+{%- endif -%}
+
+{#- A pinned pad shows its marker only as a root: a nested pad's own line is -#}
+{#- about its place in the tree, not about the pinned block. -#}
+{%- set left_pin = L.PIN if pad.pad.metadata.is_pinned and depth == 0 else "" -%}
+{%- set status_icon = L.STATUS_GLYPH[pad.pad.metadata.status] if show_status else "" -%}
+
+{#- Semantic style per section. -#}
+{%- set index_style = "list-index" -%}
+{%- if section == "Pinned" and depth == 0 -%}
+  {%- set index_style = "pinned" -%}
+{%- elif section == "Deleted" -%}
+  {%- set index_style = "deleted-index" -%}
+{%- endif -%}
+
+{%- set title_style = "list-title" -%}
+{%- if section == "Deleted" -%}
+  {%- set title_style = "deleted-title" -%}
+{%- elif peek_mode -%}
+  {%- set title_style = "title" -%}
+{%- endif -%}
+
+{%- set short_uuid = (pad.pad.metadata.id | string)[:8] if request.uuid else none -%}
+{%- set title = ("(" ~ short_uuid ~ ") " ~ pad.pad.metadata.title) if short_uuid else pad.pad.metadata.title -%}
+
+{#- Tags render as bracketed chips, right-aligned after the title. -#}
+{%- set ns = namespace(tags = "") -%}
+{%- for t in pad.pad.metadata.tags -%}
+  {%- set ns.tags = ns.tags ~ "「[tag]" ~ (t | trim) ~ "[/tag]」" ~ ("" if loop.last else " ") -%}
+{%- endfor -%}
+
+{%- set time = pad.pad.metadata.created_at | timeago -%}
+{%- set time_label = (time.value | string | pad_left(2)) ~ time.unit ~ " " ~ L.CLOCK -%}
+
+{%- set t = tabular([
+    {"key": "left_pin", "width": L.COLS.left_pin, "style": "pinned"},
+    {"key": "status", "width": col_status, "style": "status-icon"},
+    {"key": "index", "width": L.COLS.index, "style": index_style},
+    {"key": "content", "width": title_width, "sub_columns": {
+        "columns": [
+            {"width": "fill", "overflow": "truncate", "style": title_style},
+            {"width": {"min": 0, "max": L.TAGS_MAX}, "align": "right"}
+        ],
+        "separator": " "
+    }},
+    {"key": "time", "width": L.COLS.time, "align": "right", "style": "time"}
+], width=terminal.width) -%}
+
+{{- "" | pad_right(indent_width) -}}
+{{- t.row([left_pin, status_icon, index, [title, ns.tags], time_label]) -}}
+{{ "" | nl -}}

--- a/crates/padz/src/cli/templates/_match_lines.jinja
+++ b/crates/padz/src/cli/templates/_match_lines.jinja
@@ -1,8 +1,10 @@
 {#- Search hit lines under a pad: "    03L …the matching text". -#}
-{#- Reads `pad` (a render::PadRow), `show_status` and `terminal`. -#}
+{#- Reads `pad` (a core DisplayPad), `depth`, `show_status` and `terminal`. -#}
+{#- `pad.matches` is the raw core `Option<Vec<SearchMatch>>`, so line 0 (the title -#}
+{#- match, already shown by the title line) is rejected here rather than upstream. -#}
 {%- import "_layout.jinja" as L -%}
 {%- set col_status = L.COLS.status if show_status else 0 -%}
-{%- set indent_width = pad.depth * L.INDENT -%}
+{%- set indent_width = depth * L.INDENT -%}
 
 {#- A hit line's *text* starts on the title column and stops short of the time
     column, with the "04L " badge hanging in the gutter to its left. So the badge
@@ -16,7 +18,7 @@
 
 {#- Truncate the styled run as a whole: each segment is styled *after* it is cut, -#}
 {#- because `truncate_at` measures plain text and would drop the tags otherwise. -#}
-{%- for match in pad.matches -%}
+{%- for match in (pad.matches or []) if match.line_number != 0 -%}
 {{ "" | pad_right(badge_indent) }}[line-number]{#-
     Line numbers read as a column, so single digits carry a leading zero.
 -#}{{ ("0" ~ match.line_number) if match.line_number < 10 else match.line_number }}L[/line-number] {% set ns = namespace(width = 0, done = false) %}{% for seg in match.segments %}{% if not ns.done %}{% set style = "match" if seg.type == "Match" else "info" %}{% set seg_width = seg.text | display_width %}{% if ns.width + seg_width <= avail %}{{ seg.text | style_as(style) }}{% set ns.width = ns.width + seg_width %}{% else %}{{ seg.text | truncate_at(avail - ns.width) | style_as(style) }}{% set ns.done = true %}{% endif %}{% endif %}{% endfor %}{{ "" | nl }}

--- a/crates/padz/src/cli/templates/_peek_content.jinja
+++ b/crates/padz/src/cli/templates/_peek_content.jinja
@@ -1,17 +1,18 @@
-{#- Content preview under a pad. Reads `pad` (a render::PadRow with `peek`). -#}
+{#- Content preview under a pad. Reads `pv` (a padzapp::peek::PeekResult, produced by -#}
+{#- the `peek` filter in the including template) and `depth`. -#}
 {#- `indent()` carries the pad's own nesting too, so a nested pad's continuation -#}
 {#- lines stay flush with its first line. -#}
 {%- import "_layout.jinja" as L -%}
-{%- set indent_width = pad.depth * L.INDENT -%}
+{%- set indent_width = depth * L.INDENT -%}
 {%- set indent = "" | pad_right(indent_width) -%}
 {{ "" | nl }}
-    {{ indent }}    [preview]{{ pad.peek.opening_lines | indent(8 + indent_width) }}[/preview]{{ "" | nl }}
-{%- if pad.peek.truncated_count -%}
+    {{ indent }}    [preview]{{ pv.opening_lines | indent(8 + indent_width) }}[/preview]{{ "" | nl }}
+{%- if pv.truncated_count -%}
 {{ "" | nl }}
-    {{ indent }}                      [truncation]... {{ pad.peek.truncated_count }} lines not shown ...[/truncation]{{ "" | nl }}
+    {{ indent }}                      [truncation]... {{ pv.truncated_count }} lines not shown ...[/truncation]{{ "" | nl }}
 {{ "" | nl }}
 {%- endif -%}
-{%- if pad.peek.closing_lines -%}
-    {{ indent }}    [preview]{{ pad.peek.closing_lines | indent(8 + indent_width) }}[/preview]{{ "" | nl }}
+{%- if pv.closing_lines -%}
+    {{ indent }}    [preview]{{ pv.closing_lines | indent(8 + indent_width) }}[/preview]{{ "" | nl }}
 {%- endif -%}
 {{ "" | nl }}

--- a/crates/padz/src/cli/templates/list.jinja
+++ b/crates/padz/src/cli/templates/list.jinja
@@ -1,38 +1,48 @@
-{#- Listing output. `list_view` is derived at render time from the handler's -#}
-{#- PadListResult; see cli::render. -#}
+{#- Listing output, rendered straight from the core DisplayPad tree the handler -#}
+{#- returns (a cli::result::Listing: `pads` + `request`); see cli::render. -#}
 {%- import "_layout.jinja" as L -%}
-{%- set view = list_view -%}
 {#- The partials below read these off the shared include context. -#}
-{%- set show_status = view.show_status -%}
-{%- set peek_mode = view.peek -%}
-{%- if view.rows | length == 0 -%}
-{%- if view.filtered -%}
+{%- set show_status = request.status -%}
+{%- set peek_mode = request.peek -%}
+{%- if pads | length == 0 -%}
+{%- if request.filtered -%}
 [info]No matching pads.[/info]{{ "" | nl -}}
 {%- else -%}
 [empty-message]No pads yet, create one with `padz create`[/empty-message]{{ "" | nl -}}
-{{ view.help_text }}
+{{ grouped_help() }}
 {%- endif -%}
 {%- else -%}
-{%- for pad in view.rows -%}
-{#- Section breaks key off the *root's* bucket, which every row carries, so a -#}
+{#- Walk the tree: each root recurses into its children via `loop(pad.children)`, so -#}
+{#- depth is `loop.depth0` and section breaks compare only roots (depth 0). -#}
+{%- for pad in pads recursive -%}
+{%- set depth = loop.depth0 -%}
+{%- if depth == 0 -%}
+{#- Section breaks key off the *root's* bucket (its own index at depth 0), so a -#}
 {#- pinned root's Regular-indexed children never break its block open. -#}
-{%- set changed = loop.previtem is not defined or loop.previtem.section != pad.section -%}
+{%- set section = pad.index.type -%}
+{%- set prev_section = loop.previtem.index.type if loop.previtem is defined else "" -%}
+{%- set changed = loop.previtem is not defined or prev_section != section -%}
 {#- Leaving the pinned block costs a blank line: the same pads appear again -#}
 {#- below, and the gap is what says "this is the same list, unpinned". -#}
-{%- if loop.previtem is defined and loop.previtem.section == "Pinned" and pad.section != "Pinned" -%}
+{%- if loop.previtem is defined and prev_section == "Pinned" and section != "Pinned" -%}
 {{- "" | nl -}}
 {%- endif -%}
-{%- if view.sections and changed and pad.section in L.SECTION_TITLE -%}
+{%- if request.sections and changed and section in L.SECTION_TITLE -%}
 {{- "" | nl -}}
-[section-header]{{ L.SECTION_TITLE[pad.section] }}[/section-header]{{ "" | nl }}
+[section-header]{{ L.SECTION_TITLE[section] }}[/section-header]{{ "" | nl }}
 {%- endif -%}
-{%- include "_pad_line.jinja" -%}
+{%- endif -%}
+{%- include "_list_pad_line.jinja" -%}
 {%- include "_match_lines.jinja" -%}
-{%- if pad.peek -%}
+{%- if peek_mode -%}
+{%- set pv = pad.pad.content | peek -%}
+{%- if pv -%}
 {%- include "_peek_content.jinja" -%}
 {%- endif -%}
+{%- endif -%}
+{%- if pad.children -%}{{ loop(pad.children) }}{%- endif -%}
 {%- endfor -%}
 {%- endif -%}
-{%- if view.deleted_help -%}
+{%- if request.deleted_help and pads | length > 0 -%}
 {%- include "_deleted_help.jinja" -%}
 {%- endif -%}

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -29,11 +29,11 @@ use padz::cli::result::{
     CopyResult, CreateAbortKindResult, CreateAbortReasonResult, CreateResult, DoctorResult,
     ExportFormat, ExportStatus, ExportWarning, ImportDiagnosticResult, ImportResult,
     ImportSourceKindResult, ImportSourceStatusResult, ImportStatusResult, InitializationResult,
-    MetadataWarningReasonResult, ModificationActionResult, ModificationNoticeResult,
-    ModificationResult, MutationOutcomeResult, MutationStatusResult, PadContentResult,
-    PadListResult, PathResult, PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult,
-    TransferDirectionResult, TransferOperationResult, TransferResult, TransferSelectionResult,
-    TransferStatusResult, UpdateKindResult, UuidResult,
+    Listing, MetadataWarningReasonResult, ModificationActionResult, ModificationNoticeResult,
+    ModificationResult, MutationOutcomeResult, MutationStatusResult, PadContentResult, PathResult,
+    PurgeResult, TagCatalogResult, TagRegistryResult, TaggingResult, TransferDirectionResult,
+    TransferOperationResult, TransferResult, TransferSelectionResult, TransferStatusResult,
+    UpdateKindResult, UuidResult,
 };
 use padzapp::commands::NestingMode;
 use standout::cli::Output;
@@ -55,7 +55,7 @@ where
 }
 
 /// The titles a listing result carries, in the order the handler returned them.
-fn titles(result: &PadListResult) -> Vec<String> {
+fn titles(result: &Listing) -> Vec<String> {
     result
         .pads
         .iter()


### PR DESCRIPTION
for #239 (epic STD04 #238)

Establishes the "handlers return core types, presentation is templates + filters" pattern for the epic, applied to the listing family: `list`/`ls`, `search`, `peek`, `view`.

## What changed

- **`list`/`search`/`peek` return `Listing { pads, request }`** — a thin view over the core nested `Vec<DisplayPad>` (renamed from `PadListResult`; `pads` was already core `DisplayPad`, so the serialized shape is unchanged). No more tier-3 `ListView`/`PadRow` mirror.
- **`list.jinja` renders the tree with a MiniJinja recursive loop** — `{% for pad in pads recursive %}` … `{{ loop(pad.children) }}`, depth from `loop.depth0`. `_pad_line`/`_match_lines`/`_peek_content` read the core shape.
- **Two render-only filters** — `timeago` (`created_at | timeago` → `{value, unit}`, needs `Utc::now()`) and `peek` (`content | peek`, wraps `padzapp::peek::format_as_peek`, `undefined` when empty). Registered on a custom engine via `AppBuilder::template_engine`; both run only on the template path and never reach structured output.
- **Deleted (listing-exclusive):** `ListView`, `build_list_view`, `list_view_provider`, `flatten`, `LIST_VIEW` const + registration, `PadListResult`.

## Context (handoff)

**Why this shape.** The listing pads were *already* core `DisplayPad` in structured output, so the epic's win here is deleting the tier-3 flatten/`PadRow` mirror, not reshaping JSON. `list.jinja` now walks the core tree directly; the handler keeps a thin `{ pads, request }` view because the template genuinely needs the request flags (peek/uuid/status/filtered/sections/deleted_help) — which the epic/brief explicitly permit.

**`ListRequest` survived** as a thin, wording-free view-input struct (unchanged fields); only its container was renamed `PadListResult` → `Listing`.

**Section in-template.** Section = each root's own `index.type` at `loop.depth0 == 0`; `loop.previtem` at the top level is the previous *root*, so section-break/blank-after-pinned logic compares only roots. Verified that cascade-archive/delete puts children in the same bucket (child's own `index.type` == root's section), so per-pad index reproduces the old "root's SectionKind" styling byte-for-byte — no `section` field or core change needed.

**The two gotchas.**
- **⏲ compensation & COLUMNS/piped width:** standout 7.9 `tabular` defaults width to a hardcoded **80** and does **not** resolve terminal width (`RenderContext::terminal_width` is `None` under pipes). So `line_width` (reads `$COLUMNS`, clamps to 30, pays back the `⏲` under-measured column with `saturating_sub(1)`) and the `terminal.width` provider are **retained**, not deleted — removing them would break byte-identical human output, which the epic forbids. Byte-diff confirms the width/⏲ behaviour is unchanged (incl. the piped `COLUMNS=80` path tests use). **The AC "remove the `line_width`/`terminal.width` provider" is not achievable in WS01 without a Standout change or reshaping human output — flagging for coordinator/maintainer; realistically a WS07 concern and only if Standout gains terminal-aware `tabular` width.**

**Shared-partial constraint (scope boundary).** `_pad_line.jinja` is shared with `modification_result.jinja` (WS02) and `tagging.jinja` (WS03), which still use the old `PadRow` shape. So the listing pad line is a **new** `_list_pad_line.jinja`, and `PadRow`/`row`/`SectionKind`/`TimeAgo`/`build_peek`/`terminal_provider`/`line_width` are **retained** — deleting them would break the out-of-scope modification/tagging commands. Only the listing-exclusive `ListView`/`build_list_view`/`list_view_provider`/`flatten`/`LIST_VIEW` were removed. The brief's item-#2 delete list assumed these were listing-only; they are not, so their teardown moves to WS02/03/07.

**One extra render-only seam:** a `grouped_help()` MiniJinja function supplies the empty-store command help (previously computed in `list_view_provider`). It's render-only like the two filters; flagging since the epic framed "only two filters survive."

**`view` unchanged.** It already returns a thin flat view (`PadContentResult`/`PadContent`) read directly by `view.jinja` — no `PadListResult`, no render mirror, no provider — so it already embodies the target pattern. `PadContentResult` retires with the final `result.rs` teardown (WS07).

**Out of scope / left for later:** modification/tagging/transfer/import-export/singleton mirrors (WS02–06); final `result.rs` + shared-view teardown and width-provider removal (WS07); dead `text_list.jinja`/`full_pad.jinja` templates.

## Verification

- `pixi run test` (Rust): **882 passed** incl. the 81-test in-process render harness, `structured_output_harness`, `presentation_seams`, `theme`.
- `pixi run lint`: green (clippy `-D warnings` + fmt), enforced by the commit/push hooks.
- **Byte-diff** of the pristine `epic/std04` binary vs. this branch, both reading one shared store, across auto/term/text/term-debug/json/yaml/csv/xml for empty, populated, nested, pinned dual-index, `--all` sections, `--peek` (incl. >9-line truncation), `--uuid`, `--show-status`, `--deleted`, `--archived`, nested-under-deleted, search hits, filtered-empty: **identical** modulo environmental timeago drift.
- All e2e bats jq queries read the core `.pads[].pad.metadata.*` / `.children[]` shape (unchanged); no bats or structured fixtures needed regeneration.