### PR TITLE
STD04-WS02: Epic: Collapse CLI Presentation Tiers - Workstream: Modifications

### DIFF
--- a/crates/padz/src/cli/commands.rs
+++ b/crates/padz/src/cli/commands.rs
@@ -17,10 +17,7 @@
 //! 5. **Error Handling**: Convert errors to user-friendly messages and exit codes
 
 use super::handlers::AppState;
-use super::render::{
-    modification_view_provider, peek_filter, terminal_provider, timeago_filter, MODIFICATION_VIEW,
-    TERMINAL,
-};
+use super::render::{peek_filter, terminal_provider, timeago_filter, TERMINAL};
 use super::setup::{
     build_command, get_grouped_help, invocation_default_command, parse_cli, Cli, Commands,
     CompletionAction, CompletionShell, ConfigSubcommand,
@@ -72,13 +69,14 @@ pub fn run() -> Result<()> {
 /// Build the dispatch-ready App with templates, styles, command configuration, and app state
 ///
 /// Two render-time seams keep presentation out of structured output. The `context_fn`
-/// registration derives the modification template view from the serialized result —
-/// Standout resolves it only on the template path. The custom MiniJinja engine adds the
-/// listing family's filters (`timeago`, `peek`) and the empty-store `grouped_help()`
-/// helper, which are likewise render-only: structured modes bypass the engine entirely,
-/// so a JSON consumer never sees a relative timestamp, a preview, or a help blob. The
-/// `list`/`search`/`peek` and tag (`tagging`/`tag_catalog`/`tag_registry`) templates
-/// render straight from the core outcomes, so neither needs a view provider.
+/// registration installs the `terminal` width provider — Standout resolves it only on
+/// the template path. The custom MiniJinja engine adds the listing family's filters
+/// (`timeago`, `peek`) and the empty-store `grouped_help()` helper, which are likewise
+/// render-only: structured modes bypass the engine entirely, so a JSON consumer never
+/// sees a relative timestamp, a preview, or a help blob. Every command family —
+/// `list`/`search`/`peek`, the modification family (`modification_result`), and the tag
+/// templates (`tagging`/`tag_catalog`/`tag_registry`) — renders straight from the core
+/// outcomes, so none needs a view provider.
 ///
 /// Public because it is the whole app-under-test: `TestHarness` tests pair it with
 /// [`build_command`] to drive argv through render in process, against the same
@@ -103,7 +101,6 @@ pub fn build_dispatch_app(app_state: AppState) -> App {
         .styles(embed_styles!("src/styles"))
         .default_theme("default")
         .context_fn(TERMINAL, terminal_provider)
-        .context_fn(MODIFICATION_VIEW, modification_view_provider)
         .commands(Commands::dispatch_config())
         .expect("Failed to configure commands")
         .command_with("create", super::handlers::create__handler, |config| {

--- a/crates/padz/src/cli/handlers.rs
+++ b/crates/padz/src/cli/handlers.rs
@@ -29,8 +29,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use super::result::{
-    CreateAbortKindResult, CreateAbortReasonResult, CreateAbortResult, CreateResult, ListRequest,
-    Listing, ModificationActionResult, ModificationRequest, ModificationResult, PadContent,
+    ListRequest, Listing, Modification, ModificationAction, ModificationRequest, PadContent,
     PadContentResult,
 };
 use super::views::{CopyView, PathView, UuidView};
@@ -137,7 +136,7 @@ fn get_state(ctx: &CommandContext) -> &AppState {
 /// let result = state.with_api(|api| {
 ///     api.method(state.scope, &args).map_err(to_anyhow)
 /// })?;
-/// Ok(Output::Render(ModificationResult { ... }))
+/// Ok(Output::Render(Modification { ... }))
 /// ```
 ///
 /// With ScopedApi, handlers become one-liners:
@@ -161,14 +160,14 @@ impl<'a> ScopedApi<'a> {
             .with_api(|api| f(api, self.state.scope).map_err(to_anyhow))
     }
 
-    /// Map a CmdResult (modification) into the typed modification result.
+    /// Map a CmdResult (modification) into the thin modification view.
     /// When `force_show_status` is true, status icons are requested regardless of mode.
     fn modification(
         &self,
-        action: ModificationActionResult,
+        action: ModificationAction,
         result: CmdResult,
         force_show_status: bool,
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<Modification>, anyhow::Error> {
         Ok(Output::Render(self.modification_result(
             action,
             result,
@@ -176,20 +175,23 @@ impl<'a> ScopedApi<'a> {
         )))
     }
 
-    /// Build a typed modification result without wrapping it in `Output`.
+    /// Build the thin modification view without wrapping it in `Output`.
     ///
-    /// Used by the handlers that assemble a `CmdResult` themselves (create, edit).
+    /// The core's `notices`/`outcomes` (`CmdNotice`/`CmdOutcome`) ride through
+    /// verbatim — no projection — so the template and structured output read the
+    /// same core shape. Used by the handlers that assemble a `CmdResult`
+    /// themselves (create, edit).
     fn modification_result(
         &self,
-        action: ModificationActionResult,
+        action: ModificationAction,
         result: CmdResult,
         force_show_status: bool,
-    ) -> ModificationResult {
-        ModificationResult {
+    ) -> Modification {
+        Modification {
             action,
             pads: result.affected_pads,
-            notices: result.notices.into_iter().map(Into::into).collect(),
-            outcomes: result.outcomes.into_iter().map(Into::into).collect(),
+            notices: result.notices,
+            outcomes: result.outcomes,
             request: ModificationRequest {
                 status: self.state.wants_status(force_show_status),
             },
@@ -198,80 +200,59 @@ impl<'a> ScopedApi<'a> {
 
     // --- Modification operations ---
 
-    pub fn pin_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn pin_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.pin_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Pin, result, false)
+        self.modification(ModificationAction::Pin, result, false)
     }
 
-    pub fn unpin_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn unpin_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.unpin_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Unpin, result, false)
+        self.modification(ModificationAction::Unpin, result, false)
     }
 
-    pub fn delete_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn delete_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Delete, result, false)
+        self.modification(ModificationAction::Delete, result, false)
     }
 
-    pub fn delete_completed_pads(&self) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn delete_completed_pads(&self) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.delete_completed_pads(scope))?;
-        self.modification(ModificationActionResult::Delete, result, false)
+        self.modification(ModificationAction::Delete, result, false)
     }
 
-    pub fn restore_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn restore_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.restore_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Restore, result, false)
+        self.modification(ModificationAction::Restore, result, false)
     }
 
-    pub fn archive_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn archive_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.archive_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Archive, result, false)
+        self.modification(ModificationAction::Archive, result, false)
     }
 
     pub fn unarchive_pads(
         &self,
         indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.unarchive_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Unarchive, result, false)
+        self.modification(ModificationAction::Unarchive, result, false)
     }
 
-    pub fn complete_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn complete_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.complete_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Complete, result, true)
+        self.modification(ModificationAction::Complete, result, true)
     }
 
-    pub fn reopen_pads(
-        &self,
-        indexes: &[String],
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    pub fn reopen_pads(&self, indexes: &[String]) -> Result<Output<Modification>, anyhow::Error> {
         let result = self.call(|api, scope| api.reopen_pads(scope, indexes))?;
-        self.modification(ModificationActionResult::Reopen, result, true)
+        self.modification(ModificationAction::Reopen, result, true)
     }
 
     pub fn move_pads(
         &self,
         indexes: &[String],
         to_root: bool,
-    ) -> Result<Output<ModificationResult>, anyhow::Error> {
+    ) -> Result<Output<Modification>, anyhow::Error> {
         let result = if to_root {
             self.call(|api, scope| api.move_pads(scope, indexes, None))?
         } else {
@@ -283,7 +264,7 @@ impl<'a> ScopedApi<'a> {
             let (sources, dest) = indexes.split_at(indexes.len() - 1);
             self.call(|api, scope| api.move_pads(scope, sources, Some(dest[0].as_str())))?
         };
-        self.modification(ModificationActionResult::Move, result, false)
+        self.modification(ModificationAction::Move, result, false)
     }
 
     // --- Maintenance outcomes ---
@@ -650,15 +631,17 @@ pub(crate) fn split_indexes_and_content(args: &[String]) -> (Vec<String>, Vec<St
 /// decided here: `cli::input`'s chain resolves it before dispatch and this
 /// handler matches on the resulting [`RequestContent`]. The `editor` /
 /// `no_editor` flags are part of that chain's availability rules, so they are
-/// not read here either. Successful creates preserve the modification schema;
-/// empty piped/editor content returns a typed [`CreateResult::Aborted`] outcome.
+/// not read here either. Both paths return the same core [`Modification`] the rest
+/// of the family does (rendered by `modification_result.jinja` with `action =
+/// "create"`): a success carries the created pad, and empty piped/editor content
+/// carries no pads, which the template reads as the aborted-empty-content case.
 #[handler]
 pub fn create(
     #[ctx] ctx: &CommandContext,
     #[arg] inside: Option<String>,
     #[arg] format: Option<String>,
     #[arg] title: Vec<String>,
-) -> Result<Output<CreateResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     let state = get_state(ctx);
     let content = ctx.input::<RequestContent>(CREATE_CONTENT)?;
     let title_arg = if title.is_empty() {
@@ -723,7 +706,7 @@ pub fn create(
         }
 
         // An empty pipe is an abort: no pad, no editor.
-        RequestContent::PipedEmpty => return Ok(Output::Render(aborted_create())),
+        RequestContent::PipedEmpty => return Ok(aborted_create(ctx)),
 
         // Interactive: create pad first, then open real file in editor.
         //
@@ -770,25 +753,31 @@ pub fn create(
                 }
                 None => {
                     // Empty file - user aborted
-                    return Ok(Output::Render(aborted_create()));
+                    return Ok(aborted_create(ctx));
                 }
             }
         }
     };
 
-    Ok(Output::Render(CreateResult::Created(
-        api(ctx).modification_result(ModificationActionResult::Create, result, false),
+    Ok(Output::Render(api(ctx).modification_result(
+        ModificationAction::Create,
+        result,
+        false,
     )))
 }
 
 /// The result of a `create` the user abandoned by supplying no content.
 ///
-/// No pad was created, so the result carries only the semantic abort facts.
-fn aborted_create() -> CreateResult {
-    CreateResult::Aborted(CreateAbortResult {
-        kind: CreateAbortKindResult::Aborted,
-        reason: CreateAbortReasonResult::EmptyContent,
-    })
+/// No pad was created, so the outcome is a `create` [`Modification`] with no
+/// affected pads — the shape `modification_result.jinja` renders as the
+/// aborted-empty-content warning. Keeping it a `Modification` (rather than a
+/// bespoke abort projection) is what lets create share the family's core outcome.
+fn aborted_create(ctx: &CommandContext) -> Output<Modification> {
+    Output::Render(api(ctx).modification_result(
+        ModificationAction::Create,
+        CmdResult::default(),
+        false,
+    ))
 }
 
 /// List all pads with optional filtering.
@@ -938,7 +927,7 @@ pub fn copy(
 pub fn edit(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     let state = get_state(ctx);
     let content = ctx.input::<RequestContent>(EDIT_CONTENT)?;
 
@@ -966,7 +955,7 @@ pub fn edit(
             let result = update(raw)?;
             state.copy_to_clipboard(raw);
             return Ok(Output::Render(api(ctx).modification_result(
-                ModificationActionResult::Update,
+                ModificationAction::Update,
                 result,
                 false,
             )));
@@ -977,7 +966,7 @@ pub fn edit(
             let result = update(raw)?;
             copy_content_to_clipboard(state, raw);
             return Ok(Output::Render(api(ctx).modification_result(
-                ModificationActionResult::Update,
+                ModificationAction::Update,
                 result,
                 false,
             )));
@@ -1040,14 +1029,14 @@ pub fn edit(
                 ..Default::default()
             };
             Ok(Output::Render(api(ctx).modification_result(
-                ModificationActionResult::Update,
+                ModificationAction::Update,
                 result,
                 false,
             )))
         }
         None => {
             // User emptied the file
-            Ok(Output::<ModificationResult>::Silent)
+            Ok(Output::<Modification>::Silent)
         }
     }
 }
@@ -1057,7 +1046,7 @@ pub fn delete(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
     #[flag] completed: bool,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     if completed {
         api(ctx).delete_completed_pads()
     } else {
@@ -1069,7 +1058,7 @@ pub fn delete(
 pub fn restore(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).restore_pads(&indexes)
 }
 
@@ -1077,7 +1066,7 @@ pub fn restore(
 pub fn archive(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).archive_pads(&indexes)
 }
 
@@ -1085,7 +1074,7 @@ pub fn archive(
 pub fn unarchive(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).unarchive_pads(&indexes)
 }
 
@@ -1094,7 +1083,7 @@ pub fn unarchive(
 pub fn pin(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).pin_pads(&indexes)
 }
 
@@ -1102,7 +1091,7 @@ pub fn pin(
 pub fn unpin(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).unpin_pads(&indexes)
 }
 
@@ -1111,7 +1100,7 @@ pub fn move_pads(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
     #[flag] root: bool,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).move_pads(&indexes, root)
 }
 
@@ -1151,7 +1140,7 @@ pub fn uuid(
 pub fn complete(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).complete_pads(&indexes)
 }
 
@@ -1159,7 +1148,7 @@ pub fn complete(
 pub fn reopen(
     #[ctx] ctx: &CommandContext,
     #[arg] indexes: Vec<String>,
-) -> Result<Output<ModificationResult>, anyhow::Error> {
+) -> Result<Output<Modification>, anyhow::Error> {
     api(ctx).reopen_pads(&indexes)
 }
 
@@ -1639,7 +1628,7 @@ mod tests {
 
         let result = rendered(pin(&app.ctx, vec!["1".into()]).unwrap());
 
-        assert_eq!(result.action, ModificationActionResult::Pin);
+        assert_eq!(result.action, ModificationAction::Pin);
         assert_eq!(result.pads.len(), 1);
         assert_eq!(result.pads[0].pad.metadata.title, "Pin me");
         assert!(result.pads[0].pad.metadata.is_pinned);
@@ -1652,7 +1641,7 @@ mod tests {
 
         let result = rendered(complete(&app.ctx, vec!["1".into()]).unwrap());
 
-        assert_eq!(result.action, ModificationActionResult::Complete);
+        assert_eq!(result.action, ModificationAction::Complete);
         // A command that changes status always shows it, whatever the mode.
         assert!(result.request.status);
     }
@@ -1667,7 +1656,7 @@ mod tests {
         assert!(result.pads.is_empty());
         assert_eq!(
             result.notices,
-            vec![super::super::result::ModificationNoticeResult::NoCompletedPads]
+            vec![padzapp::commands::CmdNotice::NoCompletedPads]
         );
     }
 

--- a/crates/padz/src/cli/render.rs
+++ b/crates/padz/src/cli/render.rs
@@ -52,17 +52,16 @@
 //! `padzapp::peek::format_as_peek`) — registered on the template engine in
 //! [`super::commands`]. Both are render-path only and never touch structured output.
 //!
-//! The `PadRow`/`SectionKind`/`TimeAgo`/`build_peek` derivations below are still used
-//! by the modification mirror (`modification_result.jinja`), which has not migrated
-//! yet; they retire with that family. The tagging family now renders straight from
-//! the core `padzapp::commands::tagging::TaggingResult` — see `tagging.jinja`,
-//! `tag_catalog.jinja`, and `tag_registry.jinja`, which read the serialized core
-//! outcomes directly and reuse the listing's `_list_pad_line.jinja` for affected pads.
+//! The `PadRow`/`SectionKind`/`TimeAgo`/`build_peek` derivations below are retained as
+//! shared listing helpers pending final cleanup. Both the modification family
+//! (`modification_result.jinja`) and the tagging family (`tagging.jinja`,
+//! `tag_catalog.jinja`, `tag_registry.jinja`) now render straight from core types — the
+//! modification view from the core [`Modification`](super::result::Modification)
+//! (`DisplayPad`/`CmdNotice`/`CmdOutcome`), reusing the listing pad line and the
+//! `timeago` filter; the tagging views from the core
+//! `padzapp::commands::tagging::TaggingResult` — so no modification or tagging view
+//! mirror survives here.
 
-use super::result::{
-    ModificationActionResult, ModificationNoticeResult, ModificationResult, MutationOutcomeResult,
-    MutationStatusResult, UpdateKindResult,
-};
 use chrono::{DateTime, Utc};
 use minijinja::Value;
 use padzapp::index::{DisplayIndex, DisplayPad, SearchMatch};
@@ -76,8 +75,6 @@ pub const MIN_LINE_WIDTH: usize = 30;
 /// Default width when no terminal is detected and COLUMNS is unset (e.g. piped output).
 pub const DEFAULT_LINE_WIDTH: usize = 80;
 
-/// The context name `modification_result.jinja` reads its view data from.
-pub const MODIFICATION_VIEW: &str = "modification_view";
 /// The context name every template reads layout width from.
 pub const TERMINAL: &str = "terminal";
 
@@ -146,6 +143,9 @@ pub enum SectionKind {
 }
 
 impl SectionKind {
+    // Retained shared listing helper: its last callers (the modification and tagging
+    // view mirrors) have migrated to core rendering; the final cleanup pass retires it.
+    #[allow(dead_code)]
     fn of(index: &DisplayIndex) -> Self {
         match index {
             DisplayIndex::Pinned(_) => SectionKind::Pinned,
@@ -219,36 +219,6 @@ pub struct PadRow {
     pub peek: Option<PeekResult>,
 }
 
-/// Template-ready view for a modification.
-#[derive(Debug, Clone, Serialize)]
-pub struct ModificationView {
-    /// Semantic operation token. The template owns the human verb.
-    pub action: ModificationActionResult,
-    pub rows: Vec<PadRow>,
-    pub show_status: bool,
-    /// Presentation-ready projections of semantic core notices.
-    pub notices: Vec<ModificationNoticeView>,
-    /// Presentation-ready projections of semantic successful outcomes.
-    pub outcomes: Vec<MutationOutcomeView>,
-}
-
-/// The small amount of display shaping a semantic modification notice needs.
-#[derive(Debug, Clone, Serialize)]
-pub struct ModificationNoticeView {
-    pub kind: &'static str,
-    pub index: String,
-    pub status: &'static str,
-}
-
-/// The small amount of display shaping a semantic update outcome needs.
-#[derive(Debug, Clone, Serialize)]
-pub struct MutationOutcomeView {
-    pub kind: &'static str,
-    pub index: String,
-    pub title: String,
-    pub update_kind: &'static str,
-}
-
 // =============================================================================
 // Context providers (the render-time seam)
 // =============================================================================
@@ -258,107 +228,15 @@ pub fn terminal_provider(_ctx: &RenderContext) -> Value {
     Value::from_serialize(serde_json::json!({ "width": line_width() }))
 }
 
-/// Context provider for `modification_result.jinja`.
-///
-/// Returns `undefined` when the rendered command did not produce a
-/// [`ModificationResult`].
-pub fn modification_view_provider(ctx: &RenderContext) -> Value {
-    match serde_json::from_value::<ModificationResult>(ctx.data.clone()) {
-        Ok(result) => Value::from_serialize(build_modification_view(&result)),
-        Err(_) => Value::UNDEFINED,
-    }
-}
-
 // =============================================================================
 // View builders
 // =============================================================================
 
-/// Builds the template-ready view for a modification result.
-///
-/// Affected pads are reported as a flat list — a modification names the pads it
-/// touched, it does not redraw their subtrees — so every row here is at depth 0.
-pub fn build_modification_view(result: &ModificationResult) -> ModificationView {
-    let opts = super::result::ListRequest {
-        status: result.request.status,
-        ..Default::default()
-    };
-    ModificationView {
-        action: result.action,
-        rows: result
-            .pads
-            .iter()
-            .map(|dp| row(dp, 0, SectionKind::of(&dp.index), &opts))
-            .collect(),
-        show_status: result.request.status,
-        notices: result.notices.iter().map(modification_notice).collect(),
-        outcomes: result
-            .outcomes
-            .iter()
-            .filter_map(mutation_outcome)
-            .collect(),
-    }
-}
-
-fn modification_notice(notice: &ModificationNoticeResult) -> ModificationNoticeView {
-    let (kind, path, status) = match notice {
-        ModificationNoticeResult::AlreadyPinned { path } => ("already_pinned", path, ""),
-        ModificationNoticeResult::AlreadyUnpinned { path } => ("already_unpinned", path, ""),
-        ModificationNoticeResult::AlreadyAtDestination { path } => {
-            ("already_at_destination", path, "")
-        }
-        ModificationNoticeResult::AlreadyInStatus { path, status } => (
-            "already_in_status",
-            path,
-            match status {
-                MutationStatusResult::Planned => "planned",
-                MutationStatusResult::InProgress => "in progress",
-                MutationStatusResult::Done => "done",
-            },
-        ),
-        ModificationNoticeResult::NoCompletedPads => {
-            return ModificationNoticeView {
-                kind: "no_completed_pads",
-                index: String::new(),
-                status: "",
-            };
-        }
-    };
-    ModificationNoticeView {
-        kind,
-        index: path
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("."),
-        status,
-    }
-}
-
-fn mutation_outcome(outcome: &MutationOutcomeResult) -> Option<MutationOutcomeView> {
-    match outcome {
-        MutationOutcomeResult::Updated {
-            path,
-            title,
-            update_kind,
-        } => Some(MutationOutcomeView {
-            kind: "updated",
-            index: path
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join("."),
-            title: title.clone(),
-            update_kind: match update_kind {
-                UpdateKindResult::Structured => "structured",
-                UpdateKindResult::Content => "content",
-                UpdateKindResult::Refresh => "refresh",
-            },
-        }),
-        MutationOutcomeResult::StatusChanged { .. } => None,
-    }
-}
-
 /// Builds one row from a pad.
+///
+/// Retained shared listing helper: its last callers (the modification and tagging view
+/// mirrors) have migrated to core rendering; the final cleanup pass retires it.
+#[allow(dead_code)]
 fn row(
     dp: &DisplayPad,
     depth: usize,
@@ -392,6 +270,10 @@ fn row(
 ///
 /// The preview rules (how many lines, where to elide) belong to `padzapp::peek`; this
 /// only feeds it the body and drops an empty result.
+///
+/// Retained shared listing helper: its last caller ([`row`]) is itself retained pending
+/// the final cleanup pass, which retires both.
+#[allow(dead_code)]
 fn build_peek(dp: &DisplayPad) -> Option<PeekResult> {
     peek_body(&dp.pad.content)
 }
@@ -442,21 +324,6 @@ pub fn peek_filter(content: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::result::ModificationRequest;
-    use padzapp::model::Pad;
-
-    fn pad(title: &str) -> Pad {
-        Pad::new(title.to_string(), format!("{title}\n\nbody line"))
-    }
-
-    fn dp(pad: Pad, index: DisplayIndex, children: Vec<DisplayPad>) -> DisplayPad {
-        DisplayPad {
-            pad,
-            index,
-            matches: None,
-            children,
-        }
-    }
 
     // =========================================================================
     // peek / timeago filters (the listing render path)
@@ -522,32 +389,6 @@ mod tests {
     fn a_future_timestamp_clamps_to_zero() {
         let t = TimeAgo::since(Utc::now() + chrono::Duration::seconds(600));
         assert_eq!((t.value, t.unit), (0, 's'));
-    }
-
-    // =========================================================================
-    // Modification view
-    // =========================================================================
-
-    /// A modification names the pads it touched; it does not redraw their subtrees.
-    #[test]
-    fn a_modification_reports_affected_pads_flat() {
-        let result = ModificationResult {
-            action: ModificationActionResult::Pin,
-            pads: vec![dp(
-                pad("root"),
-                DisplayIndex::Pinned(1),
-                vec![dp(pad("child"), DisplayIndex::Regular(1), vec![])],
-            )],
-            notices: vec![],
-            outcomes: vec![],
-            request: ModificationRequest { status: true },
-        };
-        let view = build_modification_view(&result);
-
-        assert_eq!(view.action, ModificationActionResult::Pin);
-        assert_eq!(view.rows.len(), 1, "children are not redrawn");
-        assert_eq!(view.rows[0].depth, 0);
-        assert!(view.show_status);
     }
 
     // =========================================================================

--- a/crates/padz/src/cli/result.rs
+++ b/crates/padz/src/cli/result.rs
@@ -26,9 +26,8 @@
 //! icons), not how to draw it. It is a mode-independent fact about the invocation, so
 //! it is part of the result and visible in structured output.
 
-use padzapp::commands::{CmdNotice, CmdOutcome, NestingMode, UpdateKind};
-use padzapp::index::{DisplayIndex, DisplayPad};
-use padzapp::model::TodoStatus;
+use padzapp::commands::{CmdNotice, CmdOutcome, NestingMode};
+use padzapp::index::DisplayPad;
 use serde::{Deserialize, Serialize};
 
 /// What the user asked a listing to show.
@@ -76,30 +75,36 @@ pub struct Listing {
     pub request: ListRequest,
 }
 
-/// The outcome of a command that changed pads.
+/// The outcome of a command that changed pads, rendered straight from core types.
 ///
-/// `action` is the machine-readable operation token for the change and `pads`
-/// are the pads it affected. The human renderer owns the corresponding verb.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModificationResult {
-    pub action: ModificationActionResult,
+/// This is the thin flat view the modification family returns instead of a tier-2
+/// projection: `action` is the machine-readable operation token (the one genuinely
+/// CLI-only fact — the core has no "which command ran" enum) and `pads` are the pads
+/// it affected. `notices` and `outcomes` are the **core** semantic facts
+/// ([`CmdNotice`]/[`CmdOutcome`]) verbatim — they already `derive(Serialize)`, so
+/// structured output reads them directly and `modification_result.jinja` owns every
+/// verb and sentence. `request` records what to show (status icons), not how to draw.
+#[derive(Debug, Clone, Serialize)]
+pub struct Modification {
+    pub action: ModificationAction,
     pub pads: Vec<DisplayPad>,
     /// Machine-readable facts emitted by the core; templates own their prose.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub notices: Vec<ModificationNoticeResult>,
+    pub notices: Vec<CmdNotice>,
     /// Machine-readable successful outcomes emitted by the core.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub outcomes: Vec<MutationOutcomeResult>,
+    pub outcomes: Vec<CmdOutcome>,
     pub request: ModificationRequest,
 }
 
 /// The operation performed by a generic pad modification command.
 ///
-/// This is a machine-readable token, not the human past-tense verb. The
-/// modification template owns wording such as "Pinned" and "Moved".
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// This is a machine-readable token, not the human past-tense verb, and the one
+/// fact the core does not model (it reports *what changed*, not *which command
+/// asked*). The modification template owns wording such as "Pinned" and "Moved".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ModificationActionResult {
+pub enum ModificationAction {
     Create,
     Pin,
     Unpin,
@@ -111,150 +116,6 @@ pub enum ModificationActionResult {
     Reopen,
     Move,
     Update,
-}
-
-/// CLI projection of a semantic mutation no-op.
-///
-/// This keeps the shell's structured schema independent from the core enum while
-/// retaining the `kind` and canonical display-path shape established for pinning.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum ModificationNoticeResult {
-    AlreadyPinned {
-        path: Vec<DisplayIndex>,
-    },
-    AlreadyUnpinned {
-        path: Vec<DisplayIndex>,
-    },
-    AlreadyAtDestination {
-        path: Vec<DisplayIndex>,
-    },
-    AlreadyInStatus {
-        path: Vec<DisplayIndex>,
-        status: MutationStatusResult,
-    },
-    NoCompletedPads,
-}
-
-impl From<CmdNotice> for ModificationNoticeResult {
-    fn from(notice: CmdNotice) -> Self {
-        match notice {
-            CmdNotice::AlreadyPinned { path } => Self::AlreadyPinned { path },
-            CmdNotice::AlreadyUnpinned { path } => Self::AlreadyUnpinned { path },
-            CmdNotice::AlreadyAtDestination { path } => Self::AlreadyAtDestination { path },
-            CmdNotice::AlreadyInStatus { path, status } => Self::AlreadyInStatus {
-                path,
-                status: status.into(),
-            },
-            CmdNotice::NoCompletedPads => Self::NoCompletedPads,
-        }
-    }
-}
-
-/// Requested status exposed by a semantic no-op.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum MutationStatusResult {
-    Planned,
-    InProgress,
-    Done,
-}
-
-impl From<TodoStatus> for MutationStatusResult {
-    fn from(status: TodoStatus) -> Self {
-        match status {
-            TodoStatus::Planned => Self::Planned,
-            TodoStatus::InProgress => Self::InProgress,
-            TodoStatus::Done => Self::Done,
-        }
-    }
-}
-
-/// CLI projection of a successful semantic pad mutation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum MutationOutcomeResult {
-    Updated {
-        path: Vec<DisplayIndex>,
-        title: String,
-        update_kind: UpdateKindResult,
-    },
-    StatusChanged {
-        path: Vec<DisplayIndex>,
-        status: MutationStatusResult,
-    },
-}
-
-impl From<CmdOutcome> for MutationOutcomeResult {
-    fn from(outcome: CmdOutcome) -> Self {
-        match outcome {
-            CmdOutcome::Updated {
-                path,
-                title,
-                update_kind,
-            } => Self::Updated {
-                path,
-                title,
-                update_kind: update_kind.into(),
-            },
-            CmdOutcome::StatusChanged { path, status } => Self::StatusChanged {
-                path,
-                status: status.into(),
-            },
-        }
-    }
-}
-
-/// How an update reached the core, as part of the shell's public result schema.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum UpdateKindResult {
-    Structured,
-    Content,
-    Refresh,
-}
-
-impl From<UpdateKind> for UpdateKindResult {
-    fn from(kind: UpdateKind) -> Self {
-        match kind {
-            UpdateKind::Structured => Self::Structured,
-            UpdateKind::Content => Self::Content,
-            UpdateKind::Refresh => Self::Refresh,
-        }
-    }
-}
-
-/// The typed outcome of `create`.
-///
-/// `Created` deliberately serializes exactly like the existing
-/// [`ModificationResult`] so successful-create automation remains compatible.
-/// `Aborted` replaces the former prose-only warning with semantic facts.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CreateResult {
-    Created(ModificationResult),
-    Aborted(CreateAbortResult),
-}
-
-/// Why a create invocation stopped without creating a pad.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CreateAbortResult {
-    pub kind: CreateAbortKindResult,
-    pub reason: CreateAbortReasonResult,
-}
-
-/// The top-level outcome class for a create abort.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CreateAbortKindResult {
-    Aborted,
-}
-
-/// The semantic reason a create invocation aborted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CreateAbortReasonResult {
-    EmptyContent,
 }
 
 /// One pad's full content, as returned by `view`.

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -27,6 +27,12 @@
 {%- else -%}
 {%- set show_status = request.status -%}
 {%- set peek_mode = false -%}
+{#- `_list_pad_line.jinja` reads `request.uuid`, but a modification passes a -#}
+{#- `ModificationRequest` (status only). Set an explicit `uuid: false` — mirroring -#}
+{#- `tagging.jinja` — so the partial reads a defined flag under a strict-undefined -#}
+{#- engine. Modification output has never shown a short-UUID; `show_status` above -#}
+{#- already captured the status flag before this override. -#}
+{%- set request = {"uuid": false} -%}
 {%- set verb = {
     "create": "Created",
     "pin": "Pinned",

--- a/crates/padz/src/cli/templates/modification_result.jinja
+++ b/crates/padz/src/cli/templates/modification_result.jinja
@@ -1,13 +1,32 @@
-{#- Unified rendering for modification commands. `modification_view` is derived at -#}
-{#- render time from the handler's ModificationResult; see cli::render. -#}
-{#- An empty piped/editor create is a typed abort, not a modification. -#}
-{%- if kind == "aborted" and reason == "empty_content" -%}
+{#- Unified rendering for modification commands, straight from the core shape. -#}
+{#- Reads the handler's `Modification` view at top level: `action` (semantic token), -#}
+{#- `pads` (core DisplayPad, reported flat at depth 0), the core `notices`/`outcomes` -#}
+{#- (CmdNotice/CmdOutcome verbatim), and `request` (status-icon flag). Every verb, -#}
+{#- sentence and pluralization is presentation policy owned here. -#}
+
+{#- A core DisplayIndex path (e.g. [Regular(1), Regular(1)]) as the dotted display -#}
+{#- string the user knows ("1.1", "p1", "d2"). The core Display owns the prefixes; -#}
+{#- here the template mirrors them since it reads the serialized {type, value} shape. -#}
+{%- macro index_path(path) -%}
+{%- for idx in path -%}
+{%- if idx.type == "Pinned" -%}p{{ idx.value }}
+{%- elif idx.type == "Archived" -%}ar{{ idx.value }}
+{%- elif idx.type == "Deleted" -%}d{{ idx.value }}
+{%- else -%}{{ idx.value }}
+{%- endif -%}
+{{- "." if not loop.last -}}
+{%- endfor -%}
+{%- endmacro -%}
+
+{%- set count = pads | length -%}
+
+{#- An empty piped/editor create made no pad: the one modification that affects zero -#}
+{#- pads is the aborted-empty-content create, and it keeps its established warning. -#}
+{%- if action == "create" and count == 0 -%}
 [warning]Aborted: empty content[/warning]{{ "" | nl }}
 {%- else -%}
-{%- set view = modification_view -%}
-{%- set show_status = view.show_status -%}
+{%- set show_status = request.status -%}
 {%- set peek_mode = false -%}
-{%- set count = view.rows | length -%}
 {%- set verb = {
     "create": "Created",
     "pin": "Pinned",
@@ -20,37 +39,40 @@
     "reopen": "Reopened",
     "move": "Moved",
     "update": "Updated"
-}[view.action] -%}
+}[action] -%}
 
 {#- Human verbs and pluralization are presentation policy owned here. -#}
 {%- if count > 0 -%}
 [info]{{ verb }} {{ count }} {{ "pad" if count == 1 else "pads" }}...[/info]{{ "" | nl }}
 {%- endif -%}
 
-{%- for pad in view.rows -%}
-{%- include "_pad_line.jinja" -%}
+{%- for pad in pads -%}
+{%- set depth = 0 -%}
+{%- include "_list_pad_line.jinja" -%}
 {%- endfor -%}
 
-{#- Semantic successful outcomes: wording stays here; refresh updates deliberately -#}
-{#- add no extra line, preserving the interactive editor's established output. -#}
-{%- for outcome in view.outcomes -%}
+{#- Semantic successful outcomes: wording stays here; a StatusChanged carries no line -#}
+{#- (the pad row already shows the new status icon) and a refresh update deliberately -#}
+{#- adds none either, preserving the interactive editor's established output. -#}
+{%- for outcome in outcomes -%}
 {%- if outcome.kind == "updated" and outcome.update_kind == "structured" -%}
-[success]Pad updated ({{ outcome.index }}): {{ outcome.title }}[/success]{{ "" | nl }}
+[success]Pad updated ({{ index_path(outcome.path) }}): {{ outcome.title }}[/success]{{ "" | nl }}
 {%- elif outcome.kind == "updated" and outcome.update_kind == "content" -%}
-[success]Updated ({{ outcome.index }}): {{ outcome.title }}[/success]{{ "" | nl }}
+[success]Updated ({{ index_path(outcome.path) }}): {{ outcome.title }}[/success]{{ "" | nl }}
 {%- endif -%}
 {%- endfor -%}
 
-{#- Semantic notices: wording stays here; structured modes receive kind + fields. -#}
-{%- for notice in view.notices -%}
+{#- Semantic notices: wording stays here; structured modes receive kind + fields. The -#}
+{#- core TodoStatus serializes as Planned/InProgress/Done, so the label map is here. -#}
+{%- for notice in notices -%}
 {%- if notice.kind == "already_pinned" -%}
-[info]Pad {{ notice.index }} is already pinned[/info]{{ "" | nl }}
+[info]Pad {{ index_path(notice.path) }} is already pinned[/info]{{ "" | nl }}
 {%- elif notice.kind == "already_unpinned" -%}
-[info]Pad {{ notice.index }} is already unpinned[/info]{{ "" | nl }}
+[info]Pad {{ index_path(notice.path) }} is already unpinned[/info]{{ "" | nl }}
 {%- elif notice.kind == "already_at_destination" -%}
-[info]Pad '{{ notice.index }}' is already at destination[/info]{{ "" | nl }}
+[info]Pad '{{ index_path(notice.path) }}' is already at destination[/info]{{ "" | nl }}
 {%- elif notice.kind == "already_in_status" -%}
-[info]Pad {{ notice.index }} is already {{ notice.status }}[/info]{{ "" | nl }}
+[info]Pad {{ index_path(notice.path) }} is already {{ {"Planned": "planned", "InProgress": "in progress", "Done": "done"}[notice.status] }}[/info]{{ "" | nl }}
 {%- elif notice.kind == "no_completed_pads" -%}
 [info]No completed pads to delete.[/info]{{ "" | nl }}
 {%- endif -%}

--- a/crates/padz/tests/fixtures/semantic_outcomes/complete-mixed.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/complete-mixed.json
@@ -3,14 +3,14 @@
     {
       "kind": "already_in_status",
       "path": [{ "type": "Regular", "value": 1 }],
-      "status": "done"
+      "status": "Done"
     }
   ],
   "outcomes": [
     {
       "kind": "status_changed",
       "path": [{ "type": "Regular", "value": 2 }],
-      "status": "done"
+      "status": "Done"
     }
   ]
 }

--- a/crates/padz/tests/fixtures/semantic_outcomes/create-aborted.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/create-aborted.json
@@ -1,4 +1,5 @@
 {
-  "kind": "aborted",
-  "reason": "empty_content"
+  "action": "create",
+  "pads": [],
+  "request": { "status": false }
 }

--- a/crates/padz/tests/fixtures/semantic_outcomes/reopen-no-op.json
+++ b/crates/padz/tests/fixtures/semantic_outcomes/reopen-no-op.json
@@ -2,6 +2,6 @@
   {
     "kind": "already_in_status",
     "path": [{ "type": "Regular", "value": 1 }],
-    "status": "planned"
+    "status": "Planned"
   }
 ]

--- a/crates/padz/tests/handlers_direct.rs
+++ b/crates/padz/tests/handlers_direct.rs
@@ -25,11 +25,7 @@ mod support;
 
 use padz::cli::handlers;
 use padz::cli::input::{RequestContent, CREATE_CONTENT, EDIT_CONTENT};
-use padz::cli::result::{
-    CreateAbortKindResult, CreateAbortReasonResult, CreateResult, Listing,
-    ModificationActionResult, ModificationNoticeResult, ModificationResult, MutationOutcomeResult,
-    MutationStatusResult, PadContentResult, UpdateKindResult,
-};
+use padz::cli::result::{Listing, Modification, ModificationAction, PadContentResult};
 use padz::cli::views::{CopyView, PathView, UuidView};
 use padzapp::commands::doctor::DoctorOutcome;
 use padzapp::commands::export::{ExportFormat, ExportReport, ExportWarning};
@@ -44,8 +40,8 @@ use padzapp::commands::tags::{TagCatalogOutcome, TagRegistryOutcome};
 use padzapp::commands::transfer::{
     TransferDirection, TransferMode, TransferReport, TransferSelection, TransferStatus,
 };
-use padzapp::commands::NestingMode;
-use padzapp::model::Scope;
+use padzapp::commands::{CmdNotice, CmdOutcome, NestingMode, UpdateKind};
+use padzapp::model::{Scope, TodoStatus};
 use standout::cli::Output;
 use support::Fixture;
 
@@ -73,14 +69,19 @@ fn titles(result: &Listing) -> Vec<String> {
         .collect()
 }
 
-/// Unwraps the successful modification arm of create without changing its public
-/// serialized shape.
+/// Unwraps the `create` handler's core modification outcome.
+///
+/// `create` now returns the same [`Modification`] the rest of the family does; a
+/// successful create carries the created pad, so an empty `pads` here means the
+/// create aborted (see [`create_with_an_empty_pipe_aborts_without_creating_a_pad`]).
 #[track_caller]
-fn created(out: Result<Output<CreateResult>, anyhow::Error>) -> ModificationResult {
-    match rendered(out) {
-        CreateResult::Created(result) => result,
-        CreateResult::Aborted(abort) => panic!("expected created pad, got {abort:?}"),
-    }
+fn created(out: Result<Output<Modification>, anyhow::Error>) -> Modification {
+    let result = rendered(out);
+    assert!(
+        !result.pads.is_empty(),
+        "expected a created pad, got an aborted create: {result:?}"
+    );
+    result
 }
 
 // =============================================================================
@@ -403,19 +404,19 @@ fn copy_keeps_nested_content_in_the_payload_but_counts_only_the_root() {
 #[test]
 fn modification_handlers_report_their_semantic_action() {
     type Call =
-        fn(&standout_dispatch::CommandContext) -> Result<Output<ModificationResult>, anyhow::Error>;
+        fn(&standout_dispatch::CommandContext) -> Result<Output<Modification>, anyhow::Error>;
 
-    let cases: Vec<(&str, ModificationActionResult, Call)> = vec![
-        ("pin", ModificationActionResult::Pin, |ctx| {
+    let cases: Vec<(&str, ModificationAction, Call)> = vec![
+        ("pin", ModificationAction::Pin, |ctx| {
             handlers::pin(ctx, vec!["1".to_string()])
         }),
-        ("delete", ModificationActionResult::Delete, |ctx| {
+        ("delete", ModificationAction::Delete, |ctx| {
             handlers::delete(ctx, vec!["1".to_string()], false)
         }),
-        ("archive", ModificationActionResult::Archive, |ctx| {
+        ("archive", ModificationAction::Archive, |ctx| {
             handlers::archive(ctx, vec!["1".to_string()])
         }),
-        ("complete", ModificationActionResult::Complete, |ctx| {
+        ("complete", ModificationAction::Complete, |ctx| {
             handlers::complete(ctx, vec!["1".to_string()])
         }),
     ];
@@ -479,7 +480,7 @@ fn repeated_pin_maps_the_core_notice_without_parsing_prose() {
 
     assert_eq!(
         result.notices,
-        vec![ModificationNoticeResult::AlreadyPinned {
+        vec![CmdNotice::AlreadyPinned {
             path: vec![padzapp::index::DisplayIndex::Pinned(1)]
         }]
     );
@@ -495,7 +496,7 @@ fn unpin_reverses_pin_and_reports_its_semantic_action() {
     rendered(handlers::pin(&ctx, vec!["1".to_string()]));
     let result = rendered(handlers::unpin(&ctx, vec!["p1".to_string()]));
 
-    assert_eq!(result.action, ModificationActionResult::Unpin);
+    assert_eq!(result.action, ModificationAction::Unpin);
     assert!(!result.pads[0].pad.metadata.is_pinned);
 }
 
@@ -509,7 +510,7 @@ fn restore_maps_a_deleted_selector_back_to_active() {
     rendered(handlers::delete(&ctx, vec!["1".to_string()], false));
     let result = rendered(handlers::restore(&ctx, vec!["d1".to_string()]));
 
-    assert_eq!(result.action, ModificationActionResult::Restore);
+    assert_eq!(result.action, ModificationAction::Restore);
     assert_eq!(result.pads[0].pad.metadata.title, "gone");
 }
 
@@ -545,7 +546,7 @@ fn move_to_root_needs_only_the_sources() {
     ));
     let result = rendered(handlers::move_pads(&ctx, vec!["1.1".to_string()], true));
 
-    assert_eq!(result.action, ModificationActionResult::Move);
+    assert_eq!(result.action, ModificationAction::Move);
     assert!(
         result.pads[0].pad.metadata.parent_id.is_none(),
         "--root detaches the pad from its parent"
@@ -569,7 +570,7 @@ fn same_parent_move_maps_the_nested_no_op_path() {
     assert!(result.pads.is_empty());
     assert_eq!(
         result.notices,
-        vec![ModificationNoticeResult::AlreadyAtDestination {
+        vec![CmdNotice::AlreadyAtDestination {
             path: vec![
                 padzapp::index::DisplayIndex::Regular(1),
                 padzapp::index::DisplayIndex::Regular(1),
@@ -596,16 +597,16 @@ fn mixed_complete_maps_changed_pads_and_requested_status_no_ops() {
     assert_eq!(result.pads.len(), 2);
     assert_eq!(
         result.notices,
-        vec![ModificationNoticeResult::AlreadyInStatus {
+        vec![CmdNotice::AlreadyInStatus {
             path: vec![padzapp::index::DisplayIndex::Regular(1)],
-            status: MutationStatusResult::Done,
+            status: TodoStatus::Done,
         }]
     );
     assert_eq!(
         result.outcomes,
-        vec![MutationOutcomeResult::StatusChanged {
+        vec![CmdOutcome::StatusChanged {
             path: vec![padzapp::index::DisplayIndex::Regular(2)],
-            status: MutationStatusResult::Done,
+            status: TodoStatus::Done,
         }]
     );
 }
@@ -620,10 +621,7 @@ fn empty_delete_completed_maps_the_core_no_op() {
     let result = rendered(handlers::delete(&ctx, vec![], true));
 
     assert!(result.pads.is_empty());
-    assert_eq!(
-        result.notices,
-        vec![ModificationNoticeResult::NoCompletedPads]
-    );
+    assert_eq!(result.notices, vec![CmdNotice::NoCompletedPads]);
 }
 
 // =============================================================================
@@ -1073,7 +1071,7 @@ fn create_with_direct_content_splits_title_from_body() {
 
     let result = created(handlers::create(&ctx, None, None, vec![]));
 
-    assert_eq!(result.action, ModificationActionResult::Create);
+    assert_eq!(result.action, ModificationAction::Create);
     assert_eq!(result.pads[0].pad.metadata.title, "the title");
     assert!(result.pads[0].pad.content.contains("the body"));
 }
@@ -1123,11 +1121,15 @@ fn create_with_an_empty_pipe_aborts_without_creating_a_pad() {
 
     let result = rendered(handlers::create(&ctx, None, None, vec![]));
 
-    let CreateResult::Aborted(abort) = result else {
-        panic!("expected a semantic create abort")
-    };
-    assert_eq!(abort.kind, CreateAbortKindResult::Aborted);
-    assert_eq!(abort.reason, CreateAbortReasonResult::EmptyContent);
+    // An aborted create is a `create` modification that affected no pads — the
+    // shape `modification_result.jinja` renders as the empty-content warning.
+    assert_eq!(result.action, ModificationAction::Create);
+    assert!(
+        result.pads.is_empty(),
+        "an empty pipe creates no pad, so the outcome carries none"
+    );
+    assert!(result.notices.is_empty());
+    assert!(result.outcomes.is_empty());
 
     let listed = rendered(handlers::list(
         &ctx,
@@ -1214,10 +1216,10 @@ fn edit_with_direct_content_replaces_the_selected_pads_text() {
     assert!(result.pads[0].pad.content.contains("new body"));
     assert_eq!(
         result.outcomes,
-        vec![MutationOutcomeResult::Updated {
+        vec![CmdOutcome::Updated {
             path: vec![padzapp::index::DisplayIndex::Regular(1)],
             title: "after".to_string(),
-            update_kind: UpdateKindResult::Content,
+            update_kind: UpdateKind::Content,
         }]
     );
 }
@@ -1238,13 +1240,13 @@ fn edit_maps_a_nested_canonical_path_without_parsing_prose() {
 
     assert_eq!(
         result.outcomes,
-        vec![MutationOutcomeResult::Updated {
+        vec![CmdOutcome::Updated {
             path: vec![
                 padzapp::index::DisplayIndex::Regular(1),
                 padzapp::index::DisplayIndex::Regular(1),
             ],
             title: "edited child".to_string(),
-            update_kind: UpdateKindResult::Content,
+            update_kind: UpdateKind::Content,
         }]
     );
 }

--- a/crates/padz/tests/presentation_seams.rs
+++ b/crates/padz/tests/presentation_seams.rs
@@ -7,12 +7,12 @@
 mod support;
 
 use padz::cli::handlers;
-use padz::cli::result::{ModificationActionResult, ModificationResult};
+use padz::cli::result::{Modification, ModificationAction};
 use standout::cli::Output;
 use standout_test::{serial, TestHarness};
 use support::Fixture;
 
-fn rendered(out: Result<Output<ModificationResult>, anyhow::Error>) -> ModificationResult {
+fn rendered(out: Result<Output<Modification>, anyhow::Error>) -> Modification {
     match out.expect("handler returned an error") {
         Output::Render(value) => value,
         other => panic!("expected rendered modification result, got {other:?}"),
@@ -28,7 +28,7 @@ fn typed_pin_handler_exposes_a_semantic_action_without_generic_messages() {
 
     let result = rendered(handlers::pin(&ctx, vec!["1".to_string()]));
 
-    assert_eq!(result.action, ModificationActionResult::Pin);
+    assert_eq!(result.action, ModificationAction::Pin);
     assert_eq!(result.pads.len(), 1);
     assert!(result.notices.is_empty());
     assert!(result.outcomes.is_empty());


### PR DESCRIPTION
Workstream WS02 of STD04 (#240, parent #238). Targets **epic/std04**, not main.

## Context

Applies the WS01 pattern to the **modifications family** — `delete`/`rm`,
`restore`, `archive`, `unarchive`, `pin`, `unpin`, `move`/`mv`, `complete`/`done`,
`reopen`, `edit`/`update`, and (folded in from WS06, see below) `create`/`n`.

**Approach.** Handlers stop `.into()`-ing into the tier-2 `ModificationResult`
projection and return a thin `Modification` view (the WS01 `Listing` analog) over
the core outcome. `notices`/`outcomes` are now the core `padzapp::commands::CmdNotice`/
`CmdOutcome` **verbatim** (they already `derive(Serialize)`); the only surviving
view field is the `action` token, which the core genuinely does not model (it
reports *what changed*, not *which command asked*).

**Reused `_list_pad_line.jinja` (yes).** `modification_result.jinja` now reads the
core shape directly and reuses WS01's `_list_pad_line.jinja` for affected pads
(reported flat, depth 0) with the `timeago` filter — so the tier-3 `ModificationView`
mirror **and its `modification_view` context provider** are deleted. The
DisplayIndex->dotted-path formatting the old Rust helper did is now an in-template
`index_path` macro; the `TodoStatus`->"in progress" label map is in-template too.

**Deleted** from `cli/result.rs`: `ModificationResult`, `ModificationActionResult`,
`ModificationNoticeResult`, `MutationOutcomeResult`, `MutationStatusResult`,
`UpdateKindResult` (+ all six `From` impls). From `render.rs`: `ModificationView`,
`ModificationNoticeView`, `MutationOutcomeView`, `build_modification_view`,
`modification_view_provider`, `MODIFICATION_VIEW`, and the `modification_notice`/
`mutation_outcome` helpers. The `modification_view` context_fn registration is
removed from `commands.rs`.

**create folded in from WS06 (per coordinator).** `CreateResult::Created` embedded
`ModificationResult`, so deleting that type forces `create` to migrate atomically
or the epic head fails to build the moment either PR lands. Both create paths now
return `Modification`: an empty-content abort is a `create` action with **zero
affected pads**, which the template renders as the established
`Aborted: empty content` warning — no `CreateResult::Aborted` projection. Deleted:
`CreateResult`, `CreateAbortResult`, `CreateAbortKindResult`,
`CreateAbortReasonResult`. Input resolution (`cli::input`) is untouched, as WS06's
brief required.

**Retained shared machinery (WS07 cleanup):** `PadRow`, `row`, `SectionKind`,
`TimeAgo`, `build_peek`, `line_width`/`MIN_LINE_WIDTH`/`DEFAULT_LINE_WIDTH`,
`terminal_provider`, and the old shared `_pad_line.jinja` stay in place. `TimeAgo`,
`line_width`, and `terminal_provider` remain live (the listing filters and templates
use them). After the rebase onto the fully-migrated epic head (WS03 tagging + WS04–WS06
all landed), the last callers of `row`/`build_peek`/`SectionKind::of` — the modification
and tagging view mirrors — are both gone, so those three private helpers are marked
`#[allow(dead_code)]` pending WS07's cleanup, which retires them.

**Shared conflict surface:** this is the last and thickest of the family rebases —
`result.rs`/`handlers.rs`/`render.rs`/`commands.rs`/`handlers_direct.rs` conflicts were
resolved by the union-of-deletions rule (each family's deletions kept from both sides:
tags/transfer/import/export/singletons from the epic head, modifications/create from
this branch).

## Structured output (regenerated)

The **only** behavioral change is in structured/JSON output, which now reflects the
core shape — and per epic decision #3 the JSON schema is explicitly **not** a product
commitment. Two shapes change: (a) the `already_in_status` notice `status` field now
follows core `TodoStatus` casing (`Planned`/`InProgress`/`Done`, was snake_case
`planned`/`in_progress`/`done`); (b) an empty-content create-abort serializes as the
core create shape `{action:"create", pads:[], request:{...}}` (was the old CLI
projection `{kind:"aborted", reason:"empty_content"}`). Regenerated
`complete-mixed.json`, `reopen-no-op.json`, `create-aborted.json`; `handlers_direct.rs`
+ `presentation_seams.rs` retargeted to the core field names. **No bats change** —
they assert pad metadata, not notices/outcomes. `padzapp` core serde untouched.

## Gates

- `pixi run test` — **881 pass** (1 skipped); `pixi run lint` — **green**.
- **Human output is byte-identical to pristine** (auto/term/text) across the whole
  family — every verb, every notice/no-op path (already-pinned/unpinned/at-destination/
  in-status, no-completed-pads), and both create paths (success + empty/whitespace/
  piped-empty abort). Confirmed by an independent two-binary byte-diff of the pristine
  `epic/std04` binary against this branch: the pristine binary's human output for the
  entire family — **including `create` success and the empty-content abort** — is already
  correct (`Pad 1 is already done`/`planned`, `Aborted: empty content`) and matches this
  branch exactly. There is no human-output change and no latent human-output bug; this PR
  changes **only** the structured output described above.

for #240
